### PR TITLE
Improve support for allow_none

### DIFF
--- a/microcosm_flask/conventions/encoding.py
+++ b/microcosm_flask/conventions/encoding.py
@@ -56,18 +56,6 @@ def load_query_string_data(request_schema):
     return request_data.data
 
 
-def remove_null_values(data):
-    if isinstance(data, dict):
-        return {
-            key: remove_null_values(value)
-            for key, value in data.items()
-            if value is not None
-        }
-    if type(data) in (list, tuple):
-        return type(data)(map(remove_null_values, data))
-    return data
-
-
 def dump_response_data(response_schema, response_data, status_code=200, headers=None):
     """
     Dumps response data as JSON using the given schema.
@@ -85,10 +73,6 @@ def dump_response_data(response_schema, response_data, status_code=200, headers=
 
 
 def make_response(response_data, status_code=200, headers=None):
-    if request.headers.get("X-Response-Skip-Null"):
-        # swagger does not currently support null values; remove these conditionally
-        response_data = remove_null_values(response_data)
-
     headers = headers or {}
     if "Content-Type" not in headers:
         # Specify JSON as the response content type by default

--- a/microcosm_flask/swagger/definitions.py
+++ b/microcosm_flask/swagger/definitions.py
@@ -190,11 +190,6 @@ def build_operation(operation, ns, rule, func):
         tags=[ns.subject_name],
     )
 
-    # custom header parameter
-    swagger_operation.parameters.append(
-        header_param("X-Response-Skip-Null")
-    )
-
     # path parameters
     swagger_operation.parameters.extend([
         # TODO: inject type information for parameters based on converter syntax

--- a/microcosm_flask/swagger/schema.py
+++ b/microcosm_flask/swagger/schema.py
@@ -122,6 +122,12 @@ def build_parameter(field):
     if isinstance(field, fields.List):
         parameter["items"] = build_parameter(field.container)
 
+    if field.allow_none:
+        # XXX Update to new name when we switch to next version of OpenAPI
+        # spec
+        # See https://github.com/OAI/OpenAPI-Specification/pull/741
+        parameter["x-nullable"] = True
+
     return parameter
 
 
@@ -134,7 +140,7 @@ def build_schema(marshmallow_schema):
     required_fields = [
         field.dump_to or name
         for name, field in fields
-        if field.required and not field.allow_none
+        if field.required
     ]
     schema = {
         "type": "object",

--- a/microcosm_flask/tests/conventions/test_command.py
+++ b/microcosm_flask/tests/conventions/test_command.py
@@ -119,12 +119,6 @@ class TestCommand(object):
                     },
                     "parameters": [
                         {
-                            "in": "header",
-                            "name": "X-Response-Skip-Null",
-                            "required": False,
-                            "type": "string",
-                        },
-                        {
                             "schema": {
                                 "$ref": "#/definitions/CommandArgument",
                             },

--- a/microcosm_flask/tests/conventions/test_query.py
+++ b/microcosm_flask/tests/conventions/test_query.py
@@ -118,12 +118,6 @@ class TestQuery(object):
                     },
                     "parameters": [
                         {
-                            "in": "header",
-                            "name": "X-Response-Skip-Null",
-                            "required": False,
-                            "type": "string",
-                        },
-                        {
                             "required": False,
                             "type": "string",
                             "name": "value",

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -70,12 +70,6 @@ def test_build_swagger():
                     },
                     "parameters": [
                         {
-                            "in": "header",
-                            "name": "X-Response-Skip-Null",
-                            "required": False,
-                            "type": "string",
-                        },
-                        {
                             "in": "body",
                             "name": "body",
                             "schema": {
@@ -104,12 +98,6 @@ def test_build_swagger():
                         },
                     },
                     "parameters": [
-                        {
-                            "required": False,
-                            "type": "string",
-                            "name": "X-Response-Skip-Null",
-                            "in": "header",
-                        },
                         {
                             "required": True,
                             "type": "string",

--- a/microcosm_flask/tests/swagger/test_schema.py
+++ b/microcosm_flask/tests/swagger/test_schema.py
@@ -5,6 +5,7 @@ Test JSON Schema generation.
 from hamcrest import (
     assert_that,
     equal_to,
+    has_entries,
     is_,
 )
 
@@ -30,6 +31,7 @@ class ValueType(IntEnum):
 class TestSchema(Schema):
     id = fields.UUID()
     foo = fields.String(description="Foo", default="bar")
+    bar = fields.String(allow_none=True, required=True)
     choice = EnumField(Choices)
     value = EnumField(ValueType, by_value=True)
     names = fields.List(fields.String)
@@ -125,6 +127,18 @@ def test_field_dict():
     assert_that(parameter, is_(equal_to({
         "type": "object",
     })))
+
+
+def test_field_allow_none():
+    parameter = build_parameter(TestSchema().fields["bar"])
+    schema = build_schema(TestSchema())
+    assert_that(parameter, is_(equal_to({
+        "type": "string",
+        "x-nullable": True,
+    })))
+    assert_that(schema, has_entries(
+        required=["bar"]
+    ))
 
 
 def test_field_nested():


### PR DESCRIPTION
Switch to using `'x-nullable': true` for marshmallow fields that have `allow_none=True`.  This field is not part of the official spec, but seems to be the currently accepted workaround, and it is supported by [bravado](https://github.com/Yelp/bravado-core/).  