### PR TITLE
Support customized query string arguments during pagination

### DIFF
--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -21,6 +21,10 @@ from microcosm_flask.paging import Page, PaginatedList, make_paginated_list_sche
 
 class CRUDConvention(Convention):
 
+    @property
+    def page_cls(self):
+        return Page
+
     def configure_search(self, ns, definition):
         """
         Register a search endpoint.
@@ -43,7 +47,7 @@ class CRUDConvention(Convention):
         @response(paginated_list_schema)
         def search(**path_data):
             request_data = load_query_string_data(definition.request_schema)
-            page = Page.from_query_string(request_data)
+            page = self.page_cls.from_query_string(request_data)
             return_value = definition.func(**merge_data(path_data, request_data))
 
             if len(return_value) == 3:

--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -9,7 +9,6 @@ from microcosm_flask.conventions.encoding import (
     dump_response_data,
     load_query_string_data,
     load_request_data,
-    make_response,
     merge_data,
     require_response_data,
 )
@@ -56,9 +55,16 @@ class CRUDConvention(Convention):
                 context = {}
                 items, count = return_value
 
-            # TODO: use the schema for encoding
-            response_data = PaginatedList(ns, page, items, count, definition.response_schema, **context).to_dict()
-            return make_response(response_data)
+            response_data = PaginatedList(
+                ns=ns,
+                page=page,
+                items=items,
+                count=count,
+                schema=definition.response_schema,
+                operation=Operation.Search,
+                **context
+            )
+            return dump_response_data(paginated_list_schema, response_data)
 
         search.__doc__ = "Search the collection of all {}".format(pluralize(ns.subject_name))
 

--- a/microcosm_flask/conventions/relation.py
+++ b/microcosm_flask/conventions/relation.py
@@ -13,7 +13,6 @@ from microcosm_flask.conventions.encoding import (
     dump_response_data,
     load_query_string_data,
     load_request_data,
-    make_response,
     merge_data,
 )
 from microcosm_flask.conventions.registry import qs, request, response
@@ -129,17 +128,16 @@ class RelationConvention(Convention):
             page = Page.from_query_string(request_data)
             items, count, context = definition.func(**merge_data(path_data, request_data))
 
-            # TODO: use the schema for encoding
             response_data = self.paginated_list_class(
-                ns,
-                page,
-                items,
-                count,
-                definition.response_schema,
-                Operation.SearchFor,
+                ns=ns,
+                page=page,
+                items=items,
+                count=count,
+                schema=definition.response_schema,
+                operation=Operation.SearchFor,
                 **context
-            ).to_dict()
-            return make_response(response_data)
+            )
+            return dump_response_data(paginated_list_schema, response_data)
 
         search.__doc__ = "Search for {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
 

--- a/microcosm_flask/paging.py
+++ b/microcosm_flask/paging.py
@@ -35,9 +35,11 @@ def make_paginated_list_schema(ns, item_schema):
 
 
 class Page(object):
-    def __init__(self, offset, limit):
+
+    def __init__(self, offset, limit, **rest):
         self.offset = offset
         self.limit = limit
+        self.rest = rest
 
     @classmethod
     def from_query_string(cls, qs):
@@ -56,12 +58,14 @@ class Page(object):
         return Page(
             offset=self.offset + self.limit,
             limit=self.limit,
+            **self.rest
         )
 
     def prev(self):
         return Page(
             offset=self.offset - self.limit,
             limit=self.limit,
+            **self.rest
         )
 
     def to_dict(self):
@@ -75,6 +79,9 @@ class Page(object):
         return [
             ("offset", self.offset),
             ("limit", self.limit),
+        ] + [
+            (key, self.rest[key])
+            for key in sorted(self.rest.keys())
         ]
 
 

--- a/microcosm_flask/tests/test_paging.py
+++ b/microcosm_flask/tests/test_paging.py
@@ -122,25 +122,13 @@ def test_custom_paginated_list():
     graph = create_object_graph(name="example", testing=True)
     ns = Namespace(subject="foo", object_="bar")
 
-    class CustomPage(Page):
-        @classmethod
-        def from_query_string(cls, qs):
-            dct = qs.copy()
-            offset = dct.pop("offset")
-            limit = dct.pop("limit")
-            return cls(
-                offset=offset,
-                limit=limit,
-                **dct
-            )
-
     @graph.route(ns.relation_path, Operation.SearchFor, ns)
     def search_foo():
         pass
 
     paginated_list = PaginatedList(
         ns,
-        CustomPage.from_query_string(dict(offset=2, limit=2, baz="baz")),
+        Page.from_query_string(dict(offset=2, limit=2, baz="baz")),
         ["1", "2"],
         10,
         operation=Operation.SearchFor,


### PR DESCRIPTION
If we have a filtered search operation, our paging doesn't automatically include the filter parameters we started with; this results in useless next/prev links.

This generalizes the paging to accept further arguments. It's a first pass with some obvious improvements, but I wanted feedback before finishing.