### PR TITLE
Fix up path handling for swagger with new convention and namespace logic

### DIFF
--- a/microcosm_flask/conventions/discovery.py
+++ b/microcosm_flask/conventions/discovery.py
@@ -37,8 +37,7 @@ class DiscoveryConvention(Convention):
             for operation_name in self.graph.config.discovery_convention.operations
         }
 
-    @property
-    def operations(self):
+    def find_matching_endpoints(self, discovery_ns):
         """
         Compute current matching endpoints.
 
@@ -67,7 +66,7 @@ class DiscoveryConvention(Convention):
                 _links=Links({
                     "self": Link.for_(Operation.Discover, ns, qs=page.to_tuples()),
                     "search": [
-                        link for link in iter_links(self.operations, page)
+                        link for link in iter_links(self.find_matching_endpoints(ns), page)
                     ],
                 }).to_dict()
             )

--- a/microcosm_flask/conventions/swagger.py
+++ b/microcosm_flask/conventions/swagger.py
@@ -24,8 +24,7 @@ class SwaggerConvention(Convention):
             for operation_name in self.graph.config.swagger_convention.operations
         }
 
-    @property
-    def operations(self):
+    def find_matching_endpoints(self, swagger_ns):
         """
         Compute current matching endpoints.
 
@@ -35,7 +34,7 @@ class SwaggerConvention(Convention):
         def match_func(operation, ns, rule):
             # only expose endpoints that have the correct path prefix and operation
             return (
-                rule.rule.startswith(make_path(self.graph, ns.path)) and
+                rule.rule.startswith(make_path(self.graph, swagger_ns.path)) and
                 operation in self.matching_operations
             )
 
@@ -48,7 +47,7 @@ class SwaggerConvention(Convention):
         """
         @self.graph.route(ns.singleton_path, Operation.Discover, ns)
         def discover():
-            swagger = build_swagger(self.graph, ns, self.operations)
+            swagger = build_swagger(self.graph, ns, self.find_matching_endpoints(ns))
             g.hide_body = True
             return jsonify(swagger)
 
@@ -76,7 +75,6 @@ def configure_swagger(graph):
         subject=graph.config.swagger_convention.name,
         version=graph.config.swagger_convention.version,
     )
-
     convention = SwaggerConvention(graph)
     convention.configure(ns, discover=tuple())
     return ns.subject

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -30,7 +30,6 @@ PERSON_MAPPINGS = {
 def test_build_swagger():
     graph = create_object_graph(name="example", testing=True)
     ns = Namespace(
-        path="/v1",
         subject=Person,
         version="v1",
     )


### PR DESCRIPTION
The previous code used the wrong namespace to determine whether an endpoint should be advertised via swagger. It also was consistent in how paths were computed.