### PR TITLE
Log a warning when a service returns 500

### DIFF
--- a/microcosm_flask/audit.py
+++ b/microcosm_flask/audit.py
@@ -229,7 +229,7 @@ def _audit_request(options, func, request_context, *args, **kwargs):  # noqa: C9
         if not should_skip_logging(func):
             if request_info.status_code == 500:
                 # something actually went wrong; investigate
-                logger.warn(request_info.to_dict())
+                logger.warning(request_info.to_dict())
             else:
                 # usually log at INFO; a raised exception can be an error or expected behavior (e.g. 404)
                 logger.info(request_info.to_dict())

--- a/microcosm_flask/audit.py
+++ b/microcosm_flask/audit.py
@@ -62,6 +62,148 @@ def audit(func):
     return wrapper
 
 
+class RequestInfo(object):
+    """
+    Capture of key information for requests.
+
+    """
+    def __init__(self, options, func, request_context):
+        self.options = options
+        self.operation = request.endpoint
+        self.func = func.__name__
+        self.method = request.method
+        self.request_context = request_context
+        self.timing = dict()
+
+        self.error = None
+        self.stack_trace = None
+        self.request_body = None
+        self.response_body = None
+        self.status_code = None
+        self.success = None
+
+    def to_dict(self):
+        dct = dict(
+            operation=self.operation,
+            func=self.func,
+            method=self.method,
+            **self.timing
+        )
+
+        if self.request_context is not None:
+            dct.update(self.request_context())
+
+        if self.success:
+            dct.update(
+                success=self.success,
+                status_code=self.status_code,
+            )
+        else:
+            dct.update(
+                success=self.success,
+                message=extract_error_message(self.error)[:2048],
+                context=extract_context(self.error),
+                stack_trace=self.stack_trace,
+                status_code=self.status_code,
+            )
+
+        self.post_process_request_body(dct)
+        self.post_process_response_body(dct)
+
+        return dct
+
+    def capture_request(self):
+        if not current_app.debug:
+            # only capture request body on debug
+            return
+
+        if not self.options.include_request_body:
+            # only capture request body if requested
+            return
+
+        if not request.get_json(force=True, silent=True):
+            # only capture request body if json
+            return
+
+        self.request_body = request.get_json(force=True)
+
+    def capture_response(self, response):
+        self.success = True
+
+        body, self.status_code = parse_response(response)
+
+        if not current_app.debug:
+            # only capture responsebody on debug
+            return
+
+        if not self.options.include_response_body:
+            # only capture response body if requested
+            return
+
+        if not body:
+            # only capture request body if there is one
+            return
+
+        try:
+            self.response_body = loads(body)
+        except (TypeError, ValueError):
+            # not json
+            pass
+
+    def capture_error(self, error):
+        self.error = error
+        self.status_code = extract_status_code(error)
+        self.success = 0 < self.status_code < 400
+        self.stack_trace = format_exc(limit=10)
+
+    def post_process_request(self):
+        # determine whether to show/hide body based on the g values set during func
+        self.post_process_request_body()
+        self.post_process_response_body()
+
+    def post_process_request_body(self, dct):
+        if g.get("hide_body") or not self.request_body:
+            return
+
+        for name, new_name in g.get("show_request_fields", {}).items():
+            try:
+                value = self.request_body.pop(name)
+                self.request_body[new_name] = value
+            except KeyError:
+                pass
+
+        for field in g.get("hide_request_fields", []):
+            try:
+                del self.request_body[field]
+            except KeyError:
+                pass
+
+        dct.update(
+            request_body=self.request_body,
+        )
+
+    def post_process_response_body(self, dct):
+        if g.get("hide_body") or not self.response_body:
+            return
+
+        for name, new_name in g.get("show_response_fields", {}).items():
+            try:
+                value = self.response_body.pop(name)
+                self.response_body[new_name] = value
+            except KeyError:
+                pass
+
+        for field in g.get("hide_response_fields", []):
+            try:
+                del self.response_body[field]
+            except KeyError:
+                pass
+
+        dct.update(
+            response_body=self.response_body,
+        )
+
+
 def _audit_request(options, func, request_context, *args, **kwargs):  # noqa: C901
     """
     Run a request function under audit.
@@ -69,103 +211,28 @@ def _audit_request(options, func, request_context, *args, **kwargs):  # noqa: C9
     """
     logger = getLogger("audit")
 
