### PR TITLE
Add a convention around named, resolveable Operations

### DIFF
--- a/microcosm_flask/conventions/health.py
+++ b/microcosm_flask/conventions/health.py
@@ -7,7 +7,6 @@ using HTTP 200/503 status codes to indicate healthiness.
 """
 from flask import jsonify
 
-from microcosm.api import defaults
 from microcosm_flask.naming import singleton_path_for
 from microcosm_flask.operations import Operation
 
@@ -51,9 +50,6 @@ class Health(object):
         )
 
 
-@defaults(
-    path_prefix="/api",
-)
 def configure_health(graph):
     """
     Configure the health endpoint.
@@ -63,9 +59,8 @@ def configure_health(graph):
     """
 
     health = Health(name=graph.metadata.name)
-    path = graph.config.health.path_prefix + singleton_path_for(Health)
 
-    @graph.route(path, Operation.Retrieve, Health)
+    @graph.route(singleton_path_for(Health), Operation.Retrieve, Health)
     def current_health():
         dct = health.to_dict()
         response = jsonify(dct)

--- a/microcosm_flask/conventions/health.py
+++ b/microcosm_flask/conventions/health.py
@@ -7,6 +7,10 @@ using HTTP 200/503 status codes to indicate healthiness.
 """
 from flask import jsonify
 
+from microcosm.api import defaults
+from microcosm_flask.naming import singleton_path_for
+from microcosm_flask.operations import Operation
+
 
 class Health(object):
     """
@@ -47,6 +51,9 @@ class Health(object):
         )
 
 
+@defaults(
+    path_prefix="/api",
+)
 def configure_health(graph):
     """
     Configure the health endpoint.
