### PR TITLE
Fix offset and limit defaults for page resources.

### DIFF
--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -47,7 +47,7 @@ class CRUDConvention(Convention):
         def search(**path_data):
             request_data = load_query_string_data(definition.request_schema)
             page = self.page_cls.from_query_string(request_data)
-            return_value = definition.func(**merge_data(path_data, request_data))
+            return_value = definition.func(**merge_data(path_data, page.to_dict()))
 
             if len(return_value) == 3:
                 items, count, context = return_value

--- a/microcosm_flask/tests/test_paging.py
+++ b/microcosm_flask/tests/test_paging.py
@@ -39,6 +39,16 @@ def test_page_defaults():
         "limit": 20
     })))
 
+def test_page_defaults_with_page_schema():
+    graph = create_object_graph(name="example", testing=True)
+
+    with graph.flask.test_request_context():
+        page = Page.from_query_string(PageSchema().load({}).data)
+
+    assert_that(page.to_dict(), is_(equal_to({
+        "offset": 0,
+        "limit": 20
+    })))
 
 def test_page_to_dict():
     page = Page(0, 10)

--- a/microcosm_flask/tests/test_paging.py
+++ b/microcosm_flask/tests/test_paging.py
@@ -39,6 +39,7 @@ def test_page_defaults():
         "limit": 20
     })))
 
+
 def test_page_defaults_with_page_schema():
     graph = create_object_graph(name="example", testing=True)
 
@@ -49,6 +50,7 @@ def test_page_defaults_with_page_schema():
         "offset": 0,
         "limit": 20
     })))
+
 
 def test_page_to_dict():
     page = Page(0, 10)


### PR DESCRIPTION
Why? In: 6b31a5228339324c9d392de97f7ab8b5f1e60508 we moved offset and
limit defaulting from the PageSchema to the Page class, but we
don't call it properly when deserializing query results. This PR
leverages the Page resource to get query param defaulting.