### PR TITLE
Correctly handle schema with no required fields in swagger definition.

### DIFF
--- a/microcosm_flask/generic_resources.py
+++ b/microcosm_flask/generic_resources.py
@@ -1,8 +1,0 @@
-from marshmallow import Schema, fields
-
-
-class EmptySchema(Schema):
-    """
-    Dummy schema for making empty requests without swagger validation errors.
-    """
-    _ = fields.Boolean(required=True, dump_only=True)

--- a/microcosm_flask/swagger/schema.py
+++ b/microcosm_flask/swagger/schema.py
@@ -99,18 +99,20 @@ def build_schema(marshmallow_schema):
 
     """
     fields = list(iter_fields(marshmallow_schema))
+    required_fields = [
+        field.dump_to or name
+        for name, field in fields
+        if field.required and not field.allow_none
+    ]
     schema = {
         "type": "object",
         "properties": {
             field.dump_to or name: build_parameter(field)
             for name, field in fields
-        },
-        "required": [
-            field.dump_to or name
-            for name, field in fields
-            if field.required and not field.allow_none
-        ]
+        }
     }
+    if required_fields:
+        schema["required"] = required_fields
     return schema
 
 

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -38,6 +38,11 @@ class NewPersonBatchSchema(Schema):
     items = fields.List(fields.Nested(NewPersonSchema))
 
 
+class UpdatePersonSchema(Schema):
+    firstName = fields.Str(attribute="first_name")
+    lastName = fields.Str(attribute="last_name")
+
+
 class AddressSchema(NewAddressSchema):
     id = fields.UUID(required=True)
     _links = fields.Method("get_links", dump_only=True)

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -17,13 +17,16 @@ from microcosm_flask.swagger.definitions import build_swagger
 from microcosm_flask.tests.conventions.fixtures import (
     NewPersonSchema,
     person_create,
+    person_update,
     Person,
     PersonSchema,
+    UpdatePersonSchema,
 )
 
 
 PERSON_MAPPINGS = {
     Operation.Create: (person_create, NewPersonSchema(), PersonSchema()),
+    Operation.Update: (person_update, UpdatePersonSchema(), PersonSchema()),
 }
 
 
@@ -83,6 +86,47 @@ def test_build_swagger():
                     "operationId": "create",
                 },
             },
+            "/person/{person_id}": {
+                "patch": {
+                    "tags": ["person"],
+                    "responses": {
+                        "default": {
+                            "description": "An error occcurred",
+                            "schema": {
+                                "$ref": "#/definitions/Error",
+                            },
+                        },
+                        "200": {
+                            "description": "Update some or all of a person by id",
+                            "schema": {
+                                "$ref": "#/definitions/Person",
+                            },
+                        },
+                    },
+                    "parameters": [
+                        {
+                            "required": False,
+                            "type": "string",
+                            "name": "X-Response-Skip-Null",
+                            "in": "header",
+                        },
+                        {
+                            "required": True,
+                            "type": "string",
+                            "name": "person_id",
+                            "in": "path",
+                        },
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "schema": {
+                                "$ref": "#/definitions/UpdatePerson",
+                            },
+                        },
+                    ],
+                    "operationId": "update",
+                },
+            },
         },
         "produces": [
             "application/json",
@@ -125,6 +169,17 @@ def test_build_swagger():
                         "type": "string",
                     },
                 },
+            },
+            "UpdatePerson": {
+                "type": "object",
+                "properties": {
+                    "lastName": {
+                        "type": "string",
+                    },
+                    "firstName": {
+                        "type": "string",
+                    }
+                }
             },
             "ErrorContext": {
                 "required": ["errors"],


### PR DESCRIPTION
Previously, we were inserting a `required` attribute into every definition,
even if it had no required fields. This created problems with schema validation,
which expected the `required` value to be a non-empty list. Our workaround was
introducing the `EmptySchema` base with a placeholder required field.

It turns out that we can just omit the `required` field entirely if there are
no required fields. This makes swagger usage (and validation) much simpler.