@@ -56,8 +63,9 @@ def configure_health(graph):
     """
 
     health = Health(name=graph.metadata.name)
+    path = graph.config.health.path_prefix + singleton_path_for(Health)
 
-    @graph.flask.route("/api/health")
+    @graph.route(path, Operation.Retrieve, Health)
     def current_health():
         dct = health.to_dict()
         response = jsonify(dct)

--- a/microcosm_flask/factories.py
+++ b/microcosm_flask/factories.py
@@ -37,5 +37,6 @@ def configure_flask_app(graph):
         "error_handlers",
         "health",
         "logger",
+        "route",
     )
     return graph.flask

--- a/microcosm_flask/naming.py
+++ b/microcosm_flask/naming.py
@@ -1,0 +1,57 @@
+"""
+Naming conventions.
+
+"""
+from inspect import isclass
+
+from inflection import underscore
+
+
+def name_for(obj):
+    """
+    Get a name for something.
+
+    Allows overriding of default names using the `__alias__` attribute.
+
+    """
+    if isinstance(obj, basestring):
+        return obj
+
+    cls = obj if isclass(obj) else obj.__class__
+
+    if hasattr(cls, "__alias__"):
+        return underscore(cls.__alias__)
+    else:
+        return underscore(cls.__name__)
+
+
+def collection_path_for(name):
+    """
+    Get a path for a collection of things.
+
+    """
+    return "/{}".format(name_for(name))
+
+
+def singleton_path_for(name):
+    """
+    Get a path for a singleton thing.
+
+    """
+    return "/{}".format(name_for(name))
+
+
+def instance_path_for(name):
+    """
+    Get a path for thing.
+
+    """
+    return "/{}/<uuid(strict=False):{}_id>".format(name_for(name), name)
+
+
+def relation_path_for(name, relation):
+    """
+    Get a path relating a thing to another.
+
+    """
+    return "/{}/<uuid(strict=False):{}_id>/{}".format(name_for(name), name, relation)

--- a/microcosm_flask/operations.py
+++ b/microcosm_flask/operations.py
@@ -1,0 +1,72 @@
+"""
+A naming convention and discovery mechanism for HTTP endpoints.
+
+Operations provide a naming convention for references between endpoints,
+allowing easy construction of links or audit trails for external consumption.
+
+"""
+from collections import namedtuple
+from urllib import urlencode
+from urlparse import urljoin
+
+from enum import Enum, unique
+from flask import request, url_for
+
+from microcosm_flask.naming import name_for
+
+
+# metadata for an operation
+OperationInfo = namedtuple("OperationInfo", ["name", "method"])
+
+
+@unique
+class Operation(Enum):
+    """
+    An enumerated set of operation types, which know how to resolve themselves into
+    URLs and hrefs.
+
+    """
+    # discovery operation
+    Discover = OperationInfo("discover", "GET")
+
+    # collection operations
+    Search = OperationInfo("search", "GET")
+    Create = OperationInfo("create", "POST")
+
+    # instance operations
+    Retrieve = OperationInfo("retrieve", "GET")
+    Delete = OperationInfo("delete", "DELETE")
+    Replace = OperationInfo("replace", "PUT")
+    Update = OperationInfo("update", "PATCH")
+
+    def name_for(self, obj):
+        """
+        Generate an operation name in the scope of the resource.
+
+        This naming convention matches how Flask blueprints routes are resolved
+        (assuming that the blueprint and resources share the same name).
+
+        Example: `foo.search`
+        """
+        return "{}.{}".format(name_for(obj), self.value.name)
+
+    def url_for(self, obj, **kwargs):
+        """
+        Construct a URL for an operation against a resource.
+
+        :param kwargs: additional arguments for URL path expansion
+
+        """
+        return url_for(self.name_for(obj), **kwargs)
+
+    def href_for(self, obj, qs=None, **kwargs):
+        """
+        Construct an full href for an operation against a resource.
+
+        :parm qs: the query string dictionary, if any
+        :param kwargs: additional arguments for path expansion
+        """
+        return "{}{}".format(
+            urljoin(request.url_root, self.url_for(obj, **kwargs)),
+            "?{}".format(urlencode(qs)) if qs else "",
+        )

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -1,0 +1,50 @@
+"""
+Routing registration support.
+
+Intercepts Flask's normal route registration to inject conventions.
+
+"""
+from flask_cors import cross_origin
+
+from microcosm.api import binding, defaults
+
+
+@binding("route")
+@defaults(
+    enable_audit=True,
+    enable_cors=True,
+)
+def configure_route_decorator(graph):
+    """
+    Configure a flask route decorator that operations on `Operation` objects.
+
+    By default, enables CORS support, assuming that service APIs are not exposed
+    directly to browsers except when using API browsing tools.
+
+    Usage:
+
+        @graph.route("/foo", Operation.Search, "foo")
+        def search_foo():
+            pass
+
+    """
+    def route(path, operation, obj):
+        def decorator(func):
+            if graph.config.route.enable_cors:
+                func = cross_origin(supports_credentials=True)(func)
+
+            # keep audit decoration last (before registering the route) so that
+            # errors raised by other decorators are captured in the audit trail
+            if graph.config.route.enable_audit:
+                func = graph.audit(func)
+
+            graph.flask.route(
+                path,
+                # for blueprints, the endpoint is operation.value.name
+                # because Flask automatically prefixes blueprint endpoints with "obj."
+                endpoint=operation.name_for(obj),
+                methods=[operation.value.method],
+            )(func)
+            return func
+        return decorator
+    return route

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -13,6 +13,7 @@ from microcosm.api import binding, defaults
 @defaults(
     enable_audit=True,
     enable_cors=True,
+    path_prefix="/api",
 )
 def configure_route_decorator(graph):
     """
