### PR TITLE
Supporting keeping individual instance path URIs for bulk import

### DIFF
--- a/microcosm_flask/sync/main.py
+++ b/microcosm_flask/sync/main.py
@@ -58,6 +58,11 @@ def parse_args():
         help="Batch size (requires backend PATCH support if >1)",
     )
     parser.add_argument(
+        "--keep-instance-path",
+        action="store_true",
+        help="Keep the individual instance URI path when using the bulk import (PATCH) API. Used along with --batch-size.",  # noqa:E501
+    )
+    parser.add_argument(
         "--enable-sessions",
         action="store_true",
     )


### PR DESCRIPTION
Currently, the batch import mode for sync-resources (when using --batch-size) will default to truncate the individual instances URIs, assuming a top-level 'collection' resource to exist one level above individual instances URIs.

For cases where the instances themselves are however exported in batch and do not have a standard per-instance URI, e.g when exporting from a single /api/v1/data URI, this breaks.

This PR adds a simple flag to support keeping the individiual instance URIs (up to query parameter) when batch importing back into the service.