### PR TITLE
Add a count convention

### DIFF
--- a/microcosm_flask/conventions/crud_adapter.py
+++ b/microcosm_flask/conventions/crud_adapter.py
@@ -42,6 +42,10 @@ class CRUDStoreAdapter(object):
         count = self.store.count(**kwargs)
         return items, count
 
+    def count(self, offset=None, limit=None, **kwargs):
+        count = self.store.count(**kwargs)
+        return count
+
     def update(self, **kwargs):
         identifier = kwargs.pop(self.identifier_key)
         model = self.store.model_class(id=identifier, **kwargs)

--- a/microcosm_flask/conventions/encoding.py
+++ b/microcosm_flask/conventions/encoding.py
@@ -17,6 +17,12 @@ def with_context(error, errors):
     return error
 
 
+def encode_count_header(count):
+    return {
+        "X-Total-Count": count,
+    }
+
+
 def load_request_data(request_schema, partial=False):
     """
     Load request data as JSON using the given schema.

--- a/microcosm_flask/operations.py
+++ b/microcosm_flask/operations.py
@@ -31,6 +31,7 @@ class Operation(Enum):
 
     # collection operations
     Search = OperationInfo("search", "GET", NODE_PATTERN, 200)
+    Count = OperationInfo("count", "HEAD", NODE_PATTERN, 200)
     Create = OperationInfo("create", "POST", NODE_PATTERN, 201)
     UpdateBatch = OperationInfo("update_batch", "PATCH", NODE_PATTERN, 200)
 

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -104,6 +104,12 @@ class TestCrud(object):
             }
         })
 
+    def test_count(self):
+        uri = "/api/person"
+        response = self.client.head(uri)
+        assert_that(response.status_code, is_(equal_to(200)))
+        assert_that(response.headers["X-Total-Count"], is_(equal_to(str(1))))
+
     def test_search_with_context(self):
         uri = "/api/person/{}/address".format(PERSON_ID_1)
         response = self.client.get(uri)


### PR DESCRIPTION
We often wish to query the number of things without returning results. While we can do
this easily with a `Search` and `limit=0`, it's also nice to use a dedicated endpoint.

Changes:
 -  Allow `HEAD /api/collection`
 -  Inject an `X-Total-Count` header for all search and count responses

To use, we just need to add something like:

```
        Operation.Count: EndpointDefinition(
            func=controller.count,
            request_schema=SearchFooSchema(),
        ),
```