### PR TITLE
Ensure that swagger works for multiple versions concurrently.

### DIFF
--- a/microcosm_flask/conventions/swagger.py
+++ b/microcosm_flask/conventions/swagger.py
@@ -45,7 +45,7 @@ class SwaggerConvention(Convention):
         Register a swagger endpoint for a set of operations.
 
         """
-        @self.graph.route(ns.singleton_path, Operation.Discover, ns)
+        @self.graph.route(ns.singleton_path, Operation.DiscoverVersion, ns)
         def discover():
             swagger = build_swagger(self.graph, ns, self.find_matching_endpoints(ns))
             g.hide_body = True

--- a/microcosm_flask/operations.py
+++ b/microcosm_flask/operations.py
@@ -14,8 +14,10 @@ from enum import Enum, unique
 OperationInfo = namedtuple("OperationInfo", ["name", "method", "pattern", "default_code"])
 
 
-NODE_PATTERN = "{}.{}"
-EDGE_PATTERN = "{}.{}.{}"
+# NB: Namespace.parse_endpoint requires that operation is the second argument
+NODE_PATTERN = "{subject}.{operation}"
+EDGE_PATTERN = "{subject}.{operation}.{object_}"
+VERSIONED_NODE_PATTERN = "{subject}.{operation}.{version}"
 
 
 @unique
@@ -27,6 +29,7 @@ class Operation(Enum):
     """
     # discovery operation
     Discover = OperationInfo("discover", "GET", NODE_PATTERN, 200)
+    DiscoverVersion = OperationInfo("discover_version", "GET", VERSIONED_NODE_PATTERN, 200)
 
     # collection operations
     Search = OperationInfo("search", "GET", NODE_PATTERN, 200)
@@ -55,3 +58,15 @@ class Operation(Enum):
                 return operation
         else:
             raise ValueError(name)
+
+    @property
+    def endpoint_pattern(self):
+        """
+        Convert the operation's pattern into a regex matcher.
+
+        """
+        parts = self.value.pattern.split(".")
+        return "[.]".join(
+            "(?P<{}>[^.]*)".format(part[1:-1])
+            for part in parts
+        )

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -45,7 +45,6 @@ def configure_route_decorator(graph):
         :param operation: an `Operation` enum value
         :param ns: a `Namespace` instance
         """
-
         def decorator(func):
             if graph.config.route.enable_cors:
                 func = cross_origin(supports_credentials=True)(func)

--- a/microcosm_flask/swagger/schema.py
+++ b/microcosm_flask/swagger/schema.py
@@ -38,6 +38,16 @@ FIELD_MAPPINGS = {
 }
 
 
+SWAGGER_TYPE = "__swagger_type__"
+SWAGGER_FORMAT = "__swagger_format__"
+
+
+def swagger_field(field, swagger_type="string", swagger_format=None):
+    setattr(field, SWAGGER_TYPE, swagger_type)
+    setattr(field, SWAGGER_FORMAT, swagger_format)
+    return field
+
+
 def build_parameter(field):
     """
     Build a parameter from a marshmallow field.
@@ -48,9 +58,9 @@ def build_parameter(field):
     try:
         field_type, field_format = FIELD_MAPPINGS[type(field)]
     except KeyError:
-        if hasattr(field, "__swagger_type__"):
-            field_type = getattr(field, "__swagger_type__")
-            field_format = getattr(field, "__swagger_format__", None)
+        if hasattr(field, SWAGGER_TYPE):
+            field_type = getattr(field, SWAGGER_TYPE)
+            field_format = getattr(field, SWAGGER_FORMAT, None)
         else:
             logger.exception("No mapped swagger type for marshmallow field: {}".format(
                 field,

--- a/microcosm_flask/tests/test_namespaces.py
+++ b/microcosm_flask/tests/test_namespaces.py
@@ -56,6 +56,18 @@ def test_parse_endpoint_relation():
     assert_that(ns.object_, is_(equal_to("bar")))
 
 
+def test_parse_endpoint_swagger():
+    """
+    Versioned discovery endpoint can be parsed.
+
+    """
+    operation, ns = Namespace.parse_endpoint("swagger.discover_version.v2")
+    assert_that(operation, is_(equal_to(Operation.DiscoverVersion)))
+    assert_that(ns.subject, is_(equal_to("swagger")))
+    assert_that(ns.version, is_(equal_to("v2")))
+    assert_that(ns.object_, is_(none()))
+
+
 def test_operation_url_for():
     """
     Operations can resolve themselves via Flask's `url_for`.

--- a/microcosm_flask/tests/test_operations.py
+++ b/microcosm_flask/tests/test_operations.py
@@ -18,3 +18,22 @@ def test_from_name():
     """
     assert_that(Operation.from_name("search"), is_(equal_to(Operation.Search)))
     assert_that(Operation.from_name("Create"), is_(equal_to(Operation.Create)))
+
+
+def test_endpoint_pattern():
+    """
+    Operations define valid endpoint patterns.
+
+    """
+    assert_that(
+        Operation.DiscoverVersion.endpoint_pattern,
+        is_(equal_to("(?P<subject>[^.]*)[.](?P<operation>[^.]*)[.](?P<version>[^.]*)")),
+    )
+    assert_that(
+        Operation.Search.endpoint_pattern,
+        is_(equal_to("(?P<subject>[^.]*)[.](?P<operation>[^.]*)")),
+    )
+    assert_that(
+        Operation.SearchFor.endpoint_pattern,
+        is_(equal_to("(?P<subject>[^.]*)[.](?P<operation>[^.]*)[.](?P<object_>[^.]*)")),
+    )


### PR DESCRIPTION
The swagger endpoint was fixed, independent of version. This meant we couldn't have multiple versions.