### PR TITLE
make it possible to log context with route requests

### DIFF
--- a/microcosm_flask/audit.py
+++ b/microcosm_flask/audit.py
@@ -153,7 +153,7 @@ def configure_audit_decorator(graph):
                 include_request_body=include_request_body,
                 include_response_body=include_response_body,
             )
-            return _audit_request(options, func, graph.context,  *args, **kwargs)
+            return _audit_request(options, func, graph.request_context,  *args, **kwargs)
 
         return wrapper
     return _audit

--- a/microcosm_flask/context.py
+++ b/microcosm_flask/context.py
@@ -1,0 +1,32 @@
+from flask import request
+from microcosm.api import defaults
+
+
+X_REQUEST = "X-Request"
+
+
+def context_wrapper(include_header_prefix):
+    def retrieve_context():
+        return {
+            header: value
+            for header, value in request.headers.items()
+            if header.startswith(include_header_prefix)
+        }
+
+    return retrieve_context
+
+
+@defaults(
+    include_header_prefix=X_REQUEST,
+)
+def configure_context(graph):
+    """
+    Configure the flask context function which controls what data you want to associate
+    with your flask request context, e.g. headers, request body/response.
+
+    Usage:
+        graph.context()
+    """
+
+    include_header_prefix = graph.config.context.include_header_prefix
+    return context_wrapper(include_header_prefix)

--- a/microcosm_flask/context.py
+++ b/microcosm_flask/context.py
@@ -19,14 +19,14 @@ def context_wrapper(include_header_prefix):
 @defaults(
     include_header_prefix=X_REQUEST,
 )
-def configure_context(graph):
+def configure_request_context(graph):
     """
     Configure the flask context function which controls what data you want to associate
     with your flask request context, e.g. headers, request body/response.
 
     Usage:
-        graph.context()
+        graph.request_context()
     """
 
-    include_header_prefix = graph.config.context.include_header_prefix
+    include_header_prefix = graph.config.request_context.include_header_prefix
     return context_wrapper(include_header_prefix)

--- a/microcosm_flask/conventions/base.py
+++ b/microcosm_flask/conventions/base.py
@@ -10,13 +10,13 @@ class EndpointDefinition(tuple):
     A definition for an endpoint.
 
     """
-    def __new__(cls, func=None, request_schema=None, response_schema=None, controller=None):
+    def __new__(cls, func=None, request_schema=None, response_schema=None):
         """
         :param func: a function to process request data and return response data
         :param request_schema: a marshmallow schema to decode/validate request data
         :param response_schema: a marshmallow schema to encode response data
         """
-        return tuple.__new__(EndpointDefinition, (func, request_schema, response_schema, controller))
+        return tuple.__new__(EndpointDefinition, (func, request_schema, response_schema))
 
     @property
     def func(self):
@@ -29,10 +29,6 @@ class EndpointDefinition(tuple):
     @property
     def response_schema(self):
         return self[2]
-
-    @property
-    def controller(self):
-        return self[3]
 
 
 class Convention(object):

--- a/microcosm_flask/conventions/base.py
+++ b/microcosm_flask/conventions/base.py
@@ -10,13 +10,13 @@ class EndpointDefinition(tuple):
     A definition for an endpoint.
 
     """
-    def __new__(cls, func=None, request_schema=None, response_schema=None):
+    def __new__(cls, func=None, request_schema=None, response_schema=None, controller=None):
         """
         :param func: a function to process request data and return response data
         :param request_schema: a marshmallow schema to decode/validate request data
         :param response_schema: a marshmallow schema to encode response data
         """
-        return tuple.__new__(EndpointDefinition, (func, request_schema, response_schema))
+        return tuple.__new__(EndpointDefinition, (func, request_schema, response_schema, controller))
 
     @property
     def func(self):
@@ -29,6 +29,10 @@ class EndpointDefinition(tuple):
     @property
     def response_schema(self):
         return self[2]
+
+    @property
+    def controller(self):
+        return self[3]
 
 
 class Convention(object):