+    request_info = RequestInfo(options, func, request_context)
     response = None
 
-    # always include these fields
-    audit_dict = dict(
-        operation=request.endpoint,
-        func=func.__name__,
-        method=request.method,
-    )
-
-    # include request body on debug (if any)
-    if all((
-        current_app.debug,
-        options.include_request_body,
-        request.get_json(force=True, silent=True),
-    )):
-        request_body = request.get_json(force=True)
-    else:
-        request_body = None
-
-    response_body = None
-
-    # include headers (conditionally)
-    if request_context is not None:
-        audit_dict.update(request_context())
-
-    # process the request
+    request_info.capture_request()
     try:
-        with elapsed_time(audit_dict):
+        # process the request
+        with elapsed_time(request_info.timing):
             response = func(*args, **kwargs)
     except Exception as error:
-        status_code = extract_status_code(error)
-        success = 0 < status_code < 400
-        audit_dict.update(
-            success=success,
-            message=extract_error_message(error)[:2048],
-            context=extract_context(error),
-            stack_trace=None if success else format_exc(limit=10),
-            status_code=status_code,
-        )
+        request_info.capture_error(error)
         raise
     else:
-        body, status_code = parse_response(response)
-
-        audit_dict.update(
-            success=True,
-            status_code=status_code,
-        )
-
-        # include response body on debug (if any)
-        if all((
-                current_app.debug,
-                options.include_response_body,
-                body,
-        )):
-            try:
-                response_body = loads(body)
-            except (TypeError, ValueError):
-                # not json
-                audit_dict["response_body"] = body
-
+        request_info.capture_response(response)
         return response
     finally:
-        # determine whether to show/hide body based on the g values set during func
-        if not g.get("hide_body"):
-            if request_body:
-                for name, new_name in g.get("show_request_fields", {}).items():
-                    try:
-                        value = request_body.pop(name)
-                        request_body[new_name] = value
-                    except KeyError:
-                        pass
-                    pass
-                for field in g.get("hide_request_fields", []):
-                    try:
-                        del request_body[field]
-                    except KeyError:
-                        pass
-                audit_dict["request_body"] = request_body
-
-            if response_body:
-                for name, new_name in g.get("show_response_fields", {}).items():
-                    try:
-                        value = response_body.pop(name)
-                        response_body[new_name] = value
-                    except KeyError:
-                        pass
-                    pass
-                for field in g.get("hide_response_fields", []):
-                    try:
-                        del response_body[field]
-                    except KeyError:
-                        pass
-                audit_dict["response_body"] = response_body
-
-        # always log at INFO; a raised exception can be an error or expected behavior (e.g. 404)
         if not should_skip_logging(func):
-            logger.info(audit_dict)
+            if request_info.status_code == 500:
+                # something actually went wrong; investigate
+                logger.warn(request_info.to_dict())
+            else:
+                # usually log at INFO; a raised exception can be an error or expected behavior (e.g. 404)
+                logger.info(request_info.to_dict())
 
 
 def parse_response(response):
@@ -210,6 +277,5 @@ def configure_audit_decorator(graph):
                 include_response_body=include_response_body,
             )
             return _audit_request(options, func, graph.request_context,  *args, **kwargs)
-
         return wrapper
     return _audit

--- a/microcosm_flask/sync/push.py
+++ b/microcosm_flask/sync/push.py
@@ -127,7 +127,7 @@ def push_resource_json(session, uri, resource):
     try:
         response.raise_for_status()
     except:
