### PR TITLE
Query String usage in Namespace.href_for

### DIFF
--- a/microcosm_flask/namespaces.py
+++ b/microcosm_flask/namespaces.py
@@ -152,9 +152,12 @@ class Namespace(object):
         :parm qs: the query string dictionary, if any
         :param kwargs: additional arguments for path expansion
         """
+        url = urljoin(request.url_root, self.url_for(operation, **kwargs))
+        qs_character = "?" if url.find("?") == -1 else "&"
+
         return "{}{}".format(
-            urljoin(request.url_root, self.url_for(operation, **kwargs)),
-            "?{}".format(urlencode(qs)) if qs else "",
+            url,
+            "{}{}".format(qs_character, urlencode(qs)) if qs else "",
         )
 
     @classmethod

--- a/microcosm_flask/tests/matchers.py
+++ b/microcosm_flask/tests/matchers.py
@@ -1,0 +1,30 @@
+"""
+Hamcrest custom matchers used by unit-tests.
+
+"""
+from hamcrest.core.base_matcher import BaseMatcher
+from urltools import normalize
+
+
+class URLMatcher(BaseMatcher):
+    """
+    Hamcrest matcher for comparing URLs by canonicalizing them first.
+
+    Example:
+
+        with graph.app.test_request_context():
+           assert_that(url, matches_url("https://canonical.url.com/path?a=1&b=2"))
+
+    """
+    def __init__(self, url):
+        self.url = url
+
+    def _matches(self, item):
+        return normalize(item) == normalize(self.url)
+
+    def describe_to(self, description):
+        description.append_text("expected URL: {}".format(self.url))
+
+
+def matches_url(url):
+    return URLMatcher(url)

--- a/microcosm_flask/tests/matchers.py
+++ b/microcosm_flask/tests/matchers.py
@@ -3,6 +3,7 @@ Hamcrest custom matchers used by unit-tests.
 
 """
 from hamcrest.core.base_matcher import BaseMatcher
+from six import string_types
 from urltools import normalize
 
 
@@ -20,6 +21,9 @@ class URLMatcher(BaseMatcher):
         self.url = url
 
     def _matches(self, item):
+        if not isinstance(item, string_types):
+            return False
+
         return normalize(item) == normalize(self.url)
 
     def describe_to(self, description):

--- a/microcosm_flask/tests/test_namespaces.py
+++ b/microcosm_flask/tests/test_namespaces.py
@@ -13,6 +13,7 @@ from mock import Mock
 from microcosm.api import create_object_graph
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
+from microcosm_flask.tests.matchers import matches_url
 
 
 def test_endpoint_for():
@@ -118,6 +119,24 @@ def test_operation_href_for():
     with graph.app.test_request_context():
         url = ns.href_for(Operation.Search)
         assert_that(url, is_(equal_to("http://localhost/api/foo")))
+
+
+def test_operation_href_for_qs():
+    """
+    Operations can resolve themselves as fully expanded hrefs with
+    custom query string parameter.
+
+    """
+    graph = create_object_graph(name="example", testing=True)
+    ns = Namespace(subject="foo")
+
+    @graph.route(ns.collection_path, Operation.Search, ns)
+    def search_foo():
+        pass
+
+    with graph.app.test_request_context():
+        url = ns.href_for(Operation.Search, offset=0, limit=10, qs=dict(foo="bar"))
+        assert_that(url, matches_url("http://localhost/api/foo?offset=0&limit=10&foo=bar"))
 
 
 def test_namespace_accepts_controller():

--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,6 @@ setup(
         "coverage>=3.7.1",
         "mock>=1.0.1",
         "PyHamcrest>=1.8.5",
+        "urltools>=0.3.2",
     ],
 )


### PR DESCRIPTION
This PR modifies the Namespace.href_for code to choose query string connector character when constructing namespace href by looking at whether other qs arguments are present.