### PR TITLE
Add a timestamp field.

### DIFF
--- a/microcosm_flask/fields.py
+++ b/microcosm_flask/fields.py
@@ -2,7 +2,10 @@
 Custom fields.
 
 """
-from marshmallow.fields import Field
+from datetime import datetime
+
+from dateutil import parser
+from marshmallow.fields import Field, ValidationError
 
 
 class EnumField(Field):
@@ -46,3 +49,48 @@ class EnumField(Field):
             return getattr(self.enum, value)
         except AttributeError:
             self.fail('by_name', name=value)
+
+
+class TimestampField(Field):
+    """
+    Timestamp valued field, as either a unix timestamp (default) or isoformat string.
+
+    """
+    EPOCH = datetime(1970, 1, 1)
+
+    def __init__(self, use_isoformat=False, *args, **kwargs):
+        self.use_isoformat = use_isoformat
+        super(TimestampField, self).__init__(*args, **kwargs)
+
+    def _serialize(self, value, attr, obj):
+        """
+        Serialize value as a timestamp, either as a Unix timestamp (in float second) or a UTC isoformat string.
+
+        """
+        if value is None:
+            return None
+
+        if self.use_isoformat:
+            return datetime.utcfromtimestamp(value).isoformat()
+        else:
+            return value
+
+    def _deserialize(self, value, attr, obj):
+        """
+        Deserialize value as a Unix timestamp (in float seconds).
+
+        Handle both numeric and UTC isoformat strings.
+
+        """
+        if value is None:
+            return None
+
+        try:
+            return float(value)
+        except ValueError:
+            parsed = parser.parse(value)
+            if parsed.tzinfo:
+                if parsed.utcoffset().total_seconds():
+                    raise ValidationError("Timestamps must be defined in UTC")
+                parsed = parsed.replace(tzinfo=None)
+            return (parsed - TimestampField.EPOCH).total_seconds()

--- a/microcosm_flask/tests/test_fields.py
+++ b/microcosm_flask/tests/test_fields.py
@@ -1,0 +1,131 @@
+"""
+Test fields.
+
+"""
+from hamcrest import (
+    assert_that,
+    contains,
+    equal_to,
+    is_,
+)
+from marshmallow import Schema
+
+from microcosm_flask.fields import TimestampField
+
+
+TIMESTAMP = 1427702400.0
+TIMESTAMP_EXTRA_PRECISION = 1427702400.1
+ISOFORMAT_NAIVE = "2015-03-30T08:00:00"
+ISOFORMAT_NAIVE_EXTRA_PRECISION = "2015-03-30T08:00:00.100000"
+ISOFORMAT_NON_UTC = "2015-03-30T08:00:00+7:00"
+ISOFORMAT_UTC = "2015-03-30T08:00:00Z"
+
+
+class TimestampSchema(Schema):
+    unix = TimestampField()
+    iso = TimestampField(use_isoformat=True)
+
+
+def test_load_from_unix_timestamp_float():
+    """
+    Can deserialize float seconds.
+
+    """
+    schema = TimestampSchema()
+    result = schema.load({
+        "unix": TIMESTAMP,
+        "iso": TIMESTAMP,
+    })
+
+    assert_that(result.data["unix"], is_(equal_to(TIMESTAMP)))
+    assert_that(result.data["iso"], is_(equal_to(TIMESTAMP)))
+
+
+def test_load_from_unix_timestamp_int():
+    """
+    Can deserialize int seconds.
+
+    """
+    schema = TimestampSchema()
+    result = schema.load({
+        "unix": int(TIMESTAMP),
+        "iso": int(TIMESTAMP),
+    })
+
+    assert_that(result.data["unix"], is_(equal_to(int(TIMESTAMP))))
+    assert_that(result.data["iso"], is_(equal_to(int(TIMESTAMP))))
+
+
+def test_load_from_naive_isoformat():
+    """
+    Can deserialize naive isoformat.
+
+    """
+    schema = TimestampSchema()
+    result = schema.load({
+        "unix": ISOFORMAT_NAIVE,
+        "iso": ISOFORMAT_NAIVE,
+    })
+
+    assert_that(result.data["unix"], is_(equal_to(TIMESTAMP)))
+    assert_that(result.data["iso"], is_(equal_to(TIMESTAMP)))
+
+
+def test_load_from_naive_isoformat_extra_precision():
+    """
+    Can deserialize naive isoformat with sub-second precision.
+
+    """
+    schema = TimestampSchema()
+    result = schema.load({
+        "unix": ISOFORMAT_NAIVE_EXTRA_PRECISION,
+        "iso": ISOFORMAT_NAIVE_EXTRA_PRECISION,
+    })
+
+    assert_that(result.data["unix"], is_(equal_to(TIMESTAMP_EXTRA_PRECISION)))
+    assert_that(result.data["iso"], is_(equal_to(TIMESTAMP_EXTRA_PRECISION)))
+
+
+def test_load_from_utc_isoformat():
+    """
+    Can deserialize naive isoformat.
+
+    """
+    schema = TimestampSchema()
+    result = schema.load({
+        "unix": ISOFORMAT_UTC,
+        "iso": ISOFORMAT_UTC,
+    })
+
+    assert_that(result.data["unix"], is_(equal_to(TIMESTAMP)))
+    assert_that(result.data["iso"], is_(equal_to(TIMESTAMP)))
+
+
+def test_load_from_non_utc_isoformat():
+    """
+    Can deserialize naive isoformat.
+
+    """
+    schema = TimestampSchema()
+    result = schema.load({
+        "unix": ISOFORMAT_NON_UTC,
+        "iso": ISOFORMAT_NON_UTC,
+    })
+
+    assert_that(result.errors["unix"], contains("Timestamps must be defined in UTC"))
+    assert_that(result.errors["iso"], contains("Timestamps must be defined in UTC"))
+
+
+def test_dump():
+    """
+    Can serialize to appropriate type.
+
+    """
+    schema = TimestampSchema()
+    result = schema.dump({
+        "unix": TIMESTAMP,
+        "iso": TIMESTAMP,
+    })
+
+    assert_that(result.data["unix"], is_(equal_to(TIMESTAMP)))
+    assert_that(result.data["iso"], is_(equal_to(ISOFORMAT_NAIVE)))

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         "microcosm-logging>=0.2.0",
         "openapi>=0.2.0",
         "python-dateutil>=2.5.2",
-        "pytz>=2016.3",
         "PyYAML>=3.11",
     ],
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setup(
         "microcosm>=0.5.1",
         "microcosm-logging>=0.2.0",
         "openapi>=0.2.0",
+        "python-dateutil>=2.5.2",
+        "pytz>=2016.3",
         "PyYAML>=3.11",
     ],
     setup_requires=[


### PR DESCRIPTION
Decodes isoformat and numeric timestamps; encodes one or the other based on config.