### PR TITLE
Ensure that `sync-resources` looks at embedded links.

### DIFF
--- a/microcosm_flask/sync/pull.py
+++ b/microcosm_flask/sync/pull.py
@@ -77,7 +77,12 @@ def pull_json(args, base_url):
                 # pushing back state that cannot be persisted
                 exclude_first = False
                 continue
-            yield href, sort_links(resource)
+            sort_links(resource)
+            for relation, links in iter_links(resource):
+                if href not in seen and any(pattern.match(relation) for pattern in args.relation_patterns):
+                    seen.add(href)
+                    stack.append(href)
+            yield href, resource
 
         for relation, link in iter_links(data):
             href = link["href"]


### PR DESCRIPTION
Without this change, I was missing some links when starting from certain URIs.