### PR TITLE
Refactor conventions to use a common model (base class + data object)

### DIFF
--- a/microcosm_flask/conventions/base.py
+++ b/microcosm_flask/conventions/base.py
@@ -1,0 +1,99 @@
+"""
+Convention base class.
+
+"""
+from microcosm_flask.operations import Operation
+
+
+class EndpointDefinition(tuple):
+    """
+    A definition for an endpoint.
+
+    """
+    @classmethod
+    def make(cls, func=None, request_schema=None, response_schema=None):
+        """
+        :param func: a function to process request data and return response data
+        :param request_schema: a marshmallow schema to decode/validate request data
+        :param response_schema: a marshmallow schema to encode response data
+        """
+        return cls((func, request_schema, response_schema))
+
+    @property
+    def func(self):
+        return self[0]
+
+    @property
+    def request_schema(self):
+        return self[1]
+
+    @property
+    def response_schema(self):
+        return self[2]
+
+
+class Convention(object):
+    """
+    A convention is a recipe for applying Flask-compatible functions to a namespace.
+
+    """
+    def __init__(self, graph):
+        self.graph = graph
+
+    def configure(self, ns, mappings=None, **kwargs):
+        """
+        Apply mappings to a namespace.
+
+        """
+        if mappings is None:
+            mappings = dict()
+        mappings.update(kwargs)
+
+        for operation, definition in mappings.items():
+
+            try:
+                configure_func = self._find_func(operation)
+                configure_func(ns, self._make_definition(definition))
+            except AttributeError:
+                pass
+
+    def _find_func(self, operation):
+        """
+        Find the function to use to configure the given operation.
+
+        The input might be an `Operation` enum or a string.
+
+        """
+        if isinstance(operation, Operation):
+            operation_name = operation.name.lower()
+        else:
+            operation_name = operation.lower()
+
+        return getattr(self, "configure_{}".format(operation_name))
+
+    def _make_definition(self, definition):
+        """
+        Generate a definition.
+
+        The input might already be a `EndpointDefinition` or it might be a tuple.
+
+        """
+        if not definition:
+            return EndpointDefinition.make()
+        if isinstance(definition, EndpointDefinition):
+            return definition
+        elif len(definition) == 1:
+            return EndpointDefinition.make(
+                func=definition[0],
+            )
+        elif len(definition) == 2:
+            return EndpointDefinition.make(
+                func=definition[0],
+                response_schema=definition[1],
+            )
+        elif len(definition) == 3:
+            return EndpointDefinition.make(
+                func=definition[0],
+                request_schema=definition[1],
+                response_schema=definition[2],
+            )

--- a/microcosm_flask/conventions/relation.py
+++ b/microcosm_flask/conventions/relation.py
@@ -8,6 +8,7 @@ a subject and an object.
 from flask import jsonify
 from inflection import pluralize
 
