### PR TITLE
Implement Swagger convention on top of existing `microcosm` operations.

### DIFF
--- a/microcosm_flask/audit.py
+++ b/microcosm_flask/audit.py
@@ -7,7 +7,7 @@ from functools import wraps
 from json import loads
 from traceback import format_exc
 
-from flask import current_app, request
+from flask import current_app, g, request
 
 from microcosm_flask.errors import (
     extract_context,
@@ -60,7 +60,7 @@ def audit(func):
             )
 
             # include response body on debug (if any)
-            if current_app.debug and body:
+            if current_app.debug and body and not g.get("hide_body"):
                 try:
                     audit_dict["response_body"] = loads(body)
                 except (TypeError, ValueError):

--- a/microcosm_flask/basic_auth.py
+++ b/microcosm_flask/basic_auth.py
@@ -16,7 +16,7 @@ from flask.ext.basicauth import BasicAuth
 from werkzeug.exceptions import Unauthorized
 
 from microcosm.api import defaults
-from microcosm_flask.errors import with_headers
+from microcosm_flask.conventions.encoding import with_headers
 
 
 def encode_basic_auth(username, password):

--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -3,6 +3,7 @@ Conventions for canonical CRUD endpoints.
 
 """
 from flask import jsonify
+from inflection import pluralize
 
 from microcosm_flask.conventions.encoding import (
     dump_response_data,
@@ -59,7 +60,7 @@ def register_search_endpoint(graph, obj, path_prefix, func, request_schema, resp
             PaginatedList(obj, page, items, count, response_schema).to_dict()
         )
 
-    search.__doc__ = "Search the collection of all {}".format(name_for(obj))
+    search.__doc__ = "Search the collection of all {}".format(pluralize(name_for(obj)))
 
 
 @_crud(Operation.Create)

--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -11,9 +11,10 @@ from microcosm_flask.conventions.encoding import (
     merge_data,
     require_response_data,
 )
-from microcosm_flask.naming import instance_path_for, collection_path_for
+from microcosm_flask.conventions.registry import qs, request, response
+from microcosm_flask.naming import collection_path_for, instance_path_for, name_for
 from microcosm_flask.operations import Operation
-from microcosm_flask.paging import Page, PaginatedList
+from microcosm_flask.paging import Page, PaginatedList, make_paginated_list_schema
 
 
 # local registry of CRUD mappings
@@ -44,14 +45,21 @@ def register_search_endpoint(graph, obj, path_prefix, func, request_schema, resp
     :param response_schema: a marshmallow schema to encode (a single) response item
     """
 
+    paginated_list_schema = make_paginated_list_schema(obj, response_schema)()
+
     @graph.route(path_prefix + collection_path_for(obj), Operation.Search, obj)
+    @qs(request_schema)
+    @response(paginated_list_schema)
     def search(**path_data):
         request_data = load_query_string_data(request_schema)
         page = Page.from_query_string(request_data)
         items, count = func(**merge_data(path_data, request_data))
+        # TODO: use the schema for encoding
         return jsonify(
             PaginatedList(obj, page, items, count, response_schema).to_dict()
         )
+
+    search.__doc__ = "Search the collection of all {}".format(name_for(obj))
 
 
 @_crud(Operation.Create)
