### PR TITLE
Added as_retryable exception function decorator

### DIFF
--- a/microcosm_flask/errors.py
+++ b/microcosm_flask/errors.py
@@ -31,7 +31,7 @@ class ErrorSchema(Schema):
 def as_retryable(error):
     """
     Given an exception, mark it as retryable when serializing
-    into transporty layer error response.
+    into HTTP error response.
 
     """
     error.retryable = True

--- a/microcosm_flask/errors.py
+++ b/microcosm_flask/errors.py
@@ -28,6 +28,17 @@ class ErrorSchema(Schema):
     context = fields.Nested(ErrorContextSchema, required=False)
 
 
+def as_retryable(error):
+    """
+    Given an exception, mark it as retryable when serializing
+    into transporty layer error response.
+
+    """
+    error.retryable = True
+
+    return error
+
+
 def extract_status_code(error):
     """
     Extract an error code from a message.


### PR DESCRIPTION
Can be used around an exception to facilitate making it a retryable error when serializing into a transport (HTTP) error