### PR TITLE
Log request resources when a batch import fails

### DIFF
--- a/microcosm_flask/sync/push.py
+++ b/microcosm_flask/sync/push.py
@@ -152,8 +152,9 @@ def push_resource_json_batch(session, uri, resources):
     try:
         response.raise_for_status()
     except:
-        logger.warn("Unable to replace {}".format(
+        logger.warn("Unable to replace {}, batch: {}".format(
             uri,
+            resources,
         ))
         raise
 


### PR DESCRIPTION
When using the batch import (PATCH) API, a failure will only log the URI, which is of little use.
This adds the current batch to the log - while it's pretty long, it's very useful for debugging.

Open to suggestions on better formatting etc.