--- a/microcosm_flask/factories.py
+++ b/microcosm_flask/factories.py
@@ -38,7 +38,7 @@ def configure_flask_app(graph):
     """
     graph.use(
         "audit",
-        "context",
+        "request_context",
         "basic_auth",
         "error_handlers",
         "logger",

--- a/microcosm_flask/factories.py
+++ b/microcosm_flask/factories.py
@@ -38,6 +38,7 @@ def configure_flask_app(graph):
     """
     graph.use(
         "audit",
+        "context",
         "basic_auth",
         "error_handlers",
         "logger",

--- a/microcosm_flask/namespaces.py
+++ b/microcosm_flask/namespaces.py
@@ -32,7 +32,7 @@ class Namespace(object):
 
     """
 
-    def __init__(self, subject, object_=None, path=None, version=None):
+    def __init__(self, subject, object_=None, path=None, controller=None, version=None):
         """
         :param subject: the target resource (or resource name) of this namespace
         :param object_: the subject resource (or resource name) of this namespace (e.g. for relations)
@@ -42,6 +42,7 @@ class Namespace(object):
         self.subject = subject
         self.object_ = object_
         self.prefix = path or ""
+        self.controller = controller
         self.version = version
 
     @property

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -59,7 +59,7 @@ def configure_route_decorator(graph):
                 ns.controller is not None,
             ]):
                 func = context_logger(
-                    graph.context,
+                    graph.request_context,
                     func,
                     parent=ns.controller,
                 )

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -60,8 +60,8 @@ def configure_route_decorator(graph):
             ]):
                 func = context_logger(
                     graph.context,
-                    ns.controller,
                     func,
+                    parent=ns.controller,
                 )
 
             # keep audit decoration last (before registering the route) so that

--- a/microcosm_flask/tests/test_namespaces.py
+++ b/microcosm_flask/tests/test_namespaces.py
@@ -8,6 +8,7 @@ from hamcrest import (
     is_,
     none,
 )
+from mock import Mock
 
 from microcosm.api import create_object_graph
 from microcosm_flask.namespaces import Namespace
@@ -100,3 +101,24 @@ def test_operation_href_for():
     with graph.app.test_request_context():
         url = ns.href_for(Operation.Search)
         assert_that(url, is_(equal_to("http://localhost/api/foo")))
+
+
+def test_namespace_accepts_controller():
+    """
+    Operations can resolve themselves as fully expanded hrefs.
+
+    """
+    graph = create_object_graph(name="example", testing=True)
+    controller = Mock()
+    ns = Namespace(subject="foo", controller=controller)
+
+    @graph.route(ns.collection_path, Operation.Search, ns)
+    def search_foo():
+        pass
+
+    with graph.app.test_request_context():
+        url = ns.href_for(Operation.Search)
+        assert_that(url, is_(equal_to("http://localhost/api/foo")))
+        url = ns.url_for(Operation.Search)
+        assert_that(url, is_(equal_to("/api/foo")))
+        assert_that(ns.controller, is_(equal_to(controller)))

--- a/microcosm_flask/tests/test_namespaces.py
+++ b/microcosm_flask/tests/test_namespaces.py
@@ -105,7 +105,7 @@ def test_operation_href_for():
 
 def test_namespace_accepts_controller():
     """
-    Operations can resolve themselves as fully expanded hrefs.
+    Namespaces may optionally contain a controller.
 
     """
     graph = create_object_graph(name="example", testing=True)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "Flask-UUID>=0.2",
         "marshmallow>=2.6.0",
         "microcosm>=0.11.0",
-        "microcosm-logging>=0.2.0",
+        "microcosm-logging>=0.9.0",
         "openapi>=0.5.0",
         "python-dateutil>=2.5.2",
         "PyYAML>=3.11",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
             "app = microcosm_flask.factories:configure_flask_app",
             "audit = microcosm_flask.audit:configure_audit_decorator",
             "basic_auth = microcosm_flask.basic_auth:configure_basic_auth_decorator",
-            "context = microcosm_flask.context:configure_context",
+            "request_context = microcosm_flask.context:configure_request_context",
             "discovery_convention = microcosm_flask.conventions.discovery:configure_discovery",
             "error_handlers = microcosm_flask.errors:configure_error_handlers",
             "flask = microcosm_flask.factories:configure_flask",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "Flask-UUID>=0.2",
         "marshmallow>=2.6.0",
         "microcosm>=0.11.0",
-        "microcosm-logging>=0.9.0",
+        "microcosm-logging>=0.9.1",
         "openapi>=0.5.0",
         "python-dateutil>=2.5.2",
         "PyYAML>=3.11",

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
             "app = microcosm_flask.factories:configure_flask_app",
             "audit = microcosm_flask.audit:configure_audit_decorator",
             "basic_auth = microcosm_flask.basic_auth:configure_basic_auth_decorator",
+            "context = microcosm_flask.context:configure_context",
             "discovery_convention = microcosm_flask.conventions.discovery:configure_discovery",
             "error_handlers = microcosm_flask.errors:configure_error_handlers",
             "flask = microcosm_flask.factories:configure_flask",


### PR DESCRIPTION
See:

- https://github.com/globality-corp/microcosm-flask/pull/51
- https://github.com/globality-corp/ariza/pull/22
- https://github.com/globality-corp/microcosm-logging/pull/15

My expectation is that things that want to use the context logger will define a `context_function` and pass it to a `context_logger` decorator. We can also start using this context function in place of manually parsing headers all over the place in code where we want to log/pass them to pubsub.