### PR TITLE
Add logging and audit configuration to Flask app

### DIFF
--- a/microcosm_flask/audit.py
+++ b/microcosm_flask/audit.py
@@ -1,0 +1,98 @@
+"""
+Audit log support for Flask routes.
+
+"""
+from functools import wraps
+from json import loads
+from traceback import format_exc
+
+from flask import current_app, request
+
+from microcosm_flask.errors import extract_status_code, extract_error_message
+
+
+def audit(func):
+    """
+    Record a Flask route function in the audit log.
+
+    Generates a JSON record in the Flask log for every request.
+
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        response = None
+
+        # always include these fields
+        audit_dict = dict(
+            operation=request.url_rule.rule,
+            func=func.__name__,
+            method=request.method,
+        )
+
+        # include request body on debug (if any)
+        if current_app.debug and request.get_json(force=True, silent=True):
+            audit_dict["request_body"] = request.get_json(force=True)
+
+        try:
+            response = func(*args, **kwargs)
+        except Exception as error:
+            audit_dict.update(
+                success=False,
+                message=extract_error_message(error)[:2048],
+                stack_trace=format_exc(limit=10),
+                status_code=extract_status_code(error),
+            )
+            raise
+        else:
+            body, status_code = parse_response(response)
+
+            audit_dict.update(
+                success=True,
+                status_code=status_code,
+            )
+
+            # include response body on debug (if any)
+            if current_app.debug and body:
+                try:
+                    audit_dict["response_body"] = loads(body)
+                except (TypeError, ValueError):
+                    # not json
+                    audit_dict["response_body"] = body
+
+            return response
+        finally:
+            # always log at INFO; we can't know whether a raised exception
+            # is an error or expected behavior
+            current_app.logger.info(audit_dict)
+
+    return wrapper
+
+
+def parse_response(response):
+    """
+    Parse a Flask response into a body and status code.
+
+    The returned value from a Flask view could be:
+        * a tuple of (response, status) or (response, status, headers)
+        * a Response object
+        * a string
+    """
+    if isinstance(response, tuple) and len(response) > 1:
+        return response[0], response[1]
+    try:
+        return response.data, response.status_code
+    except AttributeError:
+        return response, 200
+
+
+def configure_audit_decorator(graph):
+    """
+    Configure the audit decorator.
+
+    Example Usage:
+
+        @graph.audit
+        def login(username, password):
+            ...
+    """
+    return audit

--- a/microcosm_flask/basic_auth.py
+++ b/microcosm_flask/basic_auth.py
@@ -66,7 +66,7 @@ class ConfigBasicAuth(BasicAuth):
         "default": "secret",
     }
 )
-def configure_basic_auth(graph):
+def configure_basic_auth_decorator(graph):
     """
     Configure a basic auth decorator.
 

--- a/microcosm_flask/factories.py
+++ b/microcosm_flask/factories.py
@@ -35,5 +35,6 @@ def configure_flask_app(graph):
         "basic_auth",
         "error_handlers",
         "health",
+        "logger",
     )
     return graph.flask

--- a/microcosm_flask/factories.py
+++ b/microcosm_flask/factories.py
@@ -32,6 +32,7 @@ def configure_flask_app(graph):
 
     """
     graph.use(
+        "audit",
         "basic_auth",
         "error_handlers",
         "health",

--- a/microcosm_flask/tests/test_basic_auth.py
+++ b/microcosm_flask/tests/test_basic_auth.py
@@ -26,6 +26,7 @@ def test_basic_auth():
     graph = create_object_graph(name="example", testing=True, loader=lambda metadata: config)
 
     @graph.app.route("/unauthorized")
+    @graph.audit
     @graph.basic_auth.required
     def unauthorized():
         raise Exception("Should not be raised!")
@@ -53,6 +54,7 @@ def test_basic_auth_default_realm():
     graph = create_object_graph(name="example", testing=True)
 
     @graph.app.route("/unauthorized")
+    @graph.audit
     @graph.basic_auth.required
     def unauthorized():
         raise Exception("Should not be raised!")
@@ -80,6 +82,7 @@ def test_basic_auth_default_credentials():
     graph = create_object_graph(name="example", testing=True)
 
     @graph.app.route("/ok")
+    @graph.audit
     @graph.basic_auth.required
     def unauthorized():
         return "OK"
@@ -108,6 +111,7 @@ def test_basic_auth_custom_credentials():
     graph = create_object_graph(name="example", testing=True, loader=lambda metadata: config)
 
     @graph.app.route("/ok")
+    @graph.audit
     @graph.basic_auth.required
     def unauthorized():
         return "OK"

--- a/microcosm_flask/tests/test_errors.py
+++ b/microcosm_flask/tests/test_errors.py
@@ -41,6 +41,7 @@ def test_werkzeug_http_error():
     graph = create_object_graph(name="example", testing=True)
 
     @graph.app.route("/not_found")
+    @graph.audit
     def not_found():
         raise NotFound
 
@@ -85,6 +86,7 @@ def test_werkzeug_http_error_custom_message():
     graph = create_object_graph(name="example", testing=True)
 
     @graph.app.route("/why_me")
+    @graph.audit
     def why_me():
         raise InternalServerError("Why me?")
 
@@ -108,6 +110,7 @@ def test_custom_error():
     graph = create_object_graph(name="example", testing=True)
 
     @graph.app.route("/unexpected")
+    @graph.audit
     def unexpected():
         raise MyUnexpectedError("unexpected")
 
@@ -131,6 +134,7 @@ def test_custom_error_status_code():
     graph = create_object_graph(name="example", testing=True)
 
     @graph.app.route("/malformed_syntax")
+    @graph.audit
     def malformed_syntax():
         raise MyValidationError
 
@@ -154,6 +158,7 @@ def test_custom_error_retryable():
     graph = create_object_graph(name="example", testing=True)
 
     @graph.app.route("/conflict")
+    @graph.audit
     def conflict():
         raise MyConflictError("Conflict")
 
@@ -182,6 +187,7 @@ def test_error_wrap():
         raise Exception("fail")
 
     @graph.app.route("/wrap")
+    @graph.audit
     def wrap():
         try:
             fail()

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "Flask>=0.10.1",
         "Flask-BasicAuth>=0.2.0",
         "microcosm>=0.4.0",
+        "microcosm-logging>=0.1.0",
     ],
     setup_requires=[
         "nose>=1.3.6",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "Flask>=0.10.1",
         "Flask-BasicAuth>=0.2.0",
         "microcosm>=0.4.0",
-        "microcosm-logging>=0.1.0",
+        "microcosm-logging>=0.2.0",
     ],
     setup_requires=[
         "nose>=1.3.6",
@@ -29,7 +29,8 @@ setup(
     entry_points={
         "microcosm.factories": [
             "app = microcosm_flask.factories:configure_flask_app",
-            "basic_auth = microcosm_flask.basic_auth:configure_basic_auth",
+            "audit = microcosm_flask.audit:configure_audit_decorator",
+            "basic_auth = microcosm_flask.basic_auth:configure_basic_auth_decorator",
             "error_handlers = microcosm_flask.errors:configure_error_handlers",
             "flask = microcosm_flask.factories:configure_flask",
             "health = microcosm_flask.conventions.health:configure_health",


### PR DESCRIPTION
Several key changes:
 - `microcosm-logging` is now a dependency; I think this is an OK amount of coupling because logging is fundamental
 - An audit logging decorator is now part of the default setup; this one varies a bit from what we've been using elsewhere