@@ -39,7 +40,7 @@ def configure_route_decorator(graph):
                 func = graph.audit(func)
 
             graph.flask.route(
-                path,
+                graph.config.route.path_prefix + path,
                 # for blueprints, the endpoint is operation.value.name
                 # because Flask automatically prefixes blueprint endpoints with "obj."
                 endpoint=operation.name_for(obj),

--- a/microcosm_flask/tests/test_naming.py
+++ b/microcosm_flask/tests/test_naming.py
@@ -1,0 +1,53 @@
+"""
+Naming tests.
+
+"""
+from hamcrest import (
+    assert_that,
+    equal_to,
+    is_,
+)
+
+from microcosm_flask.naming import (
+    collection_path_for,
+    instance_path_for,
+    name_for,
+    singleton_path_for,
+    relation_path_for,
+)
+
+
+class FooBar():
+    pass
+
+
+class TheBaz():
+    __alias__ = "baz"
+
+
+def test_name_for():
+    cases = [
+        ("foo", "foo"),
+        (FooBar, "foo_bar"),
+        (FooBar(), "foo_bar"),
+        (TheBaz, "baz"),
+        (TheBaz(), "baz"),
+    ]
+    for obj, name in cases:
+        assert_that(name_for(obj), is_(equal_to(name)))
+
+
+def test_collection_path():
+    assert_that(collection_path_for("foo"), is_(equal_to("/foo")))
+
+
+def test_singletone_path():
+    assert_that(singleton_path_for("foo"), is_(equal_to("/foo")))
+
+
+def test_instance_path():
+    assert_that(instance_path_for("foo"), is_(equal_to("/foo/<uuid(strict=False):foo_id>")))
+
+
+def test_relation_path():
+    assert_that(relation_path_for("foo", "bar"), is_(equal_to("/foo/<uuid(strict=False):foo_id>/bar")))

--- a/microcosm_flask/tests/test_operations.py
+++ b/microcosm_flask/tests/test_operations.py
@@ -35,7 +35,7 @@ def test_operation_url_for():
 
     with graph.app.test_request_context():
         url = Operation.Search.url_for("foo")
-        assert_that(url, is_(equal_to("/foo")))
+        assert_that(url, is_(equal_to("/api/foo")))
 
 
 def test_operation_href_for():
@@ -51,7 +51,4 @@ def test_operation_href_for():
 
     with graph.app.test_request_context():
         url = Operation.Search.href_for("foo")
-        assert_that(url, is_(equal_to("http://localhost/foo")))
-
-    # XXX add blueprint support
-    # XXX migrate all test endpoints
+        assert_that(url, is_(equal_to("http://localhost/api/foo")))

--- a/microcosm_flask/tests/test_operations.py
+++ b/microcosm_flask/tests/test_operations.py
@@ -1,0 +1,57 @@
+"""
+Operation tests.
+
+"""
+from hamcrest import (
+    assert_that,
+    equal_to,
+    is_,
+)
+
+from microcosm.api import create_object_graph
+from microcosm_flask.naming import collection_path_for
+from microcosm_flask.operations import Operation
+
+
+def test_operation_naming():
+    """
+    Operation naming works.
+
+    """
+    operation_name = Operation.Search.name_for("foo")
+    assert_that(operation_name, is_(equal_to("foo.search")))
+
+
+def test_operation_url_for():
+    """
+    Operations can resolve themselves via Flask's `url_for`.
+
+    """
+    graph = create_object_graph(name="example", testing=True)
+
+    @graph.route(collection_path_for("foo"), Operation.Search, "foo")
+    def search_foo():
+        pass
+
+    with graph.app.test_request_context():
+        url = Operation.Search.url_for("foo")
+        assert_that(url, is_(equal_to("/foo")))
+
+
+def test_operation_href_for():
+    """
+    Operations can resolve themselves as fully expanded hrefs.
+
+    """
+    graph = create_object_graph(name="example", testing=True)
+
+    @graph.route(collection_path_for("foo"), Operation.Search, "foo")
+    def search_foo():
+        pass
+
+    with graph.app.test_request_context():
+        url = Operation.Search.href_for("foo")
+        assert_that(url, is_(equal_to("http://localhost/foo")))
+
+    # XXX add blueprint support
+    # XXX migrate all test endpoints

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,10 @@ setup(
     zip_safe=False,
     keywords="microcosm",
     install_requires=[
+        "enum34>=1.1.2",
         "Flask>=0.10.1",
         "Flask-BasicAuth>=0.2.0",
+        "flask-cors>=2.1.2",
         "microcosm>=0.4.0",
         "microcosm-logging>=0.2.0",
     ],
@@ -34,6 +36,7 @@ setup(
             "error_handlers = microcosm_flask.errors:configure_error_handlers",
             "flask = microcosm_flask.factories:configure_flask",
             "health = microcosm_flask.conventions.health:configure_health",
+            "route = microcosm_flask.routing:configure_route_decorator",
         ],
     },
     tests_require=[


### PR DESCRIPTION
In order to enable HAL-style linking and various forms of API automation,
we need every route endpoint to have a unique name. The Operation models
a "<subject>.<verb>" pair as a name that can be mapped to a URL or href
at runtime.