### PR TITLE
Support allow_none fields to be null

### DIFF
--- a/microcosm_flask/swagger/schema.py
+++ b/microcosm_flask/swagger/schema.py
@@ -69,7 +69,10 @@ def build_parameter(field):
 
     parameter = {}
     if field_type:
-        parameter["type"] = field_type
+        if field.allow_none is True:
+            parameter["type"] = [field_type, 'null']
+        else:
+            parameter["type"] = field_type
     if field.metadata.get("description"):
         parameter["description"] = field.metadata["description"]
     if field_format:

--- a/microcosm_flask/tests/swagger/test_schema.py
+++ b/microcosm_flask/tests/swagger/test_schema.py
@@ -24,6 +24,7 @@ class Choices(Enum):
 class TestSchema(Schema):
     id = fields.UUID()
     foo = fields.String(description="Foo", default="bar")
+    bar = fields.String(allow_none=True)
     choice = EnumField(Choices)
     names = fields.List(fields.String)
     payload = fields.Dict()
@@ -55,6 +56,13 @@ def test_field_description_and_default():
         "type": "string",
         "description": "Foo",
         "default": "bar",
+    })))
+
+
+def test_field_allow_none():
+    parameter = build_parameter(TestSchema().fields["bar"])
+    assert_that(parameter, is_(equal_to({
+        "type": ["string", "null"],
     })))
 
 


### PR DESCRIPTION
Why:

* we have some fields (such as a company's thumbnailUrl) that are of
  type string but allow_none True. We want to support `null`'s in this
  case but without an explicit allowance for this check, swagger clients
  will break when they recieve a null in place of a string.

This change addresses the need by:

* per
  https://github.com/OAI/OpenAPI-Specification/issues/229#issuecomment-193537548
  support of `null` as a string works as an additional type