### PR TITLE
Version all endpoints

### DIFF
--- a/microcosm_flask/conventions/discovery.py
+++ b/microcosm_flask/conventions/discovery.py
@@ -56,7 +56,7 @@ class DiscoveryConvention(Convention):
         """
         page_schema = PageSchema()
 
-        @self.graph.route(ns.singleton_path, Operation.Discover, ns)
+        @self.graph.route("/", Operation.Discover, ns)
         def discover():
             # accept pagination limit from request
             page = Page.from_query_string(load_query_string_data(page_schema))
@@ -73,7 +73,7 @@ class DiscoveryConvention(Convention):
 
 
 @defaults(
-    name="",
+    name="hal",
     operations=[
         "search",
     ],

--- a/microcosm_flask/conventions/swagger.py
+++ b/microcosm_flask/conventions/swagger.py
@@ -45,7 +45,7 @@ class SwaggerConvention(Convention):
         Register a swagger endpoint for a set of operations.
 
         """
-        @self.graph.route(ns.singleton_path, Operation.DiscoverVersion, ns)
+        @self.graph.route(ns.singleton_path, Operation.Discover, ns)
         def discover():
             swagger = build_swagger(self.graph, ns, self.find_matching_endpoints(ns))
             g.hide_body = True

--- a/microcosm_flask/namespaces.py
+++ b/microcosm_flask/namespaces.py
@@ -102,7 +102,7 @@ class Namespace(object):
             subject=self.subject_name,
             operation=operation.value.name,
             object_=self.object_name if self.object_ else None,
-            version=self.version,
+            version=self.version or "v1",
         )
 
     @staticmethod

--- a/microcosm_flask/operations.py
+++ b/microcosm_flask/operations.py
@@ -15,9 +15,8 @@ OperationInfo = namedtuple("OperationInfo", ["name", "method", "pattern", "defau
 
 
 # NB: Namespace.parse_endpoint requires that operation is the second argument
-NODE_PATTERN = "{subject}.{operation}"
-EDGE_PATTERN = "{subject}.{operation}.{object_}"
-VERSIONED_NODE_PATTERN = "{subject}.{operation}.{version}"
+NODE_PATTERN = "{subject}.{operation}.{version}"
+EDGE_PATTERN = "{subject}.{operation}.{object_}.{version}"
 
 
 @unique
@@ -29,7 +28,6 @@ class Operation(Enum):
     """
     # discovery operation
     Discover = OperationInfo("discover", "GET", NODE_PATTERN, 200)
-    DiscoverVersion = OperationInfo("discover_version", "GET", VERSIONED_NODE_PATTERN, 200)
 
     # collection operations
     Search = OperationInfo("search", "GET", NODE_PATTERN, 200)

--- a/microcosm_flask/tests/test_namespaces.py
+++ b/microcosm_flask/tests/test_namespaces.py
@@ -21,7 +21,7 @@ def test_endpoint_for():
     """
     ns = Namespace(subject="foo")
     endpoint = ns.endpoint_for(Operation.Search)
-    assert_that(endpoint, is_(equal_to("foo.search")))
+    assert_that(endpoint, is_(equal_to("foo.search.v1")))
 
 
 def test_operation_naming_relation():
@@ -31,7 +31,7 @@ def test_operation_naming_relation():
     """
     ns = Namespace(subject="foo", object_="bar")
     endpoint = ns.endpoint_for(Operation.SearchFor)
-    assert_that(endpoint, is_(equal_to("foo.search_for.bar")))
+    assert_that(endpoint, is_(equal_to("foo.search_for.bar.v1")))
 
 
 def test_parse_endpoint():
@@ -39,7 +39,7 @@ def test_parse_endpoint():
     Simple (subject-only) endpoints can be parsed.
 
     """
-    operation, ns = Namespace.parse_endpoint("foo.search")
+    operation, ns = Namespace.parse_endpoint("foo.search.v1")
     assert_that(operation, is_(equal_to(Operation.Search)))
     assert_that(ns.subject, is_(equal_to("foo")))
     assert_that(ns.object_, is_(none()))
@@ -50,7 +50,7 @@ def test_parse_endpoint_relation():
     Complex (subject+object) endpoints can be parsed.
 
     """
-    operation, ns = Namespace.parse_endpoint("foo.search_for.bar")
+    operation, ns = Namespace.parse_endpoint("foo.search_for.bar.v1")
     assert_that(operation, is_(equal_to(Operation.SearchFor)))
     assert_that(ns.subject, is_(equal_to("foo")))
     assert_that(ns.object_, is_(equal_to("bar")))
@@ -61,8 +61,8 @@ def test_parse_endpoint_swagger():
     Versioned discovery endpoint can be parsed.
 
     """
-    operation, ns = Namespace.parse_endpoint("swagger.discover_version.v2")
-    assert_that(operation, is_(equal_to(Operation.DiscoverVersion)))
+    operation, ns = Namespace.parse_endpoint("swagger.discover.v2")
+    assert_that(operation, is_(equal_to(Operation.Discover)))
     assert_that(ns.subject, is_(equal_to("swagger")))
     assert_that(ns.version, is_(equal_to("v2")))
     assert_that(ns.object_, is_(none()))

--- a/microcosm_flask/tests/test_operations.py
+++ b/microcosm_flask/tests/test_operations.py
@@ -26,14 +26,14 @@ def test_endpoint_pattern():
 
     """
     assert_that(
-        Operation.DiscoverVersion.endpoint_pattern,
+        Operation.Discover.endpoint_pattern,
         is_(equal_to("(?P<subject>[^.]*)[.](?P<operation>[^.]*)[.](?P<version>[^.]*)")),
     )
     assert_that(
         Operation.Search.endpoint_pattern,
-        is_(equal_to("(?P<subject>[^.]*)[.](?P<operation>[^.]*)")),
+        is_(equal_to("(?P<subject>[^.]*)[.](?P<operation>[^.]*)[.](?P<version>[^.]*)")),
     )
     assert_that(
         Operation.SearchFor.endpoint_pattern,
-        is_(equal_to("(?P<subject>[^.]*)[.](?P<operation>[^.]*)[.](?P<object_>[^.]*)")),
+        is_(equal_to("(?P<subject>[^.]*)[.](?P<operation>[^.]*)[.](?P<object_>[^.]*)[.](?P<version>[^.]*)")),
     )


### PR DESCRIPTION
This PR changes the internal endpoint names to always contain versions; otherwise we cannot easily have two of the same operation in different versions within the same application.

In a few places, I've injected `v1` as a default to help with backwards compatibility; in some cases, we'll have to start adding explicit versions. The most common of these will be in HAL-style links for existing resources in a non-v1 version.

Example... Was:

```
Link.for_(Operation.Retrieve, Foo, foo_id=foo_id)
```

Now:

```
Link.for_(Operation.Retrieve, Namespace(subject=Foo, version="v2"), foo_id=foo_id)
```