-        logger.warn("Unable to replace {}".format(
+        logger.warning("Unable to replace {}".format(
             uri,
         ))
         raise
@@ -152,7 +152,7 @@ def push_resource_json_batch(session, uri, resources):
     try:
         response.raise_for_status()
     except:
-        logger.warn("Unable to replace {}".format(
+        logger.warning("Unable to replace {}".format(
             uri,
         ))
         raise

--- a/microcosm_flask/tests/test_audit.py
+++ b/microcosm_flask/tests/test_audit.py
@@ -1,0 +1,309 @@
+"""
+Audit structure tests.
+
+"""
+from flask import g
+from hamcrest import (
+    assert_that,
+    equal_to,
+    is_,
+    is_not,
+    none,
+)
+from microcosm.api import create_object_graph
+from mock import MagicMock
+from werkzeug.exceptions import NotFound
+
+from microcosm_flask.audit import AuditOptions, RequestInfo
+
+
+def test_func(*args, **kwargs):
+    pass
+
+
+class TestRequestInfo(object):
+    """
+    Test capturing of request data.
+
+    """
+    def setup(self):
+        self.graph = create_object_graph("example", testing=True, debug=True)
+        self.graph.use(
+            "flask",
+            "request_context",
+        )
+
+        self.graph.flask.route("/")(test_func)
+
+        self.options = AuditOptions(
+            include_request_body=True,
+            include_response_body=True,
+        )
+
+    def test_base_info(self):
+        """
+        Every log entry identifies the request.
+
+        """
+        with self.graph.flask.test_request_context("/"):
+            request_info = RequestInfo(self.options, test_func, None)
+            dct = request_info.to_dict()
+            assert_that(
+                dct,
+                is_(equal_to(dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+                ))),
+            )
+
+    def test_request_context(self):
+        """
+        Log entries can include context from headers.
+
+        """
+        with self.graph.flask.test_request_context("/", headers={"X-Request-Id": "request-id"}):
+            request_info = RequestInfo(self.options, test_func, self.graph.request_context)
+            dct = request_info.to_dict()
+            request_id = dct.pop("X-Request-Id")
+            assert_that(request_id, is_(equal_to("request-id")))
+            assert_that(
+                dct,
+                is_(equal_to(dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+                ))),
+            )
+
+    def test_success(self):
+        """
+        Succeessful responses capture status code.
+
+        """
+        with self.graph.flask.test_request_context("/"):
+            request_info = RequestInfo(self.options, test_func, None)
+            request_info.capture_response(MagicMock(
+                data="{}",
+                status_code=201,
+            ))
+            dct = request_info.to_dict()
+            assert_that(
+                dct,
+                is_(equal_to(dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+
+                    success=True,
+                    status_code=201,
+                ))),
+            )
+
+    def test_error(self):
+        """
+        Errors responses capture the error
+
+        """
+        with self.graph.flask.test_request_context("/"):
+            request_info = RequestInfo(self.options, test_func, None)
+            try:
+                raise NotFound("Not Found")
+            except Exception as error:
+                request_info.capture_error(error)
+
+            dct = request_info.to_dict()
+            # NB: stack trace is hard (and pointless) to compare
+            stack_trace = dct.pop("stack_trace")
+            assert_that(stack_trace, is_not(none()))
+            assert_that(
+                dct,
+                is_(equal_to(dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+
+                    success=False,
+                    status_code=404,
+                    message="Not Found",
+                    context=dict(errors=[]),
+                ))),
+            )
+
+    def test_request_body(self):
+        """
+        Can capture the request body.
+
+        """
+        with self.graph.flask.test_request_context("/", data='{"foo": "bar"}'):
+            request_info = RequestInfo(self.options, test_func, None)
+            request_info.capture_request()
+            dct = request_info.to_dict()
+            assert_that(
+                dct,
+                is_(equal_to(dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+
+                    request_body=dict(foo="bar"),
+                ))),
+            )
+
+    def test_request_body_with_field_renaming(self):
+        """
+        Can capture the request body with field renaming
+
+        """
+        with self.graph.flask.test_request_context("/", data='{"foo": "bar"}'):
+            g.show_request_fields = dict(foo="baz")
+
+            request_info = RequestInfo(self.options, test_func, None)
+            request_info.capture_request()
+            dct = request_info.to_dict()
+            assert_that(
+                dct,
+                is_(equal_to(dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+
+                    request_body=dict(baz="bar"),
+                ))),
+            )
+
+    def test_request_body_with_field_deletion(self):
+        """
+        Can capture the request body with fields removed
+
+        """
+        with self.graph.flask.test_request_context("/", data='{"foo": "bar", "this": "that"}'):
+            g.hide_request_fields = ["foo"]
+
+            request_info = RequestInfo(self.options, test_func, None)
+            request_info.capture_request()
+            dct = request_info.to_dict()
+            assert_that(
+                dct,
+                is_(equal_to(dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+
+                    request_body=dict(this="that"),
+                ))),
+            )
+
+    def test_response_body(self):
+        """
+        Can capture the response body.
+
+        """
+        with self.graph.flask.test_request_context("/"):
+            request_info = RequestInfo(self.options, test_func, None)
+            request_info.capture_response(MagicMock(
+                data='{"foo": "bar"}',
+                status_code=200,
+            ))
+            dct = request_info.to_dict()
+            assert_that(
+                dct,
+                is_(equal_to(dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+
+                    success=True,
+                    status_code=200,
+                    response_body=dict(foo="bar"),
+                ))),
+            )
+
+    def test_response_body_with_field_renaming(self):
+        """
+        Can capture the response body with field renaming
+
+        """
+        with self.graph.flask.test_request_context("/"):
+            g.show_response_fields = dict(foo="baz")
+
+            request_info = RequestInfo(self.options, test_func, None)
+            request_info.capture_response(MagicMock(
+                data='{"foo": "bar"}',
+                status_code=200,
+            ))
+            dct = request_info.to_dict()
+            assert_that(
+                dct,
+                is_(equal_to(dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+
+                    success=True,
+                    status_code=200,
+                    response_body=dict(baz="bar"),
+                ))),
+            )
+
+    def test_response_body_with_field_deletion(self):
+        """
+        Can capture the response body with fields removed
+
+        """
+        with self.graph.flask.test_request_context("/"):
+            g.hide_response_fields = ["foo"]
+
+            request_info = RequestInfo(self.options, test_func, None)
+            request_info.capture_response(MagicMock(
+                data='{"foo": "bar", "this": "that"}',
+                status_code=200,
+            ))
+            dct = request_info.to_dict()
+            assert_that(
+                dct,
+                is_(equal_to(dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+
+                    success=True,
+                    status_code=200,
+                    response_body=dict(this="that"),
+                ))),
+            )
+
+    def test_log_default(self):
+        """
+        Log at INFO by default.
+
+        """
+        with self.graph.flask.test_request_context("/"):
+            request_info = RequestInfo(self.options, test_func, None)
+
+            logger = MagicMock()
+            request_info.log(logger)
+            logger.info.assert_called_with(dict(
+                operation="test_func",
+                method="GET",
+                func="test_func",
+            ))
+            logger.warning.assert_not_called()
+
+    def test_log_internal_server_error(self):
+        """
+        Log at WARNING on internal server error.
+
+        """
+        with self.graph.flask.test_request_context("/"):
+            request_info = RequestInfo(self.options, test_func, None)
+            request_info.status_code = 500
+
+            logger = MagicMock()
+            request_info.log(logger)
+            logger.warning.assert_called_with(dict(
+                operation="test_func",
+                method="GET",
+                func="test_func",
+            ))
+            logger.info.assert_not_called()


### PR DESCRIPTION
Since our services are all much more well-behaved than they once were, it's reasonable to assume that a 500 error is actually a problem that needs investigation. Logs these are warning.

Also, refactor audit logging code path for better clarity.

Now with unit tests!