### PR TITLE
Introduce an UpdateBatch convention

### DIFF
--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -74,6 +74,30 @@ class CRUDConvention(Convention):
 
         create.__doc__ = "Create a new {}".format(ns.subject_name)
 
+    def configure_updatebatch(self, ns, definition):
+        """
+        Register an update batch endpoint.
+
+        The definition's func should be an update function, which must:
+        - accept kwargs for the request and path data
+        - return a new item
+
+        :param ns: the namespace
+        :param definition: the endpoint definition
+
+        """
+        operation = Operation.UpdateBatch
+
+        @self.graph.route(ns.collection_path, operation, ns)
+        @request(definition.request_schema)
+        @response(definition.response_schema)
+        def update_batch(**path_data):
+            request_data = load_request_data(definition.request_schema)
+            response_data = definition.func(**merge_data(path_data, request_data))
+            return dump_response_data(definition.response_schema, response_data, operation.value.default_code)
+
+        update_batch.__doc__ = "Update a batch of {}".format(ns.subject_name)
+
     def configure_retrieve(self, ns, definition):
         """
         Register a retrieve endpoint.

--- a/microcosm_flask/conventions/crud_adapter.py
+++ b/microcosm_flask/conventions/crud_adapter.py
@@ -46,3 +46,22 @@ class CRUDStoreAdapter(object):
         identifier = kwargs.pop(self.identifier_key)
         model = self.store.model_class(id=identifier, **kwargs)
         return self.store.update(identifier, model)
+
+    def update_batch(self, **kwargs):
+        """
+        Simplistic batch update operation implemented in terms of `replace()`.
+
+        Assumes that:
+
+         - Request and response schemas contains lists of items.
+         - Request items define a primary key identifier
+         - The entire batch succeeds or fails together.
+
+        """
+        items = kwargs.pop("items")
+        return dict(
+            items=[
+                self.replace(**item)
+                for item in items
+            ],
+        )

--- a/microcosm_flask/operations.py
+++ b/microcosm_flask/operations.py
@@ -31,7 +31,7 @@ class Operation(Enum):
     # collection operations
     Search = OperationInfo("search", "GET", NODE_PATTERN, 200)
     Create = OperationInfo("create", "POST", NODE_PATTERN, 201)
-    # bulk update is possible here with PATCH
+    UpdateBatch = OperationInfo("update_batch", "PATCH", NODE_PATTERN, 200)
 
     # instance operations
     Retrieve = OperationInfo("retrieve", "GET", NODE_PATTERN, 200)

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -22,6 +22,10 @@ class NewPersonSchema(Schema):
     lastName = fields.Str(attribute="last_name", required=True)
 
 
+class NewPersonBatchSchema(Schema):
+    items = fields.List(fields.Nested(NewPersonSchema))
+
+
 class PersonSchema(NewPersonSchema):
     id = fields.UUID(required=True)
     _links = fields.Method("get_links", dump_only=True)
@@ -30,6 +34,10 @@ class PersonSchema(NewPersonSchema):
         links = Links()
         links["self"] = Link.for_(Operation.Retrieve, Person, person_id=obj.id)
         return links.to_dict()
+
+
+class PersonBatchSchema(NewPersonSchema):
+    items = fields.List(fields.Nested(PersonSchema))
 
 
 PERSON_ID_1 = uuid4()
@@ -43,6 +51,15 @@ def person_create(**kwargs):
 
 def person_search(offset, limit):
     return [PERSON_1], 1
+
+
+def person_update_batch(items):
+    return dict(
+        items=[
+            person_create(**item)
+            for item in items
+        ]
+    )
 
 
 def person_retrieve(person_id):

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -16,6 +16,7 @@ from microcosm_flask.conventions.crud import configure_crud
 from microcosm_flask.operations import Operation
 from microcosm_flask.paging import PageSchema
 from microcosm_flask.tests.conventions.fixtures import (
+    NewPersonBatchSchema,
     NewPersonSchema,
     person_create,
     person_delete,
@@ -23,7 +24,9 @@ from microcosm_flask.tests.conventions.fixtures import (
     person_retrieve,
     person_search,
     person_update,
+    person_update_batch,
     Person,
+    PersonBatchSchema,
     PersonSchema,
     PERSON_ID_1,
     PERSON_ID_2,
@@ -33,6 +36,7 @@ from microcosm_flask.tests.conventions.fixtures import (
 PERSON_MAPPINGS = {
     Operation.Create: (person_create, NewPersonSchema(), PersonSchema()),
     Operation.Delete: (person_delete,),
+    Operation.UpdateBatch: (person_update_batch, NewPersonBatchSchema(), PersonBatchSchema()),
     Operation.Replace: (person_replace, NewPersonSchema(), PersonSchema()),
     Operation.Retrieve: (person_retrieve, PersonSchema()),
     Operation.Search: (person_search, PageSchema(), PersonSchema()),
@@ -140,6 +144,27 @@ class TestCrud(object):
                     ],
                 }]
             }
+        })
+
+    def test_update_batch(self):
+        request_data = {
+            "items": [{
+                "firstName": "Bob",
+                "lastName": "Jones",
+            }],
+        }
+        response = self.client.patch("/api/person", data=dumps(request_data))
+        self.assert_response(response, 200, {
+            "items": [{
+                "id": str(PERSON_ID_2),
+                "firstName": "Bob",
+                "lastName": "Jones",
+                "_links": {
+                    "self": {
+                        "href": "http://localhost/api/person/{}".format(PERSON_ID_2),
+                    }
+                },
+            }],
         })
 
     def test_retrieve(self):


### PR DESCRIPTION
Uses HTTP PATCH on a resource collection to apply several changes at once.

Most of heavy lifting is left to implementing services which will need to:
 -  Define suitable request and response schemas
 -  Determine how best to handle create-vs-update semantics
 -  Determine how best to report partial errors