### PR TITLE
Add Alias operation to redirect to a resource Retrieve endpoint

### DIFF
--- a/microcosm_flask/conventions/alias.py
+++ b/microcosm_flask/conventions/alias.py
@@ -1,0 +1,47 @@
+"""
+Conventions for aliasing endpoints.
+
+"""
+from flask import redirect
+from microcosm_flask.conventions.base import Convention
+from microcosm_flask.naming import name_for
+from microcosm_flask.operations import Operation
+
+
+class AliasConvention(Convention):
+
+    def configure_alias(self, ns, definition):
+        """
+        Register an alias endpoint which will redirect to a resource's retrieve endpoint.
+
+        Note that the retrieve endpoint MUST be registered prior to the alias endpoint.
+
+        The definition's func should be a retrieve function, which must:
+        - accept kwargs for path data
+        - return a resource
+
+        :param ns: the namespace
+        :param definition: the endpoint definition
+
+        """
+        @self.graph.route(ns.alias_path, Operation.Alias, ns)
+        def retrieve(**path_data):
+            resource = definition.func(**path_data)
+
+            kwargs = dict()
+            identifier = "{}_id".format(name_for(ns.subject))
+            kwargs[identifier] = resource.id
+            url = ns.url_for(Operation.Retrieve, **kwargs)
+
+            return redirect(url)
+
+        retrieve.__doc__ = "Alias a {} by name".format(ns.subject_name)
+
+
+def configure_alias(graph, ns, mappings):
+    """
+    Register Alias endpoints for a resource object.
+
+    """
+    convention = AliasConvention(graph)
+    convention.configure(ns, mappings)

--- a/microcosm_flask/conventions/base.py
+++ b/microcosm_flask/conventions/base.py
@@ -49,7 +49,6 @@ class Convention(object):
         mappings.update(kwargs)
 
         for operation, definition in mappings.items():
-
             try:
                 configure_func = self._find_func(operation)
             except AttributeError:

--- a/microcosm_flask/namespaces.py
+++ b/microcosm_flask/namespaces.py
@@ -12,6 +12,7 @@ from six.moves.urllib.parse import urlencode, urljoin
 from werkzeug.exceptions import InternalServerError
 
 from microcosm_flask.naming import (
+    alias_path_for,
     collection_path_for,
     instance_path_for,
     name_for,
@@ -91,6 +92,10 @@ class Namespace(object):
     @property
     def instance_path(self):
         return self.path + instance_path_for(self.subject)
+
+    @property
+    def alias_path(self):
+        return self.path + alias_path_for(self.subject)
 
     @property
     def relation_path(self):

--- a/microcosm_flask/naming.py
+++ b/microcosm_flask/naming.py
@@ -57,6 +57,17 @@ def instance_path_for(name):
     )
 
 
+def alias_path_for(name):
+    """
+    Get a path for an alias to a thing
+
+    """
+    return "/{}/<{}_name>".format(
+        name_for(name),
+        name_for(name),
+    )
+
+
 def relation_path_for(from_name, to_name):
     """
     Get a path relating a thing to another.

--- a/microcosm_flask/operations.py
+++ b/microcosm_flask/operations.py
@@ -39,6 +39,7 @@ class Operation(Enum):
     Delete = OperationInfo("delete", "DELETE", NODE_PATTERN, 204)
     Replace = OperationInfo("replace", "PUT", NODE_PATTERN, 200)
     Update = OperationInfo("update", "PATCH", NODE_PATTERN, 200)
+    Alias = OperationInfo("alias", "GET", NODE_PATTERN, 302)
 
     # relation operations
     CreateFor = OperationInfo("create_for", "POST", EDGE_PATTERN, 201)

--- a/microcosm_flask/swagger/definitions.py
+++ b/microcosm_flask/swagger/definitions.py
@@ -18,6 +18,7 @@ Note that:
 """
 from logging import getLogger
 from six import string_types
+from six.moves.urllib.parse import unquote
 from werkzeug.routing import BuildError
 
 from openapi import model as swagger
@@ -121,11 +122,13 @@ def build_path(operation, ns):
     try:
         return ns.url_for(operation, _external=False)
     except BuildError as error:
+        # we are missing some URI path parameters
         uri_templates = {
             argument: "{{{}}}".format(argument)
             for argument in error.suggested.arguments
         }
-        return ns.url_for(operation, _external=False, **uri_templates)
+        # flask will sometimes try to quote '{' and '}' characters
+        return unquote(ns.url_for(operation, _external=False, **uri_templates))
 
 
 def body_param(schema):

--- a/microcosm_flask/tests/conventions/test_alias.py
+++ b/microcosm_flask/tests/conventions/test_alias.py
@@ -1,0 +1,69 @@
+"""
+Health check convention tests.
+
+"""
+from hamcrest import (
+    assert_that,
+    equal_to,
+    is_,
+)
+
+from microcosm.api import create_object_graph
+
+from microcosm_flask.namespaces import Namespace
+from microcosm_flask.conventions.alias import configure_alias
+from microcosm_flask.conventions.base import EndpointDefinition
+from microcosm_flask.conventions.crud import configure_crud
+from microcosm_flask.operations import Operation
+from microcosm_flask.swagger.definitions import build_path
+from microcosm_flask.tests.conventions.fixtures import (
+    Person,
+)
+
+
+PERSON = Person(id=1, first_name="First", last_name="Last")
+
+
+def find_person_by_name(person_name):
+    return PERSON
+
+
+def find_person(person_id):
+    return PERSON
+
+
+PERSON_MAPPINGS = {
+    Operation.Alias: EndpointDefinition(
+        func=find_person_by_name,
+    ),
+    Operation.Retrieve: EndpointDefinition(
+        func=find_person,
+    ),
+}
+
+
+class TestAlias(object):
+
+    def setup(self):
+        self.graph = create_object_graph(name="example", testing=True)
+
+        self.ns = Namespace(subject=Person)
+        configure_crud(self.graph, self.ns, PERSON_MAPPINGS)
+        configure_alias(self.graph, self.ns, PERSON_MAPPINGS)
+
+        self.client = self.graph.flask.test_client()
+
+    def test_url_for(self):
+        with self.graph.app.test_request_context():
+            url = self.ns.url_for(Operation.Alias, person_name="foo")
+        assert_that(url, is_(equal_to("http://localhost/api/person/foo")))
+
+    def test_swagger_path(self):
+        with self.graph.app.test_request_context():
+            path = build_path(Operation.Alias, self.ns)
+        assert_that(path, is_(equal_to("/api/person/{person_name}")))
+
+    def test_alias(self):
+        response = self.client.get("/api/person/foo")
+        assert_that(response.status_code, is_(equal_to(302)))
+        assert_that(response.headers["Location"], is_(equal_to("http://localhost/api/person/1")))


### PR DESCRIPTION
This convention allows for "vanity" URLs that alias UUID-based resources using a human-
readable name (as long as the name is valid as part of the URL path).

A mapping for an Alias operation supports a `GET` based request with a path parameter
of the form `foo_name`. The mapping function is expected to return a valid resource
(or raise `NotFound`); the convention will issue a redirect to the target resource.