### PR TITLE
Add format for decimal strings

### DIFF
--- a/microcosm_flask/swagger/schema.py
+++ b/microcosm_flask/swagger/schema.py
@@ -94,8 +94,11 @@ def build_parameter(field):
         parameter["format"] = field_format
     if field.default:
         parameter["default"] = field.default
+    # NB: all marshallow Number fields support as_string
     if getattr(field, 'as_string', None):
         parameter["type"] = "string"
+        if isinstance(field, fields.Decimal):
+            parameter["format"] = "decimal"
 
     # enums
     enum = getattr(field, "enum", None)

--- a/microcosm_flask/tests/swagger/test_schema.py
+++ b/microcosm_flask/tests/swagger/test_schema.py
@@ -117,6 +117,7 @@ def test_field_decimal_as_string():
     parameter = build_parameter(TestSchema().fields["decimalString"])
     assert_that(parameter, is_(equal_to({
         "type": "string",
+        "format": "decimal",
     })))
 
 


### PR DESCRIPTION
Adds the `"decimal"` format for any marshmallow `fields.Decimal` with `as_string=True`