### PR TITLE
Support configuring customized metrics tag mappers on the namespace level

### DIFF
--- a/microcosm_flask/namespaces.py
+++ b/microcosm_flask/namespaces.py
@@ -33,15 +33,18 @@ class Namespace(object):
 
     """
 
-    def __init__(self,
-                 subject,
-                 object_=None,
-                 path=None,
-                 controller=None,
-                 version=None,
-                 enable_basic_auth=False,
-                 enable_metrics=False,
-                 identifier_type="uuid"):
+    def __init__(
+        self,
+        subject,
+        object_=None,
+        path=None,
+        controller=None,
+        version=None,
+        enable_basic_auth=False,
+        enable_metrics=False,
+        identifier_type="uuid",
+        metrics_tag_mappers=None,
+     ):
         """
         :param subject: the target resource (or resource name) of this namespace
         :param object_: the subject resource (or resource name) of this namespace (e.g. for relations)
@@ -49,6 +52,8 @@ class Namespace(object):
         :param controller: the object responsible for implementations associated with this namespace.
         :param version: the version of this namespace
         :param enable_basic_auth: enable basic auth for this namespace if it's not enabled globally
+        :param metrics_tag_mappers: mapping from kwargs key to a function that will convert its value
+                                    (when not null) to a metrics tag
         """
         self.subject = subject
         self.object_ = object_
@@ -58,6 +63,7 @@ class Namespace(object):
         self.enable_basic_auth = enable_basic_auth
         self.enable_metrics = enable_metrics
         self.identifier_type = identifier_type
+        self.metrics_tag_mappers = metrics_tag_mappers
 
     @property
     def path(self):

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -78,7 +78,7 @@ def configure_route_decorator(graph):
             if enable_metrics or ns.enable_metrics:
                 from microcosm_flask.metrics import StatusCodeClassifier
                 func = graph.metrics_counting(endpoint, classifier_cls=StatusCodeClassifier)(func)
-                func = graph.metrics_timing(endpoint)(func)
+                func = graph.metrics_timing(endpoint, ns.metrics_tag_mappers)(func)
 
             # keep audit decoration last (before registering the route) so that
             # errors raised by other decorators are captured in the audit trail

--- a/microcosm_flask/tests/test_namespaces.py
+++ b/microcosm_flask/tests/test_namespaces.py
@@ -2,6 +2,7 @@
 Namespace tests.
 
 """
+from collections import OrderedDict
 from hamcrest import (
     assert_that,
     equal_to,
@@ -158,3 +159,13 @@ def test_namespace_accepts_controller():
         url = ns.url_for(Operation.Search)
         assert_that(url, is_(equal_to("http://localhost/api/foo")))
         assert_that(ns.controller, is_(equal_to(controller)))
+
+
+def test_metrics_tag_mappers():
+    """
+    Namespaces can contain metric_tag_mappers.
+
+    """
+    metrics_tag_mappers = OrderedDict(foo=lambda x: "foo" + x)
+    ns = Namespace(subject="foo", metrics_tag_mappers=metrics_tag_mappers)
+    assert_that(ns.metrics_tag_mappers, is_(equal_to(metrics_tag_mappers)))


### PR DESCRIPTION
Tests depend on https://github.com/globality-corp/microcosm-metrics/pull/3.
