### PR TITLE
Fix paging attempt #2

### DIFF
--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -47,7 +47,7 @@ class CRUDConvention(Convention):
         def search(**path_data):
             request_data = load_query_string_data(definition.request_schema)
             page = self.page_cls.from_query_string(request_data)
-            return_value = definition.func(**merge_data(path_data, page.to_dict()))
+            return_value = definition.func(**merge_data(path_data, page.to_dict(as_str=False)))
 
             if len(return_value) == 3:
                 items, count, context = return_value


### PR DESCRIPTION
This is an attempt to fix paging following recent regressions.

Roughly, my understanding of whats happening is something like:

* We moved bunch of code (specifically defaulting offset/limit values) from PageSchema to Paging
* This involved changing code to use paging.to_dict() instead of raw request_data in the search API convention
* This had undesired side-effect since Paging.to_dict casts everything to string - this cast is valid in context of generating JSON response, but not in context of passing the parsed request data to the Search method
* My previous PR #100 did not account for this dual usage

This PR attempts to solve the issue by explicitly forking the usage using a new `as_str` parameter that can be passed to Paging.to_dict() - it's set to True for when using as part of PagingList to serialize results, and set to False when using for parsing results and passing to `search` method.

See also: https://globalityinc.slack.com/archives/dev-backend/p1486572906001121