### PR TITLE
clean null values recursively

### DIFF
--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -7,6 +7,7 @@ from inflection import pluralize
 
 from microcosm_flask.conventions.base import Convention
 from microcosm_flask.conventions.encoding import (
+    clean_response_data,
     dump_response_data,
     load_query_string_data,
     load_request_data,
@@ -53,9 +54,9 @@ class CRUDConvention(Convention):
                 items, count = return_value
 
             # TODO: use the schema for encoding
-            return jsonify(
+            return jsonify(clean_response_data(
                 PaginatedList(ns, page, items, count, definition.response_schema, **context).to_dict()
-            )
+            ))
 
         search.__doc__ = "Search the collection of all {}".format(pluralize(ns.subject_name))
 

--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -7,7 +7,7 @@ from inflection import pluralize
 
 from microcosm_flask.conventions.base import Convention
 from microcosm_flask.conventions.encoding import (
-    clean_response_data,
+    remove_null_values,
     dump_response_data,
     load_query_string_data,
     load_request_data,
@@ -54,7 +54,7 @@ class CRUDConvention(Convention):
                 items, count = return_value
 
             # TODO: use the schema for encoding
-            return jsonify(clean_response_data(
+            return jsonify(remove_null_values(
                 PaginatedList(ns, page, items, count, definition.response_schema, **context).to_dict()
             ))
 

--- a/microcosm_flask/conventions/encoding.py
+++ b/microcosm_flask/conventions/encoding.py
@@ -56,16 +56,16 @@ def load_query_string_data(request_schema):
     return request_data.data
 
 
-def clean_response_data(response_data):
-    if isinstance(response_data, dict):
+def remove_null_values(data):
+    if isinstance(data, dict):
         return {
-            key: clean_response_data(value)
-            for key, value in response_data.items()
+            key: remove_null_values(value)
+            for key, value in data.items()
             if value is not None
         }
-    if type(response_data) in (list, tuple):
-        return type(response_data)(map(clean_response_data, response_data))
-    return response_data
+    if type(data) in (list, tuple):
+        return type(data)(map(remove_null_values, data))
+    return data
 
 
 def dump_response_data(response_schema, response_data, status_code=200, headers=None):
@@ -83,9 +83,9 @@ def dump_response_data(response_schema, response_data, status_code=200, headers=
 
     if not request.headers.get("X-Response-Skip-Null"):
         # swagger does not currently support null values; remove these conditionally
-        response_data = clean_response_data(response_data)
+        response_data = remove_null_values(response_data)
 
-    response = jsonify(clean_response_data(response_data))
+    response = jsonify(remove_null_values(response_data))
     response.headers = Headers(headers or {})
     response.status_code = status_code
     return response


### PR DESCRIPTION
`null` values in schemas are not supported. Extending the current `null` cleanup to remove `null` values recursively, and also adding it to the `search` responses.
Will try to improve the implementation at some point.