### PR TITLE
Add decorators to help manage what fields we log in our audit logs.

### DIFF
--- a/microcosm_flask/audit.py
+++ b/microcosm_flask/audit.py
@@ -134,6 +134,13 @@ def _audit_request(options, func, request_context, *args, **kwargs):  # noqa: C9
         # determine whether to show/hide body based on the g values set during func
         if not g.get("hide_body"):
             if request_body:
+                for name, new_name in g.get("show_request_fields", {}).items():
+                    try:
+                        value = request_body.pop(name)
+                        request_body[new_name] = value
+                    except KeyError:
+                        pass
+                    pass
                 for field in g.get("hide_request_fields", []):
                     try:
                         del request_body[field]
@@ -142,6 +149,13 @@ def _audit_request(options, func, request_context, *args, **kwargs):  # noqa: C9
                 audit_dict["request_body"] = request_body
 
             if response_body:
+                for name, new_name in g.get("show_response_fields", {}).items():
+                    try:
+                        value = response_body.pop(name)
+                        response_body[new_name] = value
+                    except KeyError:
+                        pass
+                    pass
                 for field in g.get("hide_response_fields", []):
                     try:
                         del response_body[field]

--- a/microcosm_flask/decorators/logging.py
+++ b/microcosm_flask/decorators/logging.py
@@ -1,0 +1,49 @@
+"""
+Audit log control decorators.
+
+"""
+from functools import wraps
+
+from flask import g
+
+
+def hide(*keys):
+    """
+    Hide a set of request and/or response fields from logs.
+
+    Example:
+
+        @hide("id")
+        def create_foo():
+            return Foo(id=uuid4())
+
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            g.hide_request_fields = keys
+            g.hide_response_fields = keys
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
+def show_as(**mappings):
+    """
+    Show a set of request and/or response fields in logs using a different key.
+
+    Example:
+
+        @show_as(id="foo_id")
+        def create_foo():
+            return Foo(id=uuid4())
+
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            g.show_request_fields = mappings
+            g.show_response_fields = mappings
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator


### PR DESCRIPTION
Note that we currently suppress all request/response data in our logs
unless we're running in debug. The next step here would be to revisit
the audit log code to allow *some* request/response data based on this
or similar logic.