@@ -67,10 +75,14 @@ def register_create_endpoint(graph, obj, path_prefix, func, request_schema, resp
 
     """
     @graph.route(path_prefix + collection_path_for(obj), Operation.Create, obj)
+    @request(request_schema)
+    @response(response_schema)
     def create(**path_data):
         request_data = load_request_data(request_schema)
         response_data = func(**merge_data(path_data, request_data))
-        return dump_response_data(response_schema, response_data, 201)
+        return dump_response_data(response_schema, response_data, Operation.Create.value.default_code)
+
+    create.__doc__ = "Create a new {}".format(name_for(obj))
 
 
 @_crud(Operation.Retrieve)
@@ -85,9 +97,12 @@ def register_retrieve_endpoint(graph, obj, path_prefix, func, response_schema):
 
     """
     @graph.route(path_prefix + instance_path_for(obj), Operation.Retrieve, obj)
+    @response(response_schema)
     def retrieve(**path_data):
         response_data = require_response_data(func(**path_data))
         return dump_response_data(response_schema, response_data)
+
+    retrieve.__doc__ = "Retrieve a {} by id".format(name_for(obj))
 
 
 @_crud(Operation.Delete)
@@ -103,7 +118,9 @@ def register_delete_endpoint(graph, obj, path_prefix, func):
     @graph.route(path_prefix + instance_path_for(obj), Operation.Delete, obj)
     def delete(**path_data):
         require_response_data(func(**path_data))
-        return "", 204
+        return "", Operation.Delete.value.default_code
+
+    delete.__doc__ = "Delete a {} by id".format(name_for(obj))
 
 
 @_crud(Operation.Replace)
@@ -119,6 +136,8 @@ def register_replace_endpoint(graph, obj, path_prefix, func, request_schema, res
 
     """
     @graph.route(path_prefix + instance_path_for(obj), Operation.Replace, obj)
+    @request(request_schema)
+    @response(response_schema)
     def replace(**path_data):
         request_data = load_request_data(request_schema)
         # Replace/put should create a resource if not already present, but we do not
@@ -126,6 +145,8 @@ def register_replace_endpoint(graph, obj, path_prefix, func, request_schema, res
         # will raise a 404.
         response_data = require_response_data(func(**merge_data(path_data, request_data)))
         return dump_response_data(response_schema, response_data)
+
+    replace.__doc__ = "Create or update a {} by id".format(name_for(obj))
 
 
 @_crud(Operation.Update)
@@ -141,11 +162,15 @@ def register_update_endpoint(graph, obj, path_prefix, func, request_schema, resp
 
     """
     @graph.route(path_prefix + instance_path_for(obj), Operation.Update, obj)
+    @request(request_schema)
+    @response(response_schema)
     def update(**path_data):
         # NB: using partial here means that marshmallow will not validate required fields
         request_data = load_request_data(request_schema, partial=True)
         response_data = require_response_data(func(**merge_data(path_data, request_data)))
         return dump_response_data(response_schema, response_data)
+
+    update.__doc__ = "Update some or all of a {} by id".format(name_for(obj))
 
 
 def configure_crud(graph, obj, mappings, path_prefix=""):

--- a/microcosm_flask/conventions/discovery.py
+++ b/microcosm_flask/conventions/discovery.py
@@ -6,27 +6,11 @@ from flask import jsonify
 
 from microcosm.api import defaults
 from microcosm_flask.conventions.encoding import load_query_string_data
+from microcosm_flask.conventions.registry import iter_operations
 from microcosm_flask.linking import Link, Links
 from microcosm_flask.naming import name_for, singleton_path_for
 from microcosm_flask.paging import Page, PageSchema
 from microcosm_flask.operations import Operation
-
-
-def iter_operations(graph, match_func):
-    """
-    Iterate through operations in matches.
-
-    """
-    for rule in graph.flask.url_map.iter_rules():
-        try:
-            operation, obj = Operation.parse(rule.endpoint)
-        except ValueError:
-            # operation follows a different convention (e.g. "static")
-            continue
-        else:
-            # match_func gets access to rule to support path version filtering
-            if match_func(operation, obj, rule):
-                yield operation, obj
 
 
 def iter_links(operations, page):
@@ -34,7 +18,7 @@ def iter_links(operations, page):
     Generate links for an iterable of operations on a starting page.
 
     """
-    for operation, obj in operations:
+    for operation, obj, rule, func in operations:
         yield Link.for_(
             operation=operation,
             obj=obj,

--- a/microcosm_flask/conventions/encoding.py
+++ b/microcosm_flask/conventions/encoding.py
@@ -3,6 +3,7 @@ Support for encoding and decoding request/response content.
 
 """
 from flask import jsonify, request
+from werkzeug import Headers
 from werkzeug.exceptions import NotFound, UnprocessableEntity
 
 
@@ -68,7 +69,7 @@ def dump_response_data(response_schema, response_data, status_code=200, headers=
     if response_schema:
         response_data = response_schema.dump(response_data).data
     response = jsonify(response_data)
-    response.headers = headers
+    response.headers = Headers(headers or {})
     response.status_code = status_code
     return response
 

--- a/microcosm_flask/conventions/encoding.py
+++ b/microcosm_flask/conventions/encoding.py
@@ -5,7 +5,15 @@ Support for encoding and decoding request/response content.
 from flask import jsonify, request
 from werkzeug.exceptions import NotFound, UnprocessableEntity
 
-from microcosm_flask.errors import with_context
+
+def with_headers(error, headers):
+    setattr(error, "headers", headers)
+    return error
+
+
+def with_context(error, errors):
+    setattr(error, "context", dict(errors=errors))
+    return error
 
 
 def load_request_data(request_schema, partial=False):
@@ -22,7 +30,13 @@ def load_request_data(request_schema, partial=False):
     request_data = request_schema.load(json_data, partial=partial)
     if request_data.errors:
         # pass the validation errors back in the context
-        raise with_context(UnprocessableEntity("Validation error"), dict(errors=request_data.errors))
+        raise with_context(
+            UnprocessableEntity("Validation error"), [{
+                "message": "Could not validate field: {}".format(field),
+                "field": field,
+                "reasons": reasons
+            } for field, reasons in request_data.errors.items()],
+        )
     return request_data.data
 
 
@@ -41,7 +55,7 @@ def load_query_string_data(request_schema):
     return request_data.data
 
 
-def dump_response_data(response_schema, response_data, status_code=200):
+def dump_response_data(response_schema, response_data, status_code=200, headers=None):
     """
     Dumps response data as JSON using the given schema.
 
@@ -51,8 +65,10 @@ def dump_response_data(response_schema, response_data, status_code=200):
     HTTP 400 and 406 errors.
 
     """
-    response_data = response_schema.dump(response_data).data
+    if response_schema:
+        response_data = response_schema.dump(response_data).data
     response = jsonify(response_data)
+    response.headers = headers
     response.status_code = status_code
     return response
 

--- a/microcosm_flask/conventions/registry.py
+++ b/microcosm_flask/conventions/registry.py
@@ -1,0 +1,73 @@
+"""
+Support for registering function metadata.
+
+"""
+from microcosm_flask.operations import Operation
+
+
+REQUEST = "__request__"
+RESPONSE = "__response__"
+QS = "__qs__"
+
+
+def iter_operations(graph, match_func):
+    """
+    Iterate through operations in matches.
+
+    """
+    for rule in graph.flask.url_map.iter_rules():
+        try:
+            operation, obj = Operation.parse(rule.endpoint)
+        except (IndexError, ValueError):
+            # operation follows a different convention (e.g. "static")
+            continue
+        else:
+            # match_func gets access to rule to support path version filtering
+            if match_func(operation, obj, rule):
+                func = graph.flask.view_functions[rule.endpoint]
+                yield operation, obj, rule, func
+
+
+def request(schema):
+    """
+    Decorate a function with a request schema.
+
+    """
+    def wrapper(func):
+        setattr(func, REQUEST, schema)
+        return func
+    return wrapper
+
+
+def response(schema):
+    """
+    Decorate a function with a response schema.
+
+    """
+    def wrapper(func):
+        setattr(func, RESPONSE, schema)
+        return func
+    return wrapper
+
+
+def qs(schema):
+    """
+    Decorate a function with a query string schema.
+
+    """
+    def wrapper(func):
+        setattr(func, QS, schema)
+        return func
+    return wrapper
+
+
+def get_request_schema(func):
+    return getattr(func, REQUEST, None)
+
+
+def get_response_schema(func):
+    return getattr(func, RESPONSE, None)
+
+
+def get_qs_schema(func):
+    return getattr(func, QS, None)

--- a/microcosm_flask/conventions/relation.py
+++ b/microcosm_flask/conventions/relation.py
@@ -48,7 +48,7 @@ def register_search_relation_endpoint(graph, obj, path_prefix, func, request_sch
     :param response_schema: a marshmallow schema to encode (a single) response item
     """
 
-    paginated_list_schema = make_paginated_list_schema(obj, response_schema)()
+    paginated_list_schema = make_paginated_list_schema(obj[1], response_schema)()
 
     @graph.route(path_prefix + relation_path_for(*obj), Operation.SearchFor, obj)
     @qs(request_schema)

--- a/microcosm_flask/conventions/relation.py
+++ b/microcosm_flask/conventions/relation.py
@@ -11,9 +11,10 @@ from microcosm_flask.conventions.encoding import (
     load_query_string_data,
     merge_data,
 )
-from microcosm_flask.naming import relation_path_for
+from microcosm_flask.conventions.registry import qs, response
+from microcosm_flask.naming import name_for, relation_path_for
 from microcosm_flask.operations import Operation
-from microcosm_flask.paging import Page, PaginatedList
+from microcosm_flask.paging import Page, PaginatedList, make_paginated_list_schema
 
 
 # local registry of relation mappings
@@ -45,14 +46,22 @@ def register_search_relation_endpoint(graph, obj, path_prefix, func, request_sch
     :param request_schema: a marshmallow schema to decode/validate query string arguments
     :param response_schema: a marshmallow schema to encode (a single) response item
     """
+
+    paginated_list_schema = make_paginated_list_schema(obj, response_schema)()
+
     @graph.route(path_prefix + relation_path_for(*obj), Operation.SearchFor, obj)
+    @qs(request_schema)
+    @response(paginated_list_schema)
     def search(**path_data):
         request_data = load_query_string_data(request_schema)
         page = Page.from_query_string(request_data)
         items, count, context = func(**merge_data(path_data, request_data))
+        # TODO: use the schema for encoding
         return jsonify(
             PaginatedList(obj, page, items, count, response_schema, Operation.SearchFor, **context).to_dict()
         )
+
+    search.__doc__ = "Search for {} in relation to a {}".format(name_for(obj[1]), name_for(obj[0]))
 
 
 def configure_relation(graph, from_obj, to_obj, mappings, path_prefix=""):

--- a/microcosm_flask/conventions/relation.py
+++ b/microcosm_flask/conventions/relation.py
@@ -6,6 +6,7 @@ simplicity these are passed as a pair/tuple.
 
 """
 from flask import jsonify
+from inflection import pluralize
 
 from microcosm_flask.conventions.encoding import (
     load_query_string_data,
@@ -61,7 +62,7 @@ def register_search_relation_endpoint(graph, obj, path_prefix, func, request_sch
             PaginatedList(obj, page, items, count, response_schema, Operation.SearchFor, **context).to_dict()
         )
 
-    search.__doc__ = "Search for {} in relation to a {}".format(name_for(obj[1]), name_for(obj[0]))
+    search.__doc__ = "Search for {} relative to a {}".format(pluralize(name_for(obj[1])), name_for(obj[0]))
 
 
 def configure_relation(graph, from_obj, to_obj, mappings, path_prefix=""):

--- a/microcosm_flask/conventions/swagger.py
+++ b/microcosm_flask/conventions/swagger.py
@@ -1,0 +1,383 @@
+"""
+Swagger (OpoenAPI) convention.
+
+Generates a Swagger definition, as JSON, for registered operations.
+
+Note that:
+ -  Swagger operations and type names use different conventions from the internal definitions
+    because we want to make usage friendly for code generation (e.g. bravado)
+
+ -  Marshmallow to JSON Schema conversion is somewhat simplistic. There are several projects
+    that already implement this conversion that we could try adapting. At the moment, the
+    overhead of adapting another library's conventions is too high.
+
+ -  All resource definitions are assumed to be shared and are declared in the "definitions"
+    section of the result.
+
+ -  All errors are defined generically.
+
+
+"""
+from flask import jsonify, g
+from inflection import camelize, pluralize
+from openapi import model as swagger
+from marshmallow import fields
+from werkzeug.routing import BuildError
+
+from microcosm.api import defaults
+from microcosm_flask.conventions.registry import (
+    get_qs_schema,
+    get_request_schema,
+    get_response_schema,
+    iter_operations,
+)
+from microcosm_flask.errors import ErrorSchema, ErrorContextSchema, SubErrorSchema
+from microcosm_flask.fields import EnumField
+from microcosm_flask.naming import name_for, singleton_path_for
+from microcosm_flask.operations import Operation
+
+
+def operation_name(operation, obj):
+    """
+    Convert an operation, obj(s) pair into a swagger operation id.
+
+    For compatability with Bravado, we want to use underscores instead of dots and
+    verb-friendly names. Example:
+
+        foo.retrieve       => client.foo.retrieve()
+        foo.search_for.bar => client.foo.search_for_bars()
+
+    """
+    if isinstance(obj, (list, tuple)):
+        verb, rest = operation.value.name, obj[1:]
+    else:
+        verb, rest = operation.value.name, []
+    return "_".join([verb] + [pluralize(name_for(noun)) for noun in rest])
+
+
+def type_name(name):
+    """
+    Convert an internal name into a swagger type name.
+
+    For example:
+
+        foo_bar => FooBar
+
+    """
+    if name.endswith("_schema"):
+        name = name[:-7]
+    return camelize(name)
+
+
+# see: https://github.com/marshmallow-code/apispec/blob/dev/apispec/ext/marshmallow/swagger.py
+FIELD_MAPPINGS = {
+    fields.Integer: ("integer", "int32"),
+    fields.Number: ("number", None),
+    fields.Float: ("number", "float"),
+    fields.Decimal: ("number", None),
+    fields.String: ("string", None),
+    fields.Boolean: ("boolean", None),
+    fields.UUID: ("string", "uuid"),
+    fields.DateTime: ("string", "date-time"),
+    fields.Date: ("string", "date"),
+    fields.Time: ("string", None),
+    fields.Email: ("string", "email"),
+    fields.URL: ("string", "url"),
+    fields.Field: ("object", None),
+    fields.Raw: ("object", None),
+    fields.List: ("array", None),
+    fields.Nested: (None, None),
+    fields.Method: ("object", None),
+    EnumField: ("string", None),
+}
+
+
+def build_parameter(field):
+    """
+    Build a parameter from a marshmallow field.
+
+    See: https://github.com/marshmallow-code/apispec/blob/dev/apispec/ext/marshmallow/swagger.py#L81
+
+    """
+    field_type, field_format = FIELD_MAPPINGS[type(field)]
+    parameter = {}
+    if field_type:
+        parameter["type"] = field_type
+    if field.metadata.get("description"):
+        parameter["description"] = field.metadata["description"]
+    if field_format:
+        parameter["format"] = field_format
+    if field.default:
+        parameter["default"] = field.default
+
+    # enums
+    enum = getattr(field, "enum", None)
+    if enum:
+        parameter["enum"] = [choice.name for choice in enum]
+
+    # nested
+    if isinstance(field, fields.Nested):
+        parameter["$ref"] = "#/definitions/{}".format(type_name(name_for(field.schema)))
+
+    # arrays
+    if isinstance(field, fields.List):
+        parameter["items"] = build_parameter(field.container)
+
+    return parameter
+
+
+def build_schema(marshmallow_schema):
+    """
+    Build JSON schema from a marshmallow schema.
+
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            field.dump_to or name: build_parameter(field)
+            for name, field in marshmallow_schema.fields.items()
+        },
+        "required": [
+            field.dump_to or name
+            for name, field in marshmallow_schema.fields.items()
+            if field.required
+        ]
+    }
+    return schema
+
+
+def build_swagger(graph, version, path_prefix, operations):
+    """
+    Build out the top-level swagger definition.
+
+    """
+    base_path = graph.config.route.path_prefix
+    schema = swagger.Swagger(
+        swagger="2.0",
+        info=swagger.Info(
+            title=graph.metadata.name,
+            version=version,
+        ),
+        consumes=swagger.MediaTypeList([
+            swagger.MimeType("application/json"),
+        ]),
+        produces=swagger.MediaTypeList([
+            swagger.MimeType("application/json"),
+        ]),
+        basePath=base_path + "/" + version,
+        paths=swagger.Paths(),
+        definitions=swagger.Definitions(),
+    )
+    add_paths(schema.paths, base_path + path_prefix, operations)
+    add_definitions(schema.definitions, operations)
+    schema.validate()
+    return schema
+
+
+def add_paths(paths, path_prefix, operations):
+    """
+    Add paths to swagger.
+
+    """
+    for operation, obj, rule, func in operations:
+        path = build_path(operation, obj)[len(path_prefix):]
+        method = operation.value.method.lower()
+        paths.setdefault(path, swagger.PathItem())[method] = build_operation(operation, obj, rule, func)
+
+
+def add_definitions(definitions, operations):
+    """
+    Add definitions to swagger.
+
+    """
+    # general error schema per errors.py
+    for error_schema_class in [ErrorSchema, ErrorContextSchema, SubErrorSchema]:
+        error_schema = error_schema_class()
+        definitions[type_name(name_for(error_schema))] = swagger.Schema(build_schema(error_schema))
+
+    # add all request and response schemas
+    for operation, obj, rule, func in operations:
+        request_schema = get_request_schema(func)
+        if request_schema:
+            definitions.setdefault(type_name(name_for(request_schema)), swagger.Schema(build_schema(request_schema)))
+
+        response_schema = get_response_schema(func)
+        if response_schema:
+            definitions.setdefault(type_name(name_for(response_schema)), swagger.Schema(build_schema(response_schema)))
+
+
+def build_path(operation, obj):
+    """
+    Build a path URI for an operation.
+
+    """
+    try:
+        return operation.url_for(obj)
+    except BuildError as error:
+        uri_templates = {
+            argument: "{{{}}}".format(argument)
+            for argument in error.suggested.arguments
+        }
+        return operation.url_for(obj, **uri_templates)
+
+
+def body_param(schema):
+    return swagger.BodyParameter(**{
+        "name": "body",
+        "in": "body",
+        "schema": swagger.JsonReference({
+            "$ref": "#/definitions/{}".format(type_name(name_for(schema))),
+        }),
+    })
+
+
+def query_param(name, field, required=False):
+    """
+    Build a query parameter definition.
+
+    """
+    parameter = build_parameter(field)
+    parameter["name"] = name
+    parameter["in"] = "query"
+    parameter["required"] = False
+
+    return swagger.QueryParameterSubSchema(**parameter)
+
+
+def path_param(name, param_type="string"):
+    """
+    Build a path parameter definition.
+
+    """
+    return swagger.PathParameterSubSchema(**{
+        "name": name,
+        "in": "path",
+        "required": True,
+        "type": param_type,
+    })
+
+
+def build_operation(operation, obj, rule, func):
+    """
+    Build an operation definition.
+
+    """
+    swagger_operation = swagger.Operation(
+        operationId=operation_name(operation, obj),
+        parameters=swagger.ParametersList([
+        ]),
+        responses=swagger.Responses(),
+    )
+
+    # path parameters
+    swagger_operation.parameters.extend([
+        # TODO: inject type information for parameters based on converter syntax
+        path_param(argument)
+        for argument in rule.arguments
+    ])
+
+    # query string parameters
+    qs_schema = get_qs_schema(func)
+    if qs_schema:
+        swagger_operation.parameters.extend([
+            query_param(name, field)
+            for name, field in qs_schema.fields.items()
+        ])
+
+    # body parameter
+    request_schema = get_request_schema(func)
+    if request_schema:
+        swagger_operation.parameters.append(
+            body_param(request_schema)
+        )
+
+    add_responses(swagger_operation, operation, obj, func)
+    return swagger_operation
+
+
+def add_responses(swagger_operation, operation, obj, func):
+    """
+    Add responses to an operation.
+
+    """
+    # default error
+    swagger_operation.responses["default"] = build_response(
+        description="An error occcurred",
+        resource=type_name(name_for(ErrorSchema())),
+    )
+    # resources response
+    swagger_operation.responses[str(operation.value.default_code)] = build_response(
+        description=getattr(func, "__doc__") or "{} {}".format(operation.value.name, name_for(obj)),
+        resource=get_response_schema(func),
+    )
+
+
+def build_response(description, resource=None):
+    """
+    Build a response definition.
+
+    """
+    response = swagger.Response(
+        description=description,
+    )
+    if resource is not None:
+        response.schema = swagger.JsonReference({
+            "$ref": "#/definitions/{}".format(type_name(name_for(resource))),
+        })
+    return response
+
+
+def register_swagger_endpoint(graph, name, version, path_prefix, match_func):
+    """
+    Register a swagger endpoint for a set of operations.
+
+    """
+    @graph.route(path_prefix + singleton_path_for(name), Operation.Discover, name)
+    def discover():
+        operations = list(iter_operations(graph, match_func))
+
+        swagger = build_swagger(graph, version, path_prefix, operations)
+
+        g.hide_body = True
+
+        return jsonify(swagger)
+
+    return name
+
+
+@defaults(
+    name="swagger",
+    operations=[
+        "create",
+        "delete",
+        "replace",
+        "retrieve",
+        "search",
+        "search_for",
+        "update",
+    ],
+    path_prefix="",
+)
+def configure_swagger(graph):
+    """
+    Build a singleton endpoint that provides swagger definitions for all operations.
+
+    """
+    name = graph.config.swagger_convention.name
+    version = graph.config.swagger_convention.version
+
+    base_path = graph.config.route.path_prefix
+    path_prefix = graph.config.swagger_convention.path_prefix + "/" + version
+
+    matches = {
+        Operation.from_name(operation_name.lower())
+        for operation_name in graph.config.swagger_convention.operations
+    }
+
+    def match_func(operation, obj, rule):
+        return (
+            rule.rule.startswith(base_path + path_prefix) and
+            operation in matches
+        )
+
+    return register_swagger_endpoint(graph, name, version, path_prefix, match_func)

--- a/microcosm_flask/conventions/swagger.py
+++ b/microcosm_flask/conventions/swagger.py
@@ -267,6 +267,7 @@ def build_operation(operation, obj, rule, func):
         parameters=swagger.ParametersList([
         ]),
         responses=swagger.Responses(),
+        tags=[name_for(obj[0] if isinstance(obj, (list, tuple)) else obj)],
     )
 
     # path parameters

--- a/microcosm_flask/conventions/swagger.py
+++ b/microcosm_flask/conventions/swagger.py
@@ -1,5 +1,5 @@
 """
-Swagger (OpoenAPI) convention.
+Swagger (OpenAPI) convention.
 
 Generates a Swagger definition, as JSON, for registered operations.
 

--- a/microcosm_flask/linking.py
+++ b/microcosm_flask/linking.py
@@ -15,7 +15,7 @@ from werkzeug.routing import BuildError
 # The main obstacles are:
 #
 #  - Links values can be dictionaries (with an "href") or lists of the same.
-#  - Links are encoded in several places; it's a bit more convention to call `to_dict()`
+#  - Links are encoded in several places; it's a bit more convenient to call `to_dict()`
 #    than to instantiate a schema instance in each case.
 
 

--- a/microcosm_flask/operations.py
+++ b/microcosm_flask/operations.py
@@ -16,7 +16,7 @@ from microcosm_flask.naming import name_for
 
 
 # metadata for an operation
-OperationInfo = namedtuple("OperationInfo", ["name", "method", "pattern"])
+OperationInfo = namedtuple("OperationInfo", ["name", "method", "pattern", "default_code"])
 
 
 NODE_PATTERN = "{}.{}"
@@ -31,21 +31,21 @@ class Operation(Enum):
 
     """
     # discovery operation
-    Discover = OperationInfo("discover", "GET", NODE_PATTERN)
+    Discover = OperationInfo("discover", "GET", NODE_PATTERN, 200)
 
     # collection operations
-    Search = OperationInfo("search", "GET", NODE_PATTERN)
-    Create = OperationInfo("create", "POST", NODE_PATTERN)
+    Search = OperationInfo("search", "GET", NODE_PATTERN, 200)
+    Create = OperationInfo("create", "POST", NODE_PATTERN, 201)
     # bulk update is possible here with PATCH
 
     # instance operations
-    Retrieve = OperationInfo("retrieve", "GET", NODE_PATTERN)
-    Delete = OperationInfo("delete", "DELETE", NODE_PATTERN)
-    Replace = OperationInfo("replace", "PUT", NODE_PATTERN)
-    Update = OperationInfo("update", "PATCH", NODE_PATTERN)
+    Retrieve = OperationInfo("retrieve", "GET", NODE_PATTERN, 200)
+    Delete = OperationInfo("delete", "DELETE", NODE_PATTERN, 204)
+    Replace = OperationInfo("replace", "PUT", NODE_PATTERN, 200)
+    Update = OperationInfo("update", "PATCH", NODE_PATTERN, 200)
 
     # relation operations
-    SearchFor = OperationInfo("search_for", "GET", EDGE_PATTERN)
+    SearchFor = OperationInfo("search_for", "GET", EDGE_PATTERN, 200)
 
     def name_for(self, obj):
         """
@@ -104,5 +104,9 @@ class Operation(Enum):
         Convert an operation name back to an operation, obj tuple.
 
         """
-        obj, operation_name = name.split(".", 1)
-        return cls.from_name(operation_name), obj
+        parts = name.split(".")
+        operation = cls.from_name(parts[1])
+        if len(parts) > 2:
+            return operation, parts[0:1] + parts[2:]
+        else:
+            return operation, parts[0]

--- a/microcosm_flask/paging.py
+++ b/microcosm_flask/paging.py
@@ -21,7 +21,7 @@ def make_paginated_list_schema(obj, obj_schema):
     """
 
     class PaginatedListSchema(Schema):
-        __alias__ = "{}_list".format(name_for(obj))
+        __alias__ = "{}_list".format(name_for(obj[0] if isinstance(obj, (list, tuple)) else obj))
 
         offset = fields.Integer(required=True)
         limit = fields.Integer(required=True)

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -111,11 +111,13 @@ class TestCrud(object):
             "message": "Validation error",
             "retryable": False,
             "context": {
-                "errors": {
-                    "firstName": [
+                "errors": [{
+                    "message": "Could not validate field: firstName",
+                    "field": "firstName",
+                    "reasons": [
                         "Missing data for required field.",
                     ],
-                }
+                }]
             }
         })
 

--- a/microcosm_flask/tests/test_basic_auth.py
+++ b/microcosm_flask/tests/test_basic_auth.py
@@ -42,7 +42,7 @@ def test_basic_auth():
                    "You either supplied the wrong credentials (e.g. a bad password), or your browser "
                    "doesn't understand how to supply the credentials required.",
         "retryable": False,
-        "context": {},
+        "context": {"errors": []},
     })))
     assert_that(response.headers["WWW-Authenticate"], is_(equal_to('Basic realm="microcosm"')))
 
@@ -71,7 +71,7 @@ def test_basic_auth_default_realm():
                    "You either supplied the wrong credentials (e.g. a bad password), or your browser "
                    "doesn't understand how to supply the credentials required.",
         "retryable": False,
-        "context": {},
+        "context": {"errors": []},
     })))
     assert_that(response.headers["WWW-Authenticate"], is_(equal_to('Basic realm="example"')))
 

--- a/microcosm_flask/tests/test_errors.py
+++ b/microcosm_flask/tests/test_errors.py
@@ -57,7 +57,7 @@ def test_werkzeug_http_error():
         "message": "The requested URL was not found on the server.  "
                    "If you entered the URL manually please check your spelling and try again.",
         "retryable": False,
-        "context": {},
+        "context": {"errors": []},
     })))
 
 
@@ -78,7 +78,7 @@ def test_no_route():
         "message": "The requested URL was not found on the server.  "
                    "If you entered the URL manually please check your spelling and try again.",
         "retryable": False,
-        "context": {},
+        "context": {"errors": []},
     })))
 
 
@@ -103,7 +103,7 @@ def test_werkzeug_http_error_custom_message():
         "code": 500,
         "message": "Why me?",
         "retryable": False,
-        "context": {},
+        "context": {"errors": []},
     })))
 
 
@@ -128,7 +128,7 @@ def test_custom_error():
         "code": 500,
         "message": "unexpected",
         "retryable": False,
-        "context": {},
+        "context": {"errors": []},
     })))
 
 
@@ -153,7 +153,7 @@ def test_custom_error_status_code():
         "code": 400,
         "message": "MyValidationError",
         "retryable": False,
-        "context": {},
+        "context": {"errors": []},
     })))
 
 
@@ -213,5 +213,5 @@ def test_error_wrap():
         "code": 500,
         "message": "fail",
         "retryable": False,
-        "context": {}
+        "context": {"errors": []}
     })))

--- a/microcosm_flask/tests/test_errors.py
+++ b/microcosm_flask/tests/test_errors.py
@@ -29,7 +29,9 @@ class MyConflictError(Exception):
     @property
     def context(self):
         return dict(
-            resource="Banana!",
+            errors=[
+                dict(message="Banana!"),
+            ],
         )
 
 
@@ -177,7 +179,9 @@ def test_custom_error_retryable():
         "message": "Conflict",
         "retryable": True,
         "context": {
-            "resource": "Banana!",
+            "errors": [{
+                "message": "Banana!",
+            }]
         },
     })))
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "marshmallow>=2.6.0",
         "microcosm>=0.5.1",
         "microcosm-logging>=0.2.0",
+        "openapi>=0.2.0",
         "PyYAML>=3.11",
     ],
     setup_requires=[
@@ -45,6 +46,7 @@ setup(
             "flask = microcosm_flask.factories:configure_flask",
             "health_convention = microcosm_flask.conventions.health:configure_health",
             "route = microcosm_flask.routing:configure_route_decorator",
+            "swagger_convention = microcosm_flask.conventions.swagger:configure_swagger",
             "uuid = microcosm_flask.converters:configure_uuid",
         ],
     },


### PR DESCRIPTION
Swagger (aka OpenAPI 2.0) is a widely adopted standard for automating APIs, especially RESTful JSON APIs.

Because `microcosm` already has nice abstractions around the elements of the APIs it defines, it wasn't that much work to provide a swagger definition for services. This means that we can automate the client side of talking to a service.

It's worth noting that there are *many* partial swagger implementations out there, many of which are more complete than what I've written. I adapted code from one of them, but opted not to use any of them directly because they would have dragged in more complexity and dependencies than they would have saved.