### PR TITLE
Add Upload and UploadFor operations and conventions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ general:
 dependencies:
   override:
     - pip install tox tox-pyenv
-    - pyenv local 2.7.11 3.5.2  # Should correspond to pre-installed Python versions on CircleCI
+    - pyenv local 2.7.11 3.6.0  # Should correspond to pre-installed Python versions on CircleCI
 
 test:
   override:

--- a/microcosm_flask/conventions/swagger.py
+++ b/microcosm_flask/conventions/swagger.py
@@ -67,8 +67,11 @@ class SwaggerConvention(Convention):
         "search_for",
         "update",
         "update_batch",
+        "upload",
+        "upload_for",
     ],
     path_prefix="",
+    version="",
 )
 def configure_swagger(graph):
     """

--- a/microcosm_flask/conventions/upload.py
+++ b/microcosm_flask/conventions/upload.py
@@ -54,8 +54,10 @@ def temporary_upload(name, fileobj):
     filename = secure_filename(fileobj.filename)
     filepath = join(tempdir, filename)
     fileobj.save(filepath)
-    yield name, filepath, fileobj.filename
-    rmtree(tempdir)
+    try:
+        yield name, filepath, fileobj.filename
+    except:
+        rmtree(tempdir)
 
 
 class UploadConvention(Convention):

--- a/microcosm_flask/conventions/upload.py
+++ b/microcosm_flask/conventions/upload.py
@@ -2,7 +2,7 @@
 Conventions for file upload.
 
 """
-from contextlib import contextmanager, nested
+from contextlib import contextmanager
 from os.path import join
 from shutil import rmtree
 from tempfile import mkdtemp
@@ -19,6 +19,24 @@ from microcosm_flask.conventions.registry import qs, response
 from microcosm_flask.operations import Operation
 from werkzeug.exceptions import BadRequest
 from werkzeug.utils import secure_filename
+
+
+try:
+    # Python 2
+    from contextlib import nested
+except ImportError:
+    # Python3
+    from contextlib import ExitStack
+
+    @contextmanager
+    def nested(*contexts):
+        """
+        Reimplementation of nested in python 3.
+        """
+        with ExitStack() as stack:
+            for ctx in contexts:
+                stack.enter_context(ctx)
+            yield contexts
 
 
 @contextmanager

--- a/microcosm_flask/conventions/upload.py
+++ b/microcosm_flask/conventions/upload.py
@@ -1,0 +1,116 @@
+"""
+Conventions for file upload.
+
+"""
+from contextlib import contextmanager, nested
+from os.path import join
+from shutil import rmtree
+from tempfile import mkdtemp
+
+from flask import request
+from marshmallow import Schema
+from microcosm_flask.conventions.base import Convention
+from microcosm_flask.conventions.encoding import (
+    dump_response_data,
+    load_query_string_data,
+    merge_data,
+)
+from microcosm_flask.conventions.registry import qs, response
+from microcosm_flask.operations import Operation
+from werkzeug.exceptions import BadRequest
+from werkzeug.utils import secure_filename
+
+
+@contextmanager
+def temporary_upload(name, fileobj):
+    """
+    Upload a file to a temporary location.
+
+    Flask will not load sufficiently large (>500M) files into memory, so it
+    makes sense to always load files into a temporary directory.
+
+    """
+    tempdir = mkdtemp()
+    filename = secure_filename(fileobj.filename)
+    filepath = join(tempdir, filename)
+    fileobj.save(filepath)
+    yield name, filepath, fileobj.filename
+    rmtree(tempdir)
+
+
+class UploadConvention(Convention):
+
+    def __init__(self, graph, exclude_func=None):
+        self.graph = graph
+        self.exclude_func = exclude_func or (lambda name, fileobj: False)
+
+    def create_upload_func(self, ns, definition, path, operation):
+        request_schema = definition.request_schema or Schema()
+        response_schema = definition.response_schema or Schema()
+
+        @self.graph.route(path, operation, ns)
+        def upload(**path_data):
+            request_data = load_query_string_data(request_schema)
+
+            if not request.files:
+                raise BadRequest("No files were uploaded")
+
+            uploads = [
+                temporary_upload(name, fileobj)
+                for name, fileobj
+                in request.files.items()
+                if not self.exclude_func(name, fileobj)
+            ]
+            with nested(*uploads) as files:
+                response_data = definition.func(files, **merge_data(path_data, request_data))
+                if response_data is None:
+                    return "", 204
+
+            return dump_response_data(response_schema, response_data, operation.value.default_code)
+
+        if definition.request_schema:
+            upload = qs(definition.request_schema)(upload)
+        if definition.response_schema:
+            upload = response(definition.response_schema)(upload)
+        return upload
+
+    def configure_upload(self, ns, definition):
+        """
+        Register an upload endpoint.
+
+        The definition's func should be an upload function, which must:
+        - accept kwargs for path data and query string parameters
+        - accept a list of tuples of the form (formname, tempfilepath, filename)
+        - optionall return a resource
+
+        :param ns: the namespace
+        :param definition: the endpoint definition
+
+        """
+        upload = self.create_upload_func(ns, definition, ns.collection_path, Operation.Upload)
+        upload.__doc__ = "Upload a {}".format(ns.subject_name)
+
+    def configure_uploadfor(self, ns, definition):
+        """
+        Register an upload-for relation endpoint.
+
+        The definition's func should be an upload function, which must:
+        - accept kwargs for path data and query string parameters
+        - accept a list of tuples of the form (formname, tempfilepath, filename)
+        - optionall return a resource
+
+        :param ns: the namespace
+        :param definition: the endpoint definition
+
+        """
+        upload_for = self.create_upload_func(ns, definition, ns.relation_path, Operation.UploadFor)
+        upload_for.__doc__ = "Upload a {} for a {}".format(ns.subject_name, ns.object_name)
+
+
+def configure_upload(graph, ns, mappings, exclude_func=None):
+    """
+    Register Upload endpoints for a resource object.
+
+    """
+    convention = UploadConvention(graph, exclude_func)
+    convention.configure(ns, mappings)

