### PR TITLE
Fixes for Flask 0.11 compatibility

### DIFF
--- a/microcosm_flask/basic_auth.py
+++ b/microcosm_flask/basic_auth.py
@@ -12,7 +12,7 @@ Usage:
 """
 from base64 import b64encode
 
-from flask.ext.basicauth import BasicAuth
+from flask_basicauth import BasicAuth
 from werkzeug.exceptions import Unauthorized
 
 from microcosm.api import defaults

--- a/microcosm_flask/converters.py
+++ b/microcosm_flask/converters.py
@@ -2,7 +2,7 @@
 Flask path converters.
 
 """
-from flask.ext.uuid import FlaskUUID
+from flask_uuid import FlaskUUID
 
 
 def configure_uuid(graph):

--- a/microcosm_flask/errors.py
+++ b/microcosm_flask/errors.py
@@ -127,10 +127,9 @@ def configure_error_handlers(graph):
     Register error handlers.
 
     """
-
     # override all of the werkzeug HTTPExceptions
     for code in default_exceptions.keys():
-        graph.flask.error_handler_spec[None][code] = make_json_error
+        graph.flask.register_error_handler(code, make_json_error)
 
     # register catch all for user exceptions
-    graph.flask.error_handler_spec[None][None] = [(Exception, make_json_error)]
+    graph.flask.register_error_handler(Exception, make_json_error)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     keywords="microcosm",
     install_requires=[
         "enum34>=1.1.2",
-        "Flask>=0.10.1",
+        "Flask>=0.11",
         "Flask-BasicAuth>=0.2.0",
         "flask-cors>=2.1.2",
         "Flask-UUID>=0.2",


### PR DESCRIPTION
 - Stop using deprecated `flask.ext.foo`
 - Use functions to register error handlers instead of modifying the underlying datastructure
   (which has changed semantics)