### PR TITLE
force strict validation for list resources

### DIFF
--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -39,7 +39,7 @@ class CRUDConvention(Convention):
         :param definition: the endpoint definition
 
         """
-        paginated_list_schema = make_paginated_list_schema(ns, definition.response_schema)()
+        paginated_list_schema = make_paginated_list_schema(ns, definition.response_schema)(strict=True)
 
         @self.graph.route(ns.collection_path, Operation.Search, ns)
         @qs(definition.request_schema)

--- a/microcosm_flask/paging.py
+++ b/microcosm_flask/paging.py
@@ -29,7 +29,6 @@ def make_paginated_list_schema(ns, item_schema):
         limit = fields.Integer(required=True)
         count = fields.Integer(required=True)
         items = fields.List(fields.Nested(item_schema), required=True)
-        strict = True
         _links = fields.Raw()
 
     return PaginatedListSchema

--- a/microcosm_flask/paging.py
+++ b/microcosm_flask/paging.py
@@ -29,6 +29,7 @@ def make_paginated_list_schema(ns, item_schema):
         limit = fields.Integer(required=True)
         count = fields.Integer(required=True)
         items = fields.List(fields.Nested(item_schema), required=True)
+        strict = True
         _links = fields.Raw()
 
     return PaginatedListSchema


### PR DESCRIPTION
I wasted a lot of time debugging a validation error on a child resource of a list resource which failed to serialize properly and caused marshmallow to do weird things. We aren't using strict validation on our list resources which means when validation fails for an `item` on a paginated list, rather than raise an exception, marshmallow will just proceed like nothing happened and return an invalid resource.