### PR TITLE
default Content-Type header in response as application/json

### DIFF
--- a/microcosm_flask/conventions/encoding.py
+++ b/microcosm_flask/conventions/encoding.py
@@ -89,8 +89,13 @@ def make_response(response_data, status_code=200, headers=None):
         # swagger does not currently support null values; remove these conditionally
         response_data = remove_null_values(response_data)
 
+    headers = headers or {}
+    if "Content-Type" not in headers:
+        # Specify JSON as the response content type by default
+        headers["Content-Type"] = "application/json"
+
     response = jsonify(response_data)
-    response.headers = Headers(headers or {})
+    response.headers = Headers(headers)
     response.status_code = status_code
     return response
 


### PR DESCRIPTION
This adds setting default 'Content-Type' header for all responses as "application/json".
This is helpful especially when using things like Postman for manual API calls so that it uses the richer JSON view display for response