### PR TITLE
Allow the default pagination limit to be set by the requester.

### DIFF
--- a/microcosm_flask/paging.py
+++ b/microcosm_flask/paging.py
@@ -48,7 +48,10 @@ class Page(object):
 
     @property
     def default_limit(self):
-        return request.headers.get("X-Request-Limit", 20)
+        try:
+            return int(request.headers["X-Request-Limit"])
+        except:
+            return 20
 
     @classmethod
     def from_query_string(cls, qs):

--- a/microcosm_flask/paging.py
+++ b/microcosm_flask/paging.py
@@ -2,6 +2,7 @@
 Pagination support.
 
 """
+from flask import request
 from marshmallow import fields, Schema
 
 from microcosm_flask.linking import Link, Links
@@ -9,8 +10,8 @@ from microcosm_flask.operations import Operation
 
 
 class PageSchema(Schema):
-    offset = fields.Integer(missing=0, default=0)
-    limit = fields.Integer(missing=20, limit=20)
+    offset = fields.Integer(missing=None)
+    limit = fields.Integer(missing=None)
 
 
 def make_paginated_list_schema(ns, item_schema):
@@ -36,10 +37,18 @@ def make_paginated_list_schema(ns, item_schema):
 
 class Page(object):
 
-    def __init__(self, offset, limit, **rest):
-        self.offset = offset
-        self.limit = limit
+    def __init__(self, offset=None, limit=None, **rest):
+        self.offset = self.default_offset if offset is None else offset
+        self.limit = self.default_limit if limit is None else limit
         self.rest = rest
+
+    @property
+    def default_offset(self):
+        return 0
+
+    @property
+    def default_limit(self):
+        return request.headers.get("X-Request-Limit", 20)
 
     @classmethod
     def from_query_string(cls, qs):

--- a/microcosm_flask/tests/test_paging.py
+++ b/microcosm_flask/tests/test_paging.py
@@ -28,6 +28,18 @@ def test_page_from_query_string():
         assert_that(page.limit, is_(equal_to(20)))
 
 
+def test_page_defaults():
+    graph = create_object_graph(name="example", testing=True)
+
+    with graph.flask.test_request_context():
+        page = Page()
+
+    assert_that(page.to_dict(), is_(equal_to({
+        "offset": 0,
+        "limit": 20
+    })))
+
+
 def test_page_to_dict():
     page = Page(0, 10)
     assert_that(page.to_dict(), is_(equal_to({


### PR DESCRIPTION
There doesn't seem to be any standard way to control the pagination limit
from the client side. The `Range` header is promising, but seems geared
toward bytes-oriented and token-based pagination. Invention a custom range
type doesn't seem better than using a custom header.