### PR TITLE
Add tests for enum (de)serialization.

### DIFF
--- a/microcosm_flask/fields.py
+++ b/microcosm_flask/fields.py
@@ -42,6 +42,10 @@ class EnumField(Field):
         try:
             return self.enum(value)
         except ValueError:
+            try:
+                return self.enum(int(value))
+            except:
+                pass
             self.fail('by_value', value=value)
 
     def _deserialize_by_name(self, value, attr, data):

--- a/microcosm_flask/tests/test_fields.py
+++ b/microcosm_flask/tests/test_fields.py
@@ -2,6 +2,8 @@
 Test fields.
 
 """
+from enum import Enum, IntEnum, unique
+
 from hamcrest import (
     assert_that,
     contains,
@@ -10,7 +12,7 @@ from hamcrest import (
 )
 from marshmallow import Schema
 
-from microcosm_flask.fields import TimestampField
+from microcosm_flask.fields import EnumField, TimestampField
 
 
 TIMESTAMP = 1427702400.0
@@ -21,9 +23,79 @@ ISOFORMAT_NON_UTC = "2015-03-30T08:00:00+7:00"
 ISOFORMAT_UTC = "2015-03-30T08:00:00Z"
 
 
+@unique
+class TestEnum(Enum):
+    Foo = "foo"
+    Bar = "bar"
+
+
+@unique
+class TestIntEnum(IntEnum):
+    Foo = 1
+    Bar = 2
+
+
+class EnumSchema(Schema):
+    name = EnumField(TestEnum, by_value=False)
+    value = EnumField(TestEnum, by_value=True)
+    int_name = EnumField(TestIntEnum, by_value=False)
+    int_value = EnumField(TestIntEnum, by_value=True)
+
+
 class TimestampSchema(Schema):
     unix = TimestampField()
     iso = TimestampField(use_isoformat=True)
+
+
+def test_load_enums():
+    """
+    Can deserialize enums.
+
+    """
+    schema = EnumSchema()
+    result = schema.load({
+        "name": TestEnum.Foo.name,
+        "value": TestEnum.Bar.value,
+        "int_name": TestIntEnum.Foo.name,
+        "int_value": TestIntEnum.Bar.value,
+    })
+
+    assert_that(result.data["name"], is_(equal_to(TestEnum.Foo)))
+    assert_that(result.data["value"], is_(equal_to(TestEnum.Bar)))
+    assert_that(result.data["int_name"], is_(equal_to(TestIntEnum.Foo)))
+    assert_that(result.data["int_value"], is_(equal_to(TestIntEnum.Bar)))
+
+
+def test_dump_enums():
+    """
+    Can serialize enums.
+
+    """
+    schema = EnumSchema()
+    result = schema.dump({
+        "name": TestEnum.Foo,
+        "value": TestEnum.Bar,
+        "int_name": TestIntEnum.Foo,
+        "int_value": TestIntEnum.Bar,
+    })
+
+    assert_that(result.data["name"], is_(equal_to(TestEnum.Foo.name)))
+    assert_that(result.data["value"], is_(equal_to(TestEnum.Bar.value)))
+    assert_that(result.data["int_name"], is_(equal_to(TestIntEnum.Foo.name)))
+    assert_that(result.data["int_value"], is_(equal_to(TestIntEnum.Bar.value)))
+
+
+def test_load_int_enum_as_string():
+    """
+    Can deserialize int enums from strings.
+
+    """
+    schema = EnumSchema()
+    result = schema.load({
+        "int_value": str(TestIntEnum.Bar.value),
+    })
+
+    assert_that(result.data["int_value"], is_(equal_to(TestIntEnum.Bar)))
 
 
 def test_load_from_unix_timestamp_float():


### PR DESCRIPTION
Ensure that stringified int enum values work because that's what happens when you pass integers via a query string...