### PR TITLE
Support alternate identifiers schemes (from uuid)

### DIFF
--- a/microcosm_flask/namespaces.py
+++ b/microcosm_flask/namespaces.py
@@ -33,15 +33,14 @@ class Namespace(object):
 
     """
 
-    def __init__(
-        self,
-        subject,
-        object_=None,
-        path=None,
-        controller=None,
-        version=None,
-        enable_basic_auth=False
-    ):
+    def __init__(self,
+                 subject,
+                 object_=None,
+                 path=None,
+                 controller=None,
+                 version=None,
+                 enable_basic_auth=False,
+                 identifier_type="uuid"):
         """
         :param subject: the target resource (or resource name) of this namespace
         :param object_: the subject resource (or resource name) of this namespace (e.g. for relations)
@@ -56,6 +55,7 @@ class Namespace(object):
         self.controller = controller
         self.version = version
         self.enable_basic_auth = enable_basic_auth
+        self.identifier_type = identifier_type
 
     @property
     def path(self):
@@ -91,7 +91,7 @@ class Namespace(object):
 
     @property
     def instance_path(self):
-        return self.path + instance_path_for(self.subject)
+        return self.path + instance_path_for(self.subject, self.identifier_type)
 
     @property
     def alias_path(self):
@@ -99,7 +99,7 @@ class Namespace(object):
 
     @property
     def relation_path(self):
-        return self.path + relation_path_for(self.subject, self.object_)
+        return self.path + relation_path_for(self.subject, self.object_, self.identifier_type)
 
     @property
     def singleton_path(self):

--- a/microcosm_flask/naming.py
+++ b/microcosm_flask/naming.py
@@ -46,13 +46,14 @@ def singleton_path_for(name):
     )
 
 
-def instance_path_for(name):
+def instance_path_for(name, identifier_type):
     """
     Get a path for thing.
 
     """
-    return "/{}/<uuid:{}_id>".format(
+    return "/{}/<{}:{}_id>".format(
         name_for(name),
+        identifier_type,
         name_for(name),
     )
 
@@ -68,13 +69,14 @@ def alias_path_for(name):
     )
 
 
-def relation_path_for(from_name, to_name):
+def relation_path_for(from_name, to_name, identifier_type):
     """
     Get a path relating a thing to another.
 
     """
-    return "/{}/<uuid:{}_id>/{}".format(
+    return "/{}/<{}:{}_id>/{}".format(
         name_for(from_name),
+        identifier_type,
         name_for(from_name),
         name_for(to_name),
     )

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -81,6 +81,7 @@ ADDRESS_ID_1 = uuid4()
 PERSON_ID_1 = uuid4()
 PERSON_ID_2 = uuid4()
 PERSON_1 = Person(PERSON_ID_1, "Alice", "Smith")
+PERSON_2 = Person(PERSON_ID_2, "Bob", "Jones")
 ADDRESS_1 = Address(ADDRESS_ID_1, PERSON_ID_1, "21 Acme St., San Francisco CA 94110")
 
 

--- a/microcosm_flask/tests/test_custom_identifier.py
+++ b/microcosm_flask/tests/test_custom_identifier.py
@@ -1,0 +1,99 @@
+"""
+Identifier type may be overridden.
+
+"""
+from json import dumps, loads
+from hashlib import sha256
+
+from hamcrest import (
+    assert_that,
+    contains_inanyorder,
+    equal_to,
+    is_,
+)
+from microcosm.api import binding, create_object_graph
+from microcosm.loaders import load_from_dict
+from werkzeug.routing import BaseConverter
+
+from microcosm_flask.conventions.crud import configure_crud
+from microcosm_flask.conventions.base import EndpointDefinition
+from microcosm_flask.namespaces import Namespace
+from microcosm_flask.operations import Operation
+from microcosm_flask.tests.conventions.fixtures import (
+    Person,
+    PersonSchema,
+    PERSON_1,
+    PERSON_2,
+)
+
+
+class ContentBasedAddressConverter(BaseConverter):
+    """
+    Example of a customer identifier type: in this case a content-based address.
+
+    """
+
+    @staticmethod
+    def make_hash(obj):
+        # naive content normalization function
+        content = dumps({
+            key: str(value)
+            for key, value in obj.__dict__.items()
+        }, sort_keys=True)
+        return sha256(content).hexdigest()
+
+
+@binding("cba")
+def configure_hash_converter(graph):
+    graph.flask.url_map.converters["cba"] = ContentBasedAddressConverter
+
+
+PEOPLE = [
+    PERSON_1,
+    PERSON_2,
+]
+
+
+def retrieve_person(person_id):
+    return next(
+        person
+        for person in PEOPLE
+        if ContentBasedAddressConverter.make_hash(person) == person_id
+    )
+
+
+PERSON_MAPPINGS = {
+    Operation.Retrieve: EndpointDefinition(
+        func=retrieve_person,
+        response_schema=PersonSchema(),
+    ),
+}
+
+
+class TestIdentifierType(object):
+
+    def setup(self):
+        loader = load_from_dict(
+            route=dict(
+                converters=[
+                    "cba"
+                ],
+            ),
+        )
+        self.graph = create_object_graph(name="example", testing=True, loader=loader)
+        assert_that(self.graph.config.route.converters, contains_inanyorder("uuid", "cba"))
+        self.person_ns = Namespace(
+            subject=Person,
+            # use custom identifier type
+            identifier_type="cba",
+        )
+        configure_crud(self.graph, self.person_ns, PERSON_MAPPINGS)
+        self.client = self.graph.flask.test_client()
+
+    def test_content_based_address(self):
+        hash_id = ContentBasedAddressConverter.make_hash(PERSON_1)
+        response = self.client.get("/api/person/{}".format(hash_id))
+
+        assert_that(response.status_code, is_(equal_to(200)))
+        response_data = loads(response.get_data().decode("utf-8"))
+        assert_that(response_data["id"], is_(equal_to(str(PERSON_1.id))))

--- a/microcosm_flask/tests/test_naming.py
+++ b/microcosm_flask/tests/test_naming.py
@@ -46,8 +46,10 @@ def test_singletone_path():
 
 
 def test_instance_path():
-    assert_that(instance_path_for("foo"), is_(equal_to("/foo/<uuid:foo_id>")))
+    assert_that(instance_path_for("foo", "uuid"), is_(equal_to("/foo/<uuid:foo_id>")))
+    assert_that(instance_path_for("foo", "bar"), is_(equal_to("/foo/<bar:foo_id>")))
 
 
 def test_relation_path():
-    assert_that(relation_path_for("foo", "bar"), is_(equal_to("/foo/<uuid:foo_id>/bar")))
+    assert_that(relation_path_for("foo", "bar", "uuid"), is_(equal_to("/foo/<uuid:foo_id>/bar")))
+    assert_that(relation_path_for("foo", "bar", "baz"), is_(equal_to("/foo/<baz:foo_id>/bar")))


### PR DESCRIPTION
Includes a naive example using a content-based addressing (hash) scheme.