### PR TITLE
Support null valued fields in swagger responses.

### DIFF
--- a/microcosm_flask/conventions/encoding.py
+++ b/microcosm_flask/conventions/encoding.py
@@ -68,7 +68,14 @@ def dump_response_data(response_schema, response_data, status_code=200, headers=
     """
     if response_schema:
         response_data = response_schema.dump(response_data).data
-    response = jsonify(response_data)
+
+    # swagger does not currently support null values; remove these conditionally
+    include_null_values = not request.headers.get("X-Response-Skip-Null")
+    response = jsonify({
+        key: value
+        for key, value in response_data.items()
+        if include_null_values or value is not None
+    })
     response.headers = Headers(headers or {})
     response.status_code = status_code
     return response

--- a/microcosm_flask/swagger/definitions.py
+++ b/microcosm_flask/swagger/definitions.py
@@ -135,6 +135,19 @@ def body_param(schema):
     })
 
 
+def header_param(name, required=False, param_type="string"):
+    """
+    Build a header parameter definition.
+
+    """
+    return swagger.HeaderParameterSubSchema(**{
+        "name": name,
+        "in": "header",
+        "required": required,
+        "type": param_type,
+    })
+
+
 def query_param(name, field, required=False):
     """
     Build a query parameter definition.
@@ -172,6 +185,11 @@ def build_operation(operation, ns, rule, func):
         ]),
         responses=swagger.Responses(),
         tags=[ns.subject_name],
+    )
+
+    # custom header parameter
+    swagger_operation.parameters.append(
+        header_param("X-Response-Skip-Null")
     )
 
     # path parameters

--- a/microcosm_flask/swagger/schema.py
+++ b/microcosm_flask/swagger/schema.py
@@ -98,7 +98,7 @@ def build_schema(marshmallow_schema):
         "required": [
             field.dump_to or name
             for name, field in fields
-            if field.required
+            if field.required and not field.allow_none
         ]
     }
     return schema

--- a/microcosm_flask/tests/conventions/test_command.py
+++ b/microcosm_flask/tests/conventions/test_command.py
@@ -117,13 +117,20 @@ class TestCommand(object):
                             }
                         }
                     },
-                    "parameters": [{
-                        "schema": {
-                            "$ref": "#/definitions/CommandArgument",
+                    "parameters": [
+                        {
+                            "in": "header",
+                            "name": "X-Response-Skip-Null",
+                            "required": False,
+                            "type": "string",
                         },
-                        "name": "body",
-                        "in": "body",
-                    }
+                        {
+                            "schema": {
+                                "$ref": "#/definitions/CommandArgument",
+                            },
+                            "name": "body",
+                            "in": "body",
+                        },
                     ],
                     "operationId": "command",
                 }

--- a/microcosm_flask/tests/conventions/test_query.py
+++ b/microcosm_flask/tests/conventions/test_query.py
@@ -116,12 +116,20 @@ class TestQuery(object):
                             }
                         }
                     },
-                    "parameters": [{
-                        "required": False,
-                        "type": "string",
-                        "name": "value",
-                        "in": "query",
-                    }],
+                    "parameters": [
+                        {
+                            "in": "header",
+                            "name": "X-Response-Skip-Null",
+                            "required": False,
+                            "type": "string",
+                        },
+                        {
+                            "required": False,
+                            "type": "string",
+                            "name": "value",
+                            "in": "query",
+                        },
+                    ],
                     "operationId": "query",
                 }
             }

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -67,11 +67,17 @@ def test_build_swagger():
                     },
                     "parameters": [
                         {
+                            "in": "header",
+                            "name": "X-Response-Skip-Null",
+                            "required": False,
+                            "type": "string",
+                        },
+                        {
                             "in": "body",
                             "name": "body",
                             "schema": {
                                 "$ref": "#/definitions/NewPerson",
-                            }
+                            },
                         },
                     ],
                     "operationId": "create",


### PR DESCRIPTION
Swagger apparently does not support null values; JSON Schema does, but nullability
needs to be expressed as a `oneOf` clause over both the `null` type and the actual
type of the object; Swagger appears to have eliminated this complexity with the
expectation that null values are just removed from the data type.

This change does a few things:

 - It supports pruning null values from microcosm JSON response; this behavior
   is conditional on the `X-Response-Skip-Null` header being supplied.

 - It injects this header as an optional parameter of every microcosm request.

 - It marks `allow_none` (marshmallow) fields as non-required Swagger fields.

From a Swagger client (e.g. Yelp's bravado), we can now handle null fields via:

    response = client.foo.bar(
        args,
        _request_options=dict(
            headers={
               "X-Response-Skip-Null": True,
            },
        ),
    )