### PR TITLE
Introduce a namespace abstraction to simplify endpoint registration.

### DIFF
--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -13,7 +13,7 @@ from microcosm_flask.conventions.encoding import (
     require_response_data,
 )
 from microcosm_flask.conventions.registry import qs, request, response
-from microcosm_flask.naming import collection_path_for, instance_path_for, name_for
+from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 from microcosm_flask.paging import Page, PaginatedList, make_paginated_list_schema
 
@@ -34,13 +34,12 @@ def _crud(operation):
 
 
 @_crud(Operation.Search)
-def register_search_endpoint(graph, obj, path_prefix, func, request_schema, response_schema):
+def register_search_endpoint(graph, ns, func, request_schema, response_schema):
     """
     Register a search endpoint.
 
     :param graph: the object graph
-    :param obj: the target resource or resource name
-    :param path_prefix: the routing path prefix
+    :param ns: the namespace
     :param func: a search function, which must:
       - accept kwargs for the query string (minimally for pagination)
       - return a tuple of (items, count) where count is the total number of items
@@ -49,9 +48,9 @@ def register_search_endpoint(graph, obj, path_prefix, func, request_schema, resp
     :param response_schema: a marshmallow schema to encode (a single) response item
     """
 
-    paginated_list_schema = make_paginated_list_schema(obj, response_schema)()
+    paginated_list_schema = make_paginated_list_schema(ns, response_schema)()
 
-    @graph.route(path_prefix + collection_path_for(obj), Operation.Search, obj)
+    @graph.route(ns.collection_path, Operation.Search, ns)
     @qs(request_schema)
     @response(paginated_list_schema)
     def search(**path_data):
@@ -60,20 +59,19 @@ def register_search_endpoint(graph, obj, path_prefix, func, request_schema, resp
         items, count = func(**merge_data(path_data, request_data))
         # TODO: use the schema for encoding
         return jsonify(
-            PaginatedList(obj, page, items, count, response_schema).to_dict()
+            PaginatedList(ns, page, items, count, response_schema).to_dict()
         )
 
-    search.__doc__ = "Search the collection of all {}".format(pluralize(name_for(obj)))
+    search.__doc__ = "Search the collection of all {}".format(pluralize(ns.subject_name))
 
 
 @_crud(Operation.Create)
-def register_create_endpoint(graph, obj, path_prefix, func, request_schema, response_schema):
+def register_create_endpoint(graph, ns, func, request_schema, response_schema):
     """
     Register a create endpoint.
 
     :param graph: the object graph
-    :param obj: the target resource or resource name
-    :param path_prefix: the routing path prefix
+    :param ns: the namespace
     :param func: a create function, which must:
       - accept kwargs for the request and path data
       - return a new item
@@ -81,7 +79,7 @@ def register_create_endpoint(graph, obj, path_prefix, func, request_schema, resp
     :param response_schema: a marshmallow schema to encode response data
 
     """
-    @graph.route(path_prefix + collection_path_for(obj), Operation.Create, obj)
+    @graph.route(ns.collection_path, Operation.Create, ns)
     @request(request_schema)
     @response(response_schema)
     def create(**path_data):
@@ -89,61 +87,58 @@ def register_create_endpoint(graph, obj, path_prefix, func, request_schema, resp
         response_data = func(**merge_data(path_data, request_data))
         return dump_response_data(response_schema, response_data, Operation.Create.value.default_code)
 
-    create.__doc__ = "Create a new {}".format(name_for(obj))
+    create.__doc__ = "Create a new {}".format(ns.subject_name)
 
 
 @_crud(Operation.Retrieve)
-def register_retrieve_endpoint(graph, obj, path_prefix, func, response_schema):
+def register_retrieve_endpoint(graph, ns, func, response_schema):
     """
     Register a retrieve endpoint.
 
     :param graph: the object graph
-    :param obj: the target resource or resource name
-    :param path_prefix: the routing path prefix
+    :param ns: the namespace
     :param func: a retrieve function, which must:
       - accept kwargs for path data
       - return an item or falsey
     :param response_schema: a marshmallow schema to encode response data
 
     """
-    @graph.route(path_prefix + instance_path_for(obj), Operation.Retrieve, obj)
+    @graph.route(ns.instance_path, Operation.Retrieve, ns)
     @response(response_schema)
     def retrieve(**path_data):
         response_data = require_response_data(func(**path_data))
         return dump_response_data(response_schema, response_data)
 
-    retrieve.__doc__ = "Retrieve a {} by id".format(name_for(obj))
+    retrieve.__doc__ = "Retrieve a {} by id".format(ns.subject_name)
 
 
 @_crud(Operation.Delete)
-def register_delete_endpoint(graph, obj, path_prefix, func):
+def register_delete_endpoint(graph, ns, func):
     """
     Register a delete endpoint.
 
     :param graph: the object graph
-    :param obj: the target resource or resource name
-    :param path_prefix: the routing path prefix
+    :param ns: the namespace
     :param func: a delete function, which must:
       - accept kwargs for path data
       - return truthy/falsey
 
     """
-    @graph.route(path_prefix + instance_path_for(obj), Operation.Delete, obj)
+    @graph.route(ns.instance_path, Operation.Delete, ns)
     def delete(**path_data):
         require_response_data(func(**path_data))
         return "", Operation.Delete.value.default_code
 
-    delete.__doc__ = "Delete a {} by id".format(name_for(obj))
+    delete.__doc__ = "Delete a {} by id".format(ns.subject_name)
 
 
 @_crud(Operation.Replace)
-def register_replace_endpoint(graph, obj, path_prefix, func, request_schema, response_schema):
+def register_replace_endpoint(graph, ns, func, request_schema, response_schema):
     """
     Register a replace endpoint.
 
     :param graph: the object graph
-    :param obj: the target resource or resource name
-    :param path_prefix: the routing path prefix
+    :param ns: the namespace
     :param func: a replace function, which must:
       - accept kwargs for the request and path data
       - return the replaced item
@@ -151,7 +146,7 @@ def register_replace_endpoint(graph, obj, path_prefix, func, request_schema, res
     :param response_schema: a marshmallow schema to encode response data
 
     """
-    @graph.route(path_prefix + instance_path_for(obj), Operation.Replace, obj)
+    @graph.route(ns.instance_path, Operation.Replace, ns)
     @request(request_schema)
     @response(response_schema)
     def replace(**path_data):
@@ -162,11 +157,11 @@ def register_replace_endpoint(graph, obj, path_prefix, func, request_schema, res
         response_data = require_response_data(func(**merge_data(path_data, request_data)))
         return dump_response_data(response_schema, response_data)
 
-    replace.__doc__ = "Create or update a {} by id".format(name_for(obj))
+    replace.__doc__ = "Create or update a {} by id".format(ns.subject_name)
 
 
 @_crud(Operation.Update)
-def register_update_endpoint(graph, obj, path_prefix, func, request_schema, response_schema):
+def register_update_endpoint(graph, ns, func, request_schema, response_schema):
     """
     Register an update endpoint.
 
@@ -180,7 +175,7 @@ def register_update_endpoint(graph, obj, path_prefix, func, request_schema, resp
     :param response_schema: a marshmallow schema to encode response data
 
     """
-    @graph.route(path_prefix + instance_path_for(obj), Operation.Update, obj)
+    @graph.route(ns.instance_path, Operation.Update, ns)
     @request(request_schema)
     @response(response_schema)
     def update(**path_data):
@@ -189,10 +184,10 @@ def register_update_endpoint(graph, obj, path_prefix, func, request_schema, resp
         response_data = require_response_data(func(**merge_data(path_data, request_data)))
         return dump_response_data(response_schema, response_data)
 
-    update.__doc__ = "Update some or all of a {} by id".format(name_for(obj))
+    update.__doc__ = "Update some or all of a {} by id".format(ns.subject_name)
 
 
-def configure_crud(graph, obj, mappings, path_prefix=""):
+def configure_crud(graph, ns, mappings, path_prefix=""):
     """
     Register CRUD endpoints for a resource object.
 
@@ -209,6 +204,7 @@ def configure_crud(graph, obj, mappings, path_prefix=""):
         }
 
     """
+    ns = Namespace.make(ns, path=path_prefix)
     for operation, register in CRUD_MAPPINGS.items():
         if operation in mappings:
-            register(graph, obj, path_prefix, *mappings[operation])
+            register(graph, ns, *mappings[operation])

--- a/microcosm_flask/conventions/discovery.py
+++ b/microcosm_flask/conventions/discovery.py
@@ -6,9 +6,9 @@ from flask import jsonify
 
 from microcosm.api import defaults
 from microcosm_flask.conventions.encoding import load_query_string_data
-from microcosm_flask.conventions.registry import iter_operations
+from microcosm_flask.conventions.registry import iter_endpoints
 from microcosm_flask.linking import Link, Links
-from microcosm_flask.naming import name_for, singleton_path_for
+from microcosm_flask.namespaces import Namespace
 from microcosm_flask.paging import Page, PageSchema
 from microcosm_flask.operations import Operation
 
@@ -18,41 +18,40 @@ def iter_links(operations, page):
     Generate links for an iterable of operations on a starting page.
 
     """
-    for operation, obj, rule, func in operations:
+    for operation, ns, rule, func in operations:
         yield Link.for_(
             operation=operation,
-            obj=obj,
-            type=name_for(obj),
+            ns=ns,
+            type=ns.subject_name,
             qs=page.to_tuples(),
         )
 
 
-def register_discovery_endpoint(graph, name, match_func, path_prefix=""):
+def register_discovery_endpoint(graph, ns, match_func):
     """
     Register a discovery endpoint for a set of operations.
 
     """
     page_schema = PageSchema()
 
-    @graph.route(path_prefix + singleton_path_for(name), Operation.Discover, name)
+    @graph.route(ns.singleton_path, Operation.Discover, ns)
     def discover():
         # accept pagination limit from request
         page = Page.from_query_string(load_query_string_data(page_schema))
         page.offset = 0
 
-        operations = list(iter_operations(graph, match_func))
+        operations = list(iter_endpoints(graph, match_func))
 
         return jsonify(
             _links=Links({
-                "self": Link.for_(Operation.Discover, name, qs=page.to_tuples()),
+                "self": Link.for_(Operation.Discover, ns, qs=page.to_tuples()),
                 "search": [
                     link for link in iter_links(operations, page)
-
                 ],
             }).to_dict()
         )
 
-    return name
+    return ns.subject
 
 
 @defaults(
@@ -67,15 +66,17 @@ def configure_discovery(graph):
     Build a singleton endpoint that provides a link to all search endpoints.
 
     """
-    name = graph.config.discovery_convention.name
-    path_prefix = graph.config.discovery_convention.path_prefix
+    ns = Namespace(
+        path=graph.config.discovery_convention.path_prefix,
+        subject=graph.config.discovery_convention.name,
+    )
 
-    matches = {
-        Operation.from_name(operation_name.lower())
+    matching_operations = {
+        Operation.from_name(operation_name)
         for operation_name in graph.config.discovery_convention.operations
     }
 
-    def match_func(operation, obj, rule):
-        return operation in matches
+    def match_func(operation, ns, rule):
+        return operation in matching_operations
 
-    return register_discovery_endpoint(graph, name, match_func, path_prefix)
+    return register_discovery_endpoint(graph, ns, match_func)

--- a/microcosm_flask/conventions/health.py
+++ b/microcosm_flask/conventions/health.py
@@ -9,7 +9,7 @@ from flask import jsonify
 
 from microcosm.api import defaults
 from microcosm_flask.errors import extract_error_message
-from microcosm_flask.naming import singleton_path_for
+from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 
 
@@ -86,10 +86,14 @@ def configure_health(graph):
     :returns: a handle to the `Health` object, allowing other components to
               manipulate health state.
     """
-
     health = Health(graph)
 
-    @graph.route(graph.config.health_convention.path_prefix + singleton_path_for(Health), Operation.Retrieve, Health)
+    ns = Namespace(
+        path=graph.config.health_convention.path_prefix,
+        subject=health,
+    )
+
+    @graph.route(ns.singleton_path, Operation.Retrieve, ns)
     def current_health():
         dct = health.to_dict()
         response = jsonify(dct)

--- a/microcosm_flask/conventions/relation.py
+++ b/microcosm_flask/conventions/relation.py
@@ -93,17 +93,12 @@ def register_search_relation_endpoint(graph, ns, func, request_schema, response_
     search.__doc__ = "Search for {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
 
 
-def configure_relation(graph, from_obj, to_obj, mappings, path_prefix=""):
+def configure_relation(graph, ns, mappings, path_prefix=""):
     """
     Register relation endpoint(s) between two resources.
 
     """
-    ns = Namespace(
-        path=path_prefix,
-        subject=from_obj,
-        object_=to_obj,
-    )
-
+    ns = Namespace.make(ns, path=path_prefix)
     for operation, register in RELATION_MAPPINGS.items():
         if operation in mappings:
             register(graph, ns, *mappings[operation])

--- a/microcosm_flask/conventions/relation.py
+++ b/microcosm_flask/conventions/relation.py
@@ -1,8 +1,8 @@
 """
 Conventions for canonical relation endpoints (mapping one resource to another).
 
-For relations, operation definitions require *two* objects instead of one; for
-simplicity these are passed as a pair/tuple.
+For relations, endpoint definitions require that the `Namespace` contain *both*
+a subject and an object.
 
 """
 from flask import jsonify
@@ -15,7 +15,7 @@ from microcosm_flask.conventions.encoding import (
     merge_data,
 )
 from microcosm_flask.conventions.registry import qs, request, response
-from microcosm_flask.naming import name_for, relation_path_for
+from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 from microcosm_flask.paging import Page, PaginatedList, make_paginated_list_schema
 
@@ -36,12 +36,12 @@ def _relation(operation):
 
 
 @_relation(Operation.CreateFor)
-def register_createfor_relation_endpoint(graph, obj, path_prefix, func, request_schema, response_schema):
+def register_createfor_relation_endpoint(graph, ns, func, request_schema, response_schema):
     """
     Register a create-for relation endpoint.
 
     :param graph: the object graph
-    :param obj: the target resource or resource name
+    :param ns: the namespace
     :param path_prefix: the routing path prefix
     :param func: a store create function, which must:
       - accept kwargs for the new instance creation parameters
@@ -49,7 +49,7 @@ def register_createfor_relation_endpoint(graph, obj, path_prefix, func, request_
     :param request_schema: a marshmallow schema to decode/validate instance creation parameters
     :param response_schema: a marshmallow schema to encode the created instance
     """
-    @graph.route(path_prefix + relation_path_for(*obj), Operation.CreateFor, obj)
+    @graph.route(ns.relation_path, Operation.CreateFor, ns)
     @request(request_schema)
     @response(response_schema)
     def create(**path_data):
@@ -57,17 +57,16 @@ def register_createfor_relation_endpoint(graph, obj, path_prefix, func, request_
         response_data = func(**merge_data(path_data, request_data))
         return dump_response_data(response_schema, response_data, Operation.CreateFor.value.default_code)
 
-    create.__doc__ = "Create a new {} relative to a {}".format(pluralize(name_for(obj[1])), name_for(obj[0]))
+    create.__doc__ = "Create a new {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
 
 
 @_relation(Operation.SearchFor)
-def register_search_relation_endpoint(graph, obj, path_prefix, func, request_schema, response_schema):
+def register_search_relation_endpoint(graph, ns, func, request_schema, response_schema):
     """
     Register a relation endpoint.
 
     :param graph: the object graph
-    :param obj: the target resource or resource name
-    :param path_prefix: the routing path prefix
+    :param ns: the namespace
     :param func: a search function, which must:
       - accept kwargs for the query string (minimally for pagination)
       - return a tuple of (items, count, context) where count is the total number of items
@@ -77,9 +76,9 @@ def register_search_relation_endpoint(graph, obj, path_prefix, func, request_sch
     :param response_schema: a marshmallow schema to encode (a single) response item
     """
 
-    paginated_list_schema = make_paginated_list_schema(obj[1], response_schema)()
+    paginated_list_schema = make_paginated_list_schema(ns.object_ns, response_schema)()
 
-    @graph.route(path_prefix + relation_path_for(*obj), Operation.SearchFor, obj)
+    @graph.route(ns.relation_path, Operation.SearchFor, ns)
     @qs(request_schema)
     @response(paginated_list_schema)
     def search(**path_data):
@@ -88,10 +87,10 @@ def register_search_relation_endpoint(graph, obj, path_prefix, func, request_sch
         items, count, context = func(**merge_data(path_data, request_data))
         # TODO: use the schema for encoding
         return jsonify(
-            PaginatedList(obj, page, items, count, response_schema, Operation.SearchFor, **context).to_dict()
+            PaginatedList(ns, page, items, count, response_schema, Operation.SearchFor, **context).to_dict()
         )
 
-    search.__doc__ = "Search for {} relative to a {}".format(pluralize(name_for(obj[1])), name_for(obj[0]))
+    search.__doc__ = "Search for {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
 
 
 def configure_relation(graph, from_obj, to_obj, mappings, path_prefix=""):
@@ -99,6 +98,12 @@ def configure_relation(graph, from_obj, to_obj, mappings, path_prefix=""):
     Register relation endpoint(s) between two resources.
 
     """
+    ns = Namespace(
+        path=path_prefix,
+        subject=from_obj,
+        object_=to_obj,
+    )
+
     for operation, register in RELATION_MAPPINGS.items():
         if operation in mappings:
-            register(graph, (from_obj, to_obj), path_prefix, *mappings[operation])
+            register(graph, ns, *mappings[operation])

--- a/microcosm_flask/namespaces.py
+++ b/microcosm_flask/namespaces.py
@@ -1,0 +1,154 @@
+"""
+Defines namespaces for operations that follow various API conventions.
+
+In conjunction with the `Operation` enum, defines a naming convention for HTTP endpoints,
+which in turn provides a discovery mechanism API routes.
+
+"""
+from urllib import urlencode
+from urlparse import urljoin
+
+from flask import request, url_for
+
+from microcosm_flask.naming import (
+    collection_path_for,
+    instance_path_for,
+    name_for,
+    relation_path_for,
+    singleton_path_for,
+)
+from microcosm_flask.operations import Operation
+
+
+class Namespace(object):
+    """
+    Encapsulates the namespace for one or more operations.
+
+    Each fully qualified operation can be viewed as a subject, verb, and optional object.
+
+    The `Operation` enum defines the legal verbs (according to various conventions); this
+    object encapsulates the rest.
+
+    """
+
+    def __init__(self, subject, object_=None, path="", version=None):
+        self.subject = subject
+        self.object_ = object_
+        self.path = path
+        self.version = version
+
+    @property
+    def object_ns(self):
+        """
+        Create a new namespace for the current namespace's object value.
+
+        """
+        return Namespace(
+            path=self.path,
+            subject=self.object_,
+            object_=None,
+            version=self.version,
+        )
+
+    @property
+    def subject_name(self):
+        return name_for(self.subject)
+
+    @property
+    def object_name(self):
+        return name_for(self.object_)
+
+    @property
+    def collection_path(self):
+        return self.path + collection_path_for(self.subject)
+
+    @property
+    def instance_path(self):
+        return self.path + instance_path_for(self.subject)
+
+    @property
+    def relation_path(self):
+        return self.path + relation_path_for(self.subject, self.object_)
+
+    @property
+    def singleton_path(self):
+        return self.path + singleton_path_for(self.subject)
+
+    def endpoint_for(self, operation):
+        """
+        Create a (unique) endpoint name from an operation and a namespace.
+
+        This naming convention matches how Flask blueprints routes are resolved
+        (assuming that the blueprint and resources share the same name).
+
+        Examples: `foo.search`, `bar.search_for.baz`
+
+        """
+        if self.object_ is not None:
+            return operation.value.pattern.format(
+                self.subject_name,
+                operation.value.name,
+                self.object_name,
+            )
+        else:
+            return operation.value.pattern.format(
+                self.subject_name,
+                operation.value.name,
+            )
+
+    @staticmethod
+    def parse_endpoint(name):
+        """
+        Convert an endpoint name into an (operation, ns) tuple.
+
+        """
+        parts = name.split(".")
+        operation = Operation.from_name(parts[1])
+        if len(parts) > 2:
+            return operation, Namespace(subject=parts[0], object_=parts[2])
+        else:
+            return operation, Namespace(subject=parts[0])
+
+    def url_for(self, operation, **kwargs):
+        """
+        Construct a URL for an operation against a resource.
+
+        :param kwargs: additional arguments for URL path expansion
+
+        """
+        return url_for(self.endpoint_for(operation), **kwargs)
+
+    def href_for(self, operation, qs=None, **kwargs):
+        """
+        Construct an full href for an operation against a resource.
+
+        :parm qs: the query string dictionary, if any
+        :param kwargs: additional arguments for path expansion
+        """
+        return "{}{}".format(
+            urljoin(request.url_root, self.url_for(operation, **kwargs)),
+            "?{}".format(urlencode(qs)) if qs else "",
+        )
+
+    @classmethod
+    def make(cls, value, path=None):
+        """
+        Create a Namespace from a value.
+
+        Used to transition older APIs that relied on strings/objects/tuples/lists
+        to pass subject and object information instead of Namespace instances.
+
+        """
+        if isinstance(value, Namespace):
+            return value
+        elif isinstance(value, (tuple, list)):
+            return cls(
+                subject=value[0],
+                object_=value[1],
+                path=path,
+            )
+        else:
+            return cls(
+                subject=value,
+                path=path,
+            )

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -20,14 +20,14 @@ from microcosm.api import defaults
 )
 def configure_route_decorator(graph):
     """
-    Configure a flask route decorator that operations on `Operation` objects.
+    Configure a flask route decorator that operates on `Operation` and `Namespace` objects.
 
     By default, enables CORS support, assuming that service APIs are not exposed
     directly to browsers except when using API browsing tools.
 
     Usage:
 
-        @graph.route("/foo", Operation.Search, "foo")
+        @graph.route(ns.collection_path, Operation.Search, ns)
         def search_foo():
             pass
 
@@ -35,7 +35,12 @@ def configure_route_decorator(graph):
     # routes depends on converters
     graph.use(*graph.config.route.converters)
 
-    def route(path, operation, obj):
+    def route(path, operation, ns):
+        """
+        :param path: a URI path, possibly derived from a property of the `ns`
+        :param operation: an `Operation` enum value
+        :param ns: a `Namespace` instance
+        """
 
         def decorator(func):
             if graph.config.route.enable_cors:
@@ -51,9 +56,7 @@ def configure_route_decorator(graph):
 
             graph.app.route(
                 graph.config.route.path_prefix + path,
-                # for blueprints, the endpoint is operation.value.name
-                # because Flask automatically prefixes blueprint endpoints with "obj."
-                endpoint=operation.name_for(obj),
+                endpoint=ns.endpoint_for(operation),
                 methods=[operation.value.method],
             )(func)
             return func

--- a/microcosm_flask/swagger/naming.py
+++ b/microcosm_flask/swagger/naming.py
@@ -7,10 +7,8 @@ Intended to play nice with generated code (e.g. with Bravado)
 
 from inflection import camelize, pluralize
 
-from microcosm_flask.naming import name_for
 
-
-def operation_name(operation, obj):
+def operation_name(operation, ns):
     """
     Convert an operation, obj(s) pair into a swagger operation id.
 
@@ -21,11 +19,11 @@ def operation_name(operation, obj):
         foo.search_for.bar => client.foo.search_for_bars()
 
     """
-    if isinstance(obj, (list, tuple)):
-        verb, rest = operation.value.name, obj[1:]
+    verb = operation.value.name
+    if ns.object_:
+        return "{}_{}".format(verb, pluralize(ns.object_name))
     else:
-        verb, rest = operation.value.name, []
-    return "_".join([verb] + [pluralize(name_for(noun)) for noun in rest])
+        return verb
 
 
 def type_name(name):

--- a/microcosm_flask/tests/conventions/test_discovery.py
+++ b/microcosm_flask/tests/conventions/test_discovery.py
@@ -11,6 +11,7 @@ from hamcrest import (
 )
 
 from microcosm.api import create_object_graph
+from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 
 
@@ -18,7 +19,9 @@ def test_discovery():
     graph = create_object_graph(name="example", testing=True)
     graph.use("discovery_convention")
 
-    @graph.route("/path", Operation.Search, "foo")
+    ns = Namespace("foo")
+
+    @graph.route(ns.collection_path, Operation.Search, ns)
     def search_foo():
         pass
 
@@ -30,7 +33,7 @@ def test_discovery():
     assert_that(data, is_(equal_to({
         "_links": {
             "search": [{
-                "href": "http://localhost/api/path?offset=0&limit=20",
+                "href": "http://localhost/api/foo?offset=0&limit=20",
                 "type": "foo",
             }],
             "self": {

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -11,7 +11,8 @@ from hamcrest import (
 from microcosm.api import create_object_graph
 from microcosm_flask.conventions.crud import configure_crud
 from microcosm_flask.operations import Operation
-from microcosm_flask.conventions.registry import iter_operations
+from microcosm_flask.conventions.registry import iter_endpoints
+from microcosm_flask.namespaces import Namespace
 from microcosm_flask.swagger.definitions import build_swagger
 from microcosm_flask.tests.conventions.fixtures import (
     NewPersonSchema,
@@ -28,17 +29,20 @@ PERSON_MAPPINGS = {
 
 def test_build_swagger():
     graph = create_object_graph(name="example", testing=True)
-    version = "v1"
-    path_prefix = "/{}".format(version)
-    configure_crud(graph, Person, PERSON_MAPPINGS, path_prefix=path_prefix)
+    ns = Namespace(
+        path="/v1",
+        subject=Person,
+        version="v1",
+    )
+    configure_crud(graph, ns.subject, PERSON_MAPPINGS, ns.path)
 
     # match all (of the one) operations
     def match_function(operation, obj, rule):
         return True
 
     with graph.flask.test_request_context():
-        operations = list(iter_operations(graph, match_function))
-        swagger_schema = build_swagger(graph, version, path_prefix, operations)
+        operations = list(iter_endpoints(graph, match_function))
+        swagger_schema = build_swagger(graph, ns.version, ns.path, operations)
 
     assert_that(swagger_schema, is_(equal_to({
         "info": {

--- a/microcosm_flask/tests/swagger/test_naming.py
+++ b/microcosm_flask/tests/swagger/test_naming.py
@@ -8,17 +8,20 @@ from hamcrest import (
     is_,
 )
 
+from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 from microcosm_flask.swagger.naming import operation_name, type_name
 
 
 def test_operation_name_retrieve():
-    name = operation_name(Operation.Retrieve, "foo")
+    ns = Namespace(subject="foo")
+    name = operation_name(Operation.Retrieve, ns)
     assert_that(name, is_(equal_to("retrieve")))
 
 
 def test_operation_name_search_for():
-    name = operation_name(Operation.SearchFor, ("foo", "bar"))
+    ns = Namespace(subject="foo", object_="bar")
+    name = operation_name(Operation.SearchFor, ns)
     assert_that(name, is_(equal_to("search_for_bars")))
 
 

--- a/microcosm_flask/tests/test_linking.py
+++ b/microcosm_flask/tests/test_linking.py
@@ -10,7 +10,7 @@ from hamcrest import (
 
 from microcosm.api import create_object_graph
 from microcosm_flask.linking import Link, Links
-from microcosm_flask.naming import collection_path_for, instance_path_for
+from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 
 
@@ -47,8 +47,22 @@ def test_templated_link_to_dict():
 
 def test_link_for_operation():
     graph = create_object_graph(name="example", testing=True)
+    ns = Namespace("foo")
 
-    @graph.route(collection_path_for("foo"), Operation.Search, "foo")
+    @graph.route(ns.collection_path, Operation.Search, ns)
+    def func():
+        pass
+
+    with graph.app.test_request_context():
+        link = Link.for_(Operation.Search, ns)
+        assert_that(link.href, is_(equal_to("http://localhost/api/foo")))
+
+
+def test_link_for_operation_without_namespace():
+    graph = create_object_graph(name="example", testing=True)
+    ns = Namespace("foo")
+
+    @graph.route(ns.collection_path, Operation.Search, ns)
     def func():
         pass
 
@@ -59,25 +73,27 @@ def test_link_for_operation():
 
 def test_link_for_operation_with_query_string():
     graph = create_object_graph(name="example", testing=True)
+    ns = Namespace("foo")
 
-    @graph.route(collection_path_for("foo"), Operation.Search, "foo")
+    @graph.route(ns.collection_path, Operation.Search, ns)
     def func():
         pass
 
     with graph.app.test_request_context():
-        link = Link.for_(Operation.Search, "foo", qs=dict(bar="baz"))
+        link = Link.for_(Operation.Search, ns, qs=dict(bar="baz"))
         assert_that(link.href, is_(equal_to("http://localhost/api/foo?bar=baz")))
 
 
 def test_link_for_operation_templated():
     graph = create_object_graph(name="example", testing=True)
+    ns = Namespace("foo")
 
-    @graph.route(instance_path_for("foo"), Operation.Retrieve, "foo")
+    @graph.route(ns.instance_path, Operation.Retrieve, ns)
     def func():
         pass
 
     with graph.app.test_request_context():
-        link = Link.for_(Operation.Retrieve, "foo", allow_templates=True)
+        link = Link.for_(Operation.Retrieve, ns, allow_templates=True)
         assert_that(link.href, is_(equal_to("http://localhost/api/foo/{}".format("{foo_id}"))))
 
 

--- a/microcosm_flask/tests/test_namespaces.py
+++ b/microcosm_flask/tests/test_namespaces.py
@@ -1,0 +1,90 @@
+"""
+Namespace tests.
+
+"""
+from hamcrest import (
+    assert_that,
+    equal_to,
+    is_,
+    none,
+)
+
+from microcosm.api import create_object_graph
+from microcosm_flask.namespaces import Namespace
+from microcosm_flask.operations import Operation
+
+
+def test_endpoint_for():
+    """
+    Simple (subject-only) endpoint naming works.
+
+    """
+    ns = Namespace(subject="foo")
+    endpoint = ns.endpoint_for(Operation.Search)
+    assert_that(endpoint, is_(equal_to("foo.search")))
+
+
+def test_operation_naming_relation():
+    """
+    Complext (subject+object) endpoint naming works.
+
+    """
+    ns = Namespace(subject="foo", object_="bar")
+    endpoint = ns.endpoint_for(Operation.SearchFor)
+    assert_that(endpoint, is_(equal_to("foo.search_for.bar")))
+
+
+def test_parse_endpoint():
+    """
+    Simple (subject-only) endpoints can be parsed.
+
+    """
+    operation, ns = Namespace.parse_endpoint("foo.search")
+    assert_that(operation, is_(equal_to(Operation.Search)))
+    assert_that(ns.subject, is_(equal_to("foo")))
+    assert_that(ns.object_, is_(none()))
+
+
+def test_parse_endpoint_relation():
+    """
+    Complex (subject+object) endpoints can be parsed.
+
+    """
+    operation, ns = Namespace.parse_endpoint("foo.search_for.bar")
+    assert_that(operation, is_(equal_to(Operation.SearchFor)))
+    assert_that(ns.subject, is_(equal_to("foo")))
+    assert_that(ns.object_, is_(equal_to("bar")))
+
+
+def test_operation_url_for():
+    """
+    Operations can resolve themselves via Flask's `url_for`.
+
+    """
+    graph = create_object_graph(name="example", testing=True)
+    ns = Namespace(subject="foo")
+
+    @graph.route(ns.collection_path, Operation.Search, ns)
+    def search_foo():
+        pass
+
+    with graph.app.test_request_context():
+        url = ns.url_for(Operation.Search)
+        assert_that(url, is_(equal_to("/api/foo")))
+
+
+def test_operation_href_for():
+    """
+    Operations can resolve themselves as fully expanded hrefs.
+
+    """
+    graph = create_object_graph(name="example", testing=True)
+    ns = Namespace(subject="foo")
+
+    @graph.route(ns.collection_path, Operation.Search, ns)
+    def search_foo():
+        pass
+
+    with graph.app.test_request_context():
+        url = ns.href_for(Operation.Search)
+        assert_that(url, is_(equal_to("http://localhost/api/foo")))

--- a/microcosm_flask/tests/test_operations.py
+++ b/microcosm_flask/tests/test_operations.py
@@ -8,56 +8,13 @@ from hamcrest import (
     is_,
 )
 
-from microcosm.api import create_object_graph
-from microcosm_flask.naming import collection_path_for
 from microcosm_flask.operations import Operation
 
 
-def test_operation_naming():
+def test_from_name():
     """
-    Operation naming works.
-
-    """
-    operation_name = Operation.Search.name_for("foo")
-    assert_that(operation_name, is_(equal_to("foo.search")))
-
-
-def test_operation_naming_relation():
-    """
-    Operation naming works for relations.
+    Operations can be looked up by name.
 
     """
-    operation_name = Operation.SearchFor.name_for(("foo", "bar"))
-    assert_that(operation_name, is_(equal_to("foo.search_for.bar")))
-
-
-def test_operation_url_for():
-    """
-    Operations can resolve themselves via Flask's `url_for`.
-
-    """
-    graph = create_object_graph(name="example", testing=True)
-
-    @graph.route(collection_path_for("foo"), Operation.Search, "foo")
-    def search_foo():
-        pass
-
-    with graph.app.test_request_context():
-        url = Operation.Search.url_for("foo")
-        assert_that(url, is_(equal_to("/api/foo")))
-
-
-def test_operation_href_for():
-    """
-    Operations can resolve themselves as fully expanded hrefs.
-
-    """
-    graph = create_object_graph(name="example", testing=True)
-
-    @graph.route(collection_path_for("foo"), Operation.Search, "foo")
-    def search_foo():
-        pass
-
-    with graph.app.test_request_context():
-        url = Operation.Search.href_for("foo")
-        assert_that(url, is_(equal_to("http://localhost/api/foo")))
+    assert_that(Operation.from_name("search"), is_(equal_to(Operation.Search)))
+    assert_that(Operation.from_name("Create"), is_(equal_to(Operation.Create)))

--- a/microcosm_flask/tests/test_paging.py
+++ b/microcosm_flask/tests/test_paging.py
@@ -10,6 +10,7 @@ from hamcrest import (
 
 from microcosm.api import create_object_graph
 from microcosm_flask.conventions.encoding import load_query_string_data
+from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 from microcosm_flask.paging import Page, PageSchema, PaginatedList
 
@@ -46,12 +47,13 @@ def test_page_prev():
 
 def test_paginated_list_to_dict():
     graph = create_object_graph(name="example", testing=True)
+    ns = Namespace(subject="foo")
 
-    @graph.route("/foo", Operation.Search, "foo")
+    @graph.route(ns.collection_path, Operation.Search, ns)
     def search_foo():
         pass
 
-    paginated_list = PaginatedList("foo", Page(2, 2), ["1", "2"], 10)
+    paginated_list = PaginatedList(ns, Page(2, 2), ["1", "2"], 10)
 
     with graph.flask.test_request_context():
         assert_that(paginated_list.to_dict(), is_(equal_to({
@@ -78,13 +80,14 @@ def test_paginated_list_to_dict():
 
 def test_paginated_list_relation_to_dict():
     graph = create_object_graph(name="example", testing=True)
+    ns = Namespace(subject="foo", object_="bar")
 
-    @graph.route("/foo/<foo_id>/bar", Operation.SearchFor, ("foo", "bar"))
+    @graph.route(ns.relation_path, Operation.SearchFor, ns)
     def search_foo():
         pass
 
     paginated_list = PaginatedList(
-        ("foo", "bar"),
+        ns,
         Page(2, 2),
         ["1", "2"],
         10,


### PR DESCRIPTION
Earlier versions of this library put a lot of responsiblity into the Operation enum
to define naming conventions. Since the naming depends heavily on the context of the
resources being operated on, the Operation functions had some fairly complex argumentation.

In the new approach, these functions move to a Namespace class, which has concrete
instance variables to make the naming evaluation simpler. As much as possible, convention
creation functions now accept Namespace instances, though not yet everywhere because of
backward compatibility concerns.