### PR TITLE
Add support for Swagger mapping from marshmallow Fields.Dict() type

### DIFF
--- a/microcosm_flask/swagger/schema.py
+++ b/microcosm_flask/swagger/schema.py
@@ -11,6 +11,7 @@ from microcosm_flask.swagger.naming import type_name
 
 # see: https://github.com/marshmallow-code/apispec/blob/dev/apispec/ext/marshmallow/swagger.py
 FIELD_MAPPINGS = {
+    fields.Dict: ("object", None),
     fields.Integer: ("integer", "int32"),
     fields.Number: ("number", None),
     fields.Float: ("number", "float"),

--- a/microcosm_flask/tests/swagger/test_schema.py
+++ b/microcosm_flask/tests/swagger/test_schema.py
@@ -26,6 +26,7 @@ class TestSchema(Schema):
     foo = fields.String(description="Foo", default="bar")
     choice = EnumField(Choices)
     names = fields.List(fields.String)
+    payload = fields.Dict()
     ref = fields.Nested(NewPersonSchema)
 
 
@@ -82,6 +83,13 @@ def test_field_array():
         "items": {
             "type": "string",
         }
+    })))
+
+
+def test_field_dict():
+    parameter = build_parameter(TestSchema().fields["payload"])
+    assert_that(parameter, is_(equal_to({
+        "type": "object",
     })))
 
 


### PR DESCRIPTION
For APIs which work on top of non-relational / document-oriented persistence (e.g DynamoDB), there are cases where a fairly opaque payload is involved in CRUD operations (e.g a JSON / dict object mapped to a field with no strict schema).
Marshmallow already supports this via the fields.Dict type, and Swagger supports a generic 'object' field type definition.

This PR adds this mapping to microcosm-flask explicitly