### PR TITLE
Forward ports

### DIFF
--- a/microcosm_flask/forwarding.py
+++ b/microcosm_flask/forwarding.py
@@ -1,0 +1,46 @@
+"""
+Support for request forwarding.
+
+HATEOAS depends heavily on services being able to generate URIs back to their own resources.
+Under some request forwarding scenarios (especially AWS ALBs), services may not be resolved
+on a URI that is accessible to other services. This can be solved by configuring static
+service URIs... or by resolving URIs using X-Forwarded headers.
+
+"""
+from flask import request, _request_ctx_stack
+
+from microcosm_flask.session import register_session_factory
+
+
+def use_forwarded_port(graph):
+    """
+    Inject the `X-Forwarded-Port` (if any) into the current URL adapter.
+
+    The URL adapter is used by `url_for` to build a URLs.
+
+    """
+    forwarded_port = request.headers.get("X-Forwarded-Port")
+    if not forwarded_port:
+        return None
+
+    if _request_ctx_stack is None:
+        return None
+
+    # There must be a better way!
+    context = _request_ctx_stack.top
+    context.url_adapter.server_name = "{}:{}".format(
+        context.url_adapter.server_name.split(":", 1)[0],
+        forwarded_port,
+    )
+
+    return forwarded_port
+
+
+def configure_port_forwarding(graph):
+    """
+    Bind the SQLAlchemy session context to Flask.
+
+    The current session is available at `g.db.session`.
+
+    """
+    return register_session_factory(graph, "forwarded_port", use_forwarded_port)

--- a/microcosm_flask/tests/test_forwarding.py
+++ b/microcosm_flask/tests/test_forwarding.py
@@ -9,6 +9,7 @@ from hamcrest import (
     is_,
 )
 from microcosm.api import create_object_graph
+from six import b
 
 
 def test_forwarding():
@@ -31,4 +32,4 @@ def test_forwarding():
     )
 
     assert_that(response.status_code, is_(equal_to(200)))
-    assert_that(response.data, is_(equal_to("http://localhost:8080/")))
+    assert_that(response.data, is_(equal_to(b("http://localhost:8080/"))))

--- a/microcosm_flask/tests/test_forwarding.py
+++ b/microcosm_flask/tests/test_forwarding.py
@@ -1,0 +1,34 @@
+"""
+Middleware tests.
+
+"""
+from flask import url_for
+from hamcrest import (
+    assert_that,
+    equal_to,
+    is_,
+)
+from microcosm.api import create_object_graph
+
+
+def test_forwarding():
+    graph = create_object_graph("test", testing=True)
+    graph.use(
+        "flask",
+        "port_forwarding",
+    )
+
+    @graph.app.route("/", endpoint="test")
+    def endpoint():
+        return url_for("test", _external=True)
+
+    client = graph.app.test_client()
+    response = client.get(
+        "/",
+        headers={
+            "X-Forwarded-Port": "8080",
+        },
+    )
+
+    assert_that(response.status_code, is_(equal_to(200)))
+    assert_that(response.data, is_(equal_to("http://localhost:8080/")))

--- a/microcosm_flask/tests/test_forwarding.py
+++ b/microcosm_flask/tests/test_forwarding.py
@@ -1,5 +1,5 @@
 """
-Middleware tests.
+Forwarding tests.
 
 """
 from flask import url_for

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
             "error_handlers = microcosm_flask.errors:configure_error_handlers",
             "flask = microcosm_flask.factories:configure_flask",
             "health_convention = microcosm_flask.conventions.health:configure_health",
+            "port_forwarding = microcosm_flask.forwarding:configure_port_forwarding",
             "route = microcosm_flask.routing:configure_route_decorator",
             "swagger_convention = microcosm_flask.conventions.swagger:configure_swagger",
             "uuid = microcosm_flask.converters:configure_uuid",


### PR DESCRIPTION
When our software is deployed behind an ALB, the client's port is not the port that Flask gets requested on. This PR adds an adapter that uses the `X-Forwarded-Port` to ensure that generated URIs (e.g. from `url_for`) reflect the client's view.

At the moment, we have no need for other forwarded headers; the scheme and host are appropriate.