--- a/microcosm_flask/conventions/upload.py
+++ b/microcosm_flask/conventions/upload.py
@@ -46,7 +46,7 @@ def temporary_upload(name, fileobj):
     """
     Upload a file to a temporary location.
 
-    Flask will not load sufficiently large (>500M) files into memory, so it
+    Flask will not load sufficiently large files into memory, so it
     makes sense to always load files into a temporary directory.
 
     """

--- a/microcosm_flask/conventions/upload.py
+++ b/microcosm_flask/conventions/upload.py
@@ -34,9 +34,11 @@ except ImportError:
         Reimplementation of nested in python 3.
         """
         with ExitStack() as stack:
-            for ctx in contexts:
-                stack.enter_context(ctx)
-            yield contexts
+            results = [
+                stack.enter_context(context)
+                for context in contexts
+            ]
+            yield results
 
 
 @contextmanager

--- a/microcosm_flask/operations.py
+++ b/microcosm_flask/operations.py
@@ -50,6 +50,10 @@ class Operation(Enum):
     SearchFor = OperationInfo("search_for", "GET", EDGE_PATTERN, 200)
     UpdateFor = OperationInfo("update_for", "PATCH", EDGE_PATTERN, 200)
 
+    # file upload operations
+    Upload = OperationInfo("upload", "POST", NODE_PATTERN, 200)
+    UploadFor = OperationInfo("upload_for", "POST", EDGE_PATTERN, 200)
+
     # ad hoc operations
     Command = OperationInfo("command", "POST", NODE_PATTERN, 200)
     Query = OperationInfo("query", "GET", NODE_PATTERN, 200)

--- a/microcosm_flask/swagger/definitions.py
+++ b/microcosm_flask/swagger/definitions.py
@@ -30,6 +30,7 @@ from microcosm_flask.conventions.registry import (
 )
 from microcosm_flask.errors import ErrorSchema, ErrorContextSchema, SubErrorSchema
 from microcosm_flask.naming import name_for
+from microcosm_flask.operations import Operation
 from microcosm_flask.routing import make_path
 from microcosm_flask.swagger.naming import operation_name, type_name
 from microcosm_flask.swagger.schema import build_parameter, iter_schemas
@@ -240,6 +241,11 @@ def add_responses(swagger_operation, operation, ns, func):
     else:
         description = "{} {}".format(operation.value.name, ns.subject_name)
 
+    if operation in (Operation.Upload, Operation.UploadFor):
+        swagger_operation.consumes = [
+            "multipart/form-data"
+        ]
+
     # resource request
     request_resource = get_request_schema(func)
     if isinstance(request_resource, string_types):
@@ -253,6 +259,10 @@ def add_responses(swagger_operation, operation, ns, func):
         if not hasattr(swagger_operation, "produces"):
             swagger_operation.produces = []
         swagger_operation.produces.append(response_resource)
+    elif not response_resource:
+        swagger_operation.responses["204"] = build_response(
+            description=description,
+        )
     else:
         swagger_operation.responses[str(operation.value.default_code)] = build_response(
             description=description,

--- a/microcosm_flask/tests/conventions/test_upload.py
+++ b/microcosm_flask/tests/conventions/test_upload.py
@@ -1,0 +1,169 @@
+"""
+Alias convention tests.
+
+"""
+from uuid import uuid4
+
+from hamcrest import (
+    all_of,
+    assert_that,
+    contains,
+    equal_to,
+    has_entry,
+    has_item,
+    has_key,
+    is_,
+    is_not,
+)
+from json import loads
+from marshmallow import fields, Schema
+from microcosm.api import create_object_graph
+from six import b, BytesIO
+
+from microcosm_flask.namespaces import Namespace
+from microcosm_flask.conventions.base import EndpointDefinition
+from microcosm_flask.conventions.swagger import configure_swagger
+from microcosm_flask.conventions.upload import configure_upload
+from microcosm_flask.operations import Operation
+from microcosm_flask.swagger.definitions import build_path
+from microcosm_flask.tests.conventions.fixtures import Person
+
+
+def upload_file(files, extra):
+    pass
+
+
+def upload_file_for(files, person_id):
+    return dict(
+        id=person_id,
+    )
+
+
+class FileExtraSchema(Schema):
+    extra = fields.String(missing="something")
+
+
+class FileResponseSchema(Schema):
+    id = fields.UUID(required=True)
+
+
+UPLOAD_MAPPINGS = {
+    Operation.Upload: EndpointDefinition(
+        func=upload_file,
+        request_schema=FileExtraSchema(),
+    ),
+}
+
+UPLOAD_FOR_MAPPINGS = {
+    Operation.UploadFor: EndpointDefinition(
+        func=upload_file_for,
+        response_schema=FileResponseSchema(),
+    ),
+}
+
+
+class TestUpload(object):
+
+    def setup(self):
+        self.graph = create_object_graph(name="example", testing=True)
+
+        self.ns = Namespace(subject="file")
+        self.relation_ns = Namespace(subject=Person, object_="file")
+        configure_upload(self.graph, self.ns, UPLOAD_MAPPINGS)
+        configure_upload(self.graph, self.relation_ns, UPLOAD_FOR_MAPPINGS)
+        configure_swagger(self.graph)
+
+        self.client = self.graph.flask.test_client()
+
+    def test_upload_url_for(self):
+        with self.graph.app.test_request_context():
+            url = self.ns.url_for(Operation.Upload)
+        assert_that(url, is_(equal_to("http://localhost/api/file")))
+
+    def test_upload_for_url_for(self):
+        with self.graph.app.test_request_context():
+            url = self.relation_ns.url_for(Operation.UploadFor, person_id=1)
+        assert_that(url, is_(equal_to("http://localhost/api/person/1/file")))
+
+    def test_upload_swagger_path(self):
+        with self.graph.app.test_request_context():
+            path = build_path(Operation.Upload, self.ns)
+        assert_that(path, is_(equal_to("/api/file")))
+
+    def test_upload_for_swagger_path(self):
+        with self.graph.app.test_request_context():
+            path = build_path(Operation.UploadFor, self.relation_ns)
+        assert_that(path, is_(equal_to("/api/person/{person_id}/file")))
+
+    def test_swagger(self):
+        response = self.client.get("/api/swagger")
+        assert_that(response.status_code, is_(equal_to(200)))
+        data = loads(response.data)
+
+        upload = data["paths"]["/file"]["post"]
+        upload_for = data["paths"]["/person/{person_id}/file"]["post"]
+
+        # both endpoints return form data
+        assert_that(
+            upload["consumes"],
+            contains("multipart/form-data"),
+        )
+        assert_that(
+            upload_for["consumes"],
+            contains("multipart/form-data"),
+        )
+
+        # one endpoint gets an extra query string parameter (and the other doesn't)
+        assert_that(
+            upload["parameters"],
+            has_item(
+                has_entry("name", "extra"),
+            ),
+        )
+        assert_that(
+            upload_for["parameters"],
+            has_item(
+                is_not(has_entry("name", "extra")),
+            ),
+        )
+
+        # one endpoint gets a custom response type (and the other doesn't)
+        assert_that(
+            upload["responses"],
+            all_of(
+                has_key("204"),
+                is_not(has_key("200")),
+                has_entry("204", is_not(has_key("schema"))),
+            ),
+        )
+        assert_that(
+            upload_for["responses"],
+            all_of(
+                has_key("200"),
+                is_not(has_key("204")),
+                has_entry("200", has_entry("schema", has_entry("$ref", "#/definitions/FileResponse"))),
+            ),
+        )
+
+    def test_upload(self):
+        response = self.client.post(
+            "/api/file",
+            data=dict(
+                file=(BytesIO(b("Hello World\n")), "hello.txt"),
+            ),
+        )
+        assert_that(response.status_code, is_(equal_to(204)))
+
+    def test_upload_for(self):
+        person_id = uuid4()
+        response = self.client.post(
+            "/api/person/{}/file".format(person_id),
+            data=dict(
+                file=(BytesIO(b("Hello World\n")), "hello.txt"),
+            ),
+        )
+        assert_that(response.status_code, is_(equal_to(200)))
+        response_data = loads(response.get_data().decode("utf-8"))
+        assert_that(response_data, is_(equal_to(dict(
+            id=str(person_id),
+        ))))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, lint
+envlist = py27, py36, lint
 
 [testenv]
 commands =


### PR DESCRIPTION
 -  Supports an upload handler
 -  Saves files safely to a temporary locaiton
 -  Sets consumes media type in swagger
 -  Supports query string and path arguments
 -  Supports no content or resource responses