+from microcosm_flask.conventions.base import Convention
 from microcosm_flask.conventions.encoding import (
     dump_response_data,
     load_query_string_data,
@@ -20,77 +21,69 @@ from microcosm_flask.operations import Operation
 from microcosm_flask.paging import Page, PaginatedList, make_paginated_list_schema
 
 
-# local registry of relation mappings
-RELATION_MAPPINGS = {}
+class RelationConvention(Convention):
 
+    def configure_createfor(self, ns, definition):
+        """
+        Register a create-for relation endpoint.
 
-def _relation(operation):
-    """
-    Register a "register_<foo>_relation_endpoint" function with an operation.
+        The definition's func should be a create function, which must:
+        - accept kwargs for the new instance creation parameters
+        - return the created instance
 
-    """
-    def decorator(func):
-        RELATION_MAPPINGS[operation] = func
-        return func
-    return decorator
+        :param ns: the namespace
+        :param definition: the endpoint definition
 
+        """
+        @self.graph.route(ns.relation_path, Operation.CreateFor, ns)
+        @request(definition.request_schema)
+        @response(definition.response_schema)
+        def create(**path_data):
+            request_data = load_request_data(definition.request_schema)
+            response_data = definition.func(**merge_data(path_data, request_data))
+            return dump_response_data(definition.response_schema, response_data, Operation.CreateFor.value.default_code)
 
-@_relation(Operation.CreateFor)
-def register_createfor_relation_endpoint(graph, ns, func, request_schema, response_schema):
-    """
-    Register a create-for relation endpoint.
+        create.__doc__ = "Create a new {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
 
-    :param graph: the object graph
-    :param ns: the namespace
-    :param path_prefix: the routing path prefix
-    :param func: a store create function, which must:
-      - accept kwargs for the new instance creation parameters
-      - return the created instance
-    :param request_schema: a marshmallow schema to decode/validate instance creation parameters
-    :param response_schema: a marshmallow schema to encode the created instance
-    """
-    @graph.route(ns.relation_path, Operation.CreateFor, ns)
-    @request(request_schema)
-    @response(response_schema)
-    def create(**path_data):
-        request_data = load_request_data(request_schema)
-        response_data = func(**merge_data(path_data, request_data))
-        return dump_response_data(response_schema, response_data, Operation.CreateFor.value.default_code)
+    def configure_searchfor(self, ns, definition):
+        """
+        Register a relation endpoint.
 
-    create.__doc__ = "Create a new {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
+        The definition's func should be a search function, which must:
+        - accept kwargs for the query string (minimally for pagination)
+        - return a tuple of (items, count, context) where count is the total number of items
+          available (in the case of pagination) and context is a dictionary providing any
+          needed context variables for constructing pagination links
 
+        The definition's request_schema will be used to process query string arguments.
 
-@_relation(Operation.SearchFor)
-def register_search_relation_endpoint(graph, ns, func, request_schema, response_schema):
-    """
-    Register a relation endpoint.
+        :param ns: the namespace
+        :param definition: the endpoint definition
 
-    :param graph: the object graph
-    :param ns: the namespace
-    :param func: a search function, which must:
-      - accept kwargs for the query string (minimally for pagination)
-      - return a tuple of (items, count, context) where count is the total number of items
-        available (in the case of pagination) and context is a dictionary providing any
-        needed context variables for constructing pagination links
-    :param request_schema: a marshmallow schema to decode/validate query string arguments
-    :param response_schema: a marshmallow schema to encode (a single) response item
-    """
+        """
+        paginated_list_schema = make_paginated_list_schema(ns.object_ns, definition.response_schema)()
 
-    paginated_list_schema = make_paginated_list_schema(ns.object_ns, response_schema)()
+        @self.graph.route(ns.relation_path, Operation.SearchFor, ns)
+        @qs(definition.request_schema)
+        @response(paginated_list_schema)
+        def search(**path_data):
+            request_data = load_query_string_data(definition.request_schema)
+            page = Page.from_query_string(request_data)
+            items, count, context = definition.func(**merge_data(path_data, request_data))
+            # TODO: use the schema for encoding
+            return jsonify(
+                PaginatedList(
+                    ns,
+                    page,
+                    items,
+                    count,
+                    definition.response_schema,
+                    Operation.SearchFor,
+                    **context
+                ).to_dict()
+            )
 
-    @graph.route(ns.relation_path, Operation.SearchFor, ns)
-    @qs(request_schema)
-    @response(paginated_list_schema)
-    def search(**path_data):
-        request_data = load_query_string_data(request_schema)
-        page = Page.from_query_string(request_data)
-        items, count, context = func(**merge_data(path_data, request_data))
-        # TODO: use the schema for encoding
-        return jsonify(
-            PaginatedList(ns, page, items, count, response_schema, Operation.SearchFor, **context).to_dict()
-        )
-
-    search.__doc__ = "Search for {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
+        search.__doc__ = "Search for {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
 
 
 def configure_relation(graph, ns, mappings, path_prefix=""):
@@ -99,6 +92,5 @@ def configure_relation(graph, ns, mappings, path_prefix=""):
 
     """
     ns = Namespace.make(ns, path=path_prefix)
-    for operation, register in RELATION_MAPPINGS.items():
-        if operation in mappings:
-            register(graph, ns, *mappings[operation])
+    convention = RelationConvention(graph)
+    convention.configure(ns, mappings)


### PR DESCRIPTION
Conventions are recipes for mapping some user data ("EndpointDefinitions") to operations attached at a specific namespace.

This is now explicit.

As a user, you do something like:

```
convention = CRUDConvention(graph)

mapping = {
    Operation.Create: (func, request_schema, response_schema),
}

convention.configure(ns, mapping)
```

For readability, it's also now possible to use a clearer structure for the mapping:

```
mapping = dict(
    create=EndpointDefinition.make(func, request_schema, response_schema),
)
```

Overall, this cleanup will make it easier to define behaviors that apply to all conventions. In particular, I want to extend the `Namespace` to support the idea of a low and high level path prefix and allow the same (or very similar) logic to be applied to each of these.
