### PR TITLE
Hack to fix error reporting

### DIFF
--- a/microcosm_flask/errors.py
+++ b/microcosm_flask/errors.py
@@ -125,7 +125,7 @@ def make_json_error(error):
     # Serialize into JSON response
     response_data = {
         "code": status_code,
-        "context": context,
+        "context": str(context),
         "message": message,
         "retryable": retryable,
     }


### PR DESCRIPTION
When an error is raised, microcosm flask tries to serialize the error context to json to send to the client.  However, the error context cannot be serialized to json.  This hack just converts the error context to a string.  This at least allows the server to send something coherent in the case of an error, but there are probably a lot better ways to handle this, potentially even by just getting rid of the context.  Another option would be to serialize its stack trace instead.