### PR TITLE
Support ad hoc command and query operations

### DIFF
--- a/microcosm_flask/operations.py
+++ b/microcosm_flask/operations.py
@@ -47,6 +47,10 @@ class Operation(Enum):
     # relation operations
     SearchFor = OperationInfo("search_for", "GET", EDGE_PATTERN, 200)
 
+    # ad hoc operations
+    Command = OperationInfo("command", "POST", NODE_PATTERN, 200)
+    Query = OperationInfo("query", "GET", NODE_PATTERN, 200)
+
     def name_for(self, obj):
         """
         Generate an operation name in the scope of one or more resources.

--- a/microcosm_flask/swagger/definitions.py
+++ b/microcosm_flask/swagger/definitions.py
@@ -192,9 +192,15 @@ def add_responses(swagger_operation, operation, obj, func):
         description="An error occcurred",
         resource=type_name(name_for(ErrorSchema())),
     )
+
+    if hasattr(func, "__doc__"):
+        description = func.__doc__.strip().splitlines()[0]
+    else:
+        description = "{} {}".format(operation.value.name, name_for(obj))
+
     # resources response
     swagger_operation.responses[str(operation.value.default_code)] = build_response(
-        description=getattr(func, "__doc__") or "{} {}".format(operation.value.name, name_for(obj)),
+        description=description,
         resource=get_response_schema(func),
     )
 

--- a/microcosm_flask/tests/conventions/test_query.py
+++ b/microcosm_flask/tests/conventions/test_query.py
@@ -15,10 +15,9 @@ from microcosm.api import create_object_graph
 from microcosm_flask.conventions.encoding import dump_response_data, load_query_string_data
 from microcosm_flask.conventions.registry import qs, response
 from microcosm_flask.operations import Operation
-from microcosm_flask.paging import PageSchema
 
 
-class QueryStringSchema(PageSchema):
+class QueryStringSchema(Schema):
     value = fields.String(required=True)
 
 
@@ -118,21 +117,9 @@ class TestQuery(object):
                     },
                     "parameters": [{
                         "required": False,
-                        "in": "query",
-                        "type": "integer",
-                        "name": "limit",
-                        "format": "int32",
-                    }, {
-                        "required": False,
                         "type": "string",
                         "name": "value",
                         "in": "query",
-                    }, {
-                        "required": False,
-                        "in": "query",
-                        "type": "integer",
-                        "name": "offset",
-                        "format": "int32",
                     }],
                     "operationId": "query",
                 }

--- a/microcosm_flask/tests/conventions/test_query.py
+++ b/microcosm_flask/tests/conventions/test_query.py
@@ -2,7 +2,7 @@
 Query operation tests.
 
 """
-from json import dumps, loads
+from json import loads
 from hamcrest import (
     assert_that,
     equal_to,

--- a/microcosm_flask/tests/conventions/test_query.py
+++ b/microcosm_flask/tests/conventions/test_query.py
@@ -1,0 +1,140 @@
+"""
+Query operation tests.
+
+"""
+from json import dumps, loads
+from hamcrest import (
+    assert_that,
+    equal_to,
+    is_,
+)
+
+from marshmallow import fields, Schema
+from microcosm.api import create_object_graph
+
+from microcosm_flask.conventions.encoding import dump_response_data, load_query_string_data
+from microcosm_flask.conventions.registry import qs, response
+from microcosm_flask.operations import Operation
+from microcosm_flask.paging import PageSchema
+
+
+class QueryStringSchema(PageSchema):
+    value = fields.String(required=True)
+
+
+class QueryResultSchema(Schema):
+    result = fields.Boolean(required=True)
+    value = fields.String(required=True)
+
+
+def make_query(graph, request_schema, response_schema):
+    """
+    Create an example query route.
+
+    """
+
+    @graph.route("/v1/foo/get", Operation.Query, "foo")
+    @qs(request_schema)
+    @response(response_schema)
+    def foo_query():
+        """
+        My doc string
+        """
+        request_data = load_query_string_data(request_schema)
+        response_data = dict(
+            result=True,
+            value=request_data["value"],
+        )
+        return dump_response_data(response_schema, response_data, Operation.Query.value.default_code)
+
+
+class TestQuery(object):
+
+    def setup(self):
+        # override configuration to use "query" operations for swagger
+        def loader(metadata):
+            return dict(
+                swagger_convention=dict(
+                    # default behavior appends this list to defaults; use a tuple to override
+                    operations=["query"],
+                    version="v1",
+                ),
+            )
+        self.graph = create_object_graph(name="example", testing=True, loader=loader)
+        self.graph.use("swagger_convention")
+
+        make_query(self.graph, QueryStringSchema(), QueryResultSchema())
+
+        self.client = self.graph.flask.test_client()
+
+    def test_url_for(self):
+        """
+        The operation knowns how to resolve a URI for this query.
+
+        """
+        with self.graph.flask.test_request_context():
+            assert_that(Operation.Query.url_for("foo"), is_(equal_to("/api/v1/foo/get")))
+
+    def test_query(self):
+        """
+        The query can take advantage of boilerplate encoding/decoding.
+
+        """
+        uri = "/api/v1/foo/get"
+        query_string = {
+            "value": "bar",
+        }
+        response = self.client.get(uri, query_string=query_string)
+        assert_that(response.status_code, is_(equal_to(200)))
+        assert_that(loads(response.get_data()), is_(equal_to({
+            "result": True,
+            "value": "bar",
+        })))
+
+    def test_swagger(self):
+        """
+        Swagger definitions including this operation.
+
+        """
+        response = self.client.get("/api/v1/swagger")
+        assert_that(response.status_code, is_(equal_to(200)))
+        swagger = loads(response.get_data())
+        assert_that(swagger["paths"], is_(equal_to({
+            "/foo/get": {
+                "get": {
+                    "tags": ["foo"],
+                    "responses": {
+                        "default": {
+                            "description": "An error occcurred", "schema": {
+                                "$ref": "#/definitions/Error",
+                            }
+                        },
+                        "200": {
+                            "description": "My doc string",
+                            "schema": {
+                                "$ref": "#/definitions/QueryResult",
+                            }
+                        }
+                    },
+                    "parameters": [{
+                        "required": False,
+                        "in": "query",
+                        "type": "integer",
+                        "name": "limit",
+                        "format": "int32",
+                    }, {
+                        "required": False,
+                        "type": "string",
+                        "name": "value",
+                        "in": "query",
+                    }, {
+                        "required": False,
+                        "in": "query",
+                        "type": "integer",
+                        "name": "offset",
+                        "format": "int32",
+                    }],
+                    "operationId": "query",
+                }
+            }
+        })))


### PR DESCRIPTION
While microcosm aims for drive most operations from conventions, it has the plumbing to allow custom operations as well.

I've added two classes of operations and provided test cases that demonstrate how they (can) work:
 - Commands are verb-oriented, non-RESTful uses of POST
 - Queries are verb-oriented, non-RESTful uses of GET