### PR TITLE
Rebuild web request paging abstractions.

### DIFF
--- a/microcosm_flask/conventions/discovery.py
+++ b/microcosm_flask/conventions/discovery.py
@@ -4,11 +4,11 @@ A discovery endpoint provides links to other endpoints.
 """
 from microcosm.api import defaults
 from microcosm_flask.conventions.base import Convention
-from microcosm_flask.conventions.encoding import load_query_string_data, make_response
+from microcosm_flask.conventions.encoding import make_response
 from microcosm_flask.conventions.registry import iter_endpoints
 from microcosm_flask.linking import Link, Links
 from microcosm_flask.namespaces import Namespace
-from microcosm_flask.paging import Page, PageSchema
+from microcosm_flask.paging import OffsetLimitPage, OffsetLimitPageSchema
 from microcosm_flask.operations import Operation
 
 
@@ -22,7 +22,7 @@ def iter_links(operations, page):
             operation=operation,
             ns=ns,
             type=ns.subject_name,
-            qs=page.to_tuples(),
+            qs=page.to_items(),
         )
 
 
@@ -52,17 +52,17 @@ class DiscoveryConvention(Convention):
         Register a discovery endpoint for a set of operations.
 
         """
-        page_schema = PageSchema()
+        page_schema = OffsetLimitPageSchema()
 
         @self.add_route("/", Operation.Discover, ns)
         def discover():
             # accept pagination limit from request
-            page = Page.from_query_string(load_query_string_data(page_schema))
+            page = OffsetLimitPage.from_query_string(page_schema)
             page.offset = 0
 
             response_data = dict(
                 _links=Links({
-                    "self": Link.for_(Operation.Discover, ns, qs=page.to_tuples()),
+                    "self": Link.for_(Operation.Discover, ns, qs=page.to_items()),
                     "search": [
                         link for link in iter_links(self.find_matching_endpoints(ns), page)
                     ],

--- a/microcosm_flask/conventions/encoding.py
+++ b/microcosm_flask/conventions/encoding.py
@@ -52,14 +52,16 @@ def load_request_data(request_schema, partial=False):
     return request_data.data
 
 
-def load_query_string_data(request_schema):
+def load_query_string_data(request_schema, query_string_data=None):
     """
     Load query string data using the given schema.
 
     Schemas are assumed to be compatible with the `PageSchema`.
 
     """
-    query_string_data = request.args
+    if query_string_data is None:
+        query_string_data = request.args
+
     request_data = request_schema.load(query_string_data)
     if request_data.errors:
         # pass the validation errors back in the context

--- a/microcosm_flask/paging.py
+++ b/microcosm_flask/paging.py
@@ -1,12 +1,47 @@
 """
 Pagination support.
 
-"""
-from flask import request
-from marshmallow import fields, Schema
+Most applications start with offset/limit pagination because it's simplest to implement,
+but other pagination schemes are possible and can be more performant especially in infinite
+scroll settings. This module encapsulates paging into a set of extensible, inter-related objects.
 
+ -  A `Page` is represents information about a specific page (for example, the currently requested one)
+ -  A `PageSchema` defines a (marshmallow) schema for decoding a page from some data (e.g. the query string)
+ -  A `PaginatedList` defines a list of items that knows about its current page and *may* define HAL-style
+    links to other pages.
+ -  A `PaginatedListSchema` defines a (marshmallow) schema for encoding a paginated list (e.g. in a response)
+
+
+Typical Usage:
+
+    # pre-conditions: we are processes a search operation for `foo`
+    ns, operation, foo_schema = Namespace("foo"), Operation.Search, Schema()
+
+    # choose a page implementation
+    page_cls = OffsetLimitPage
+
+    # choose a page schema (we may wish to extend the base class for more search arguments)
+    page_schema = OffsetLimitPageSchema()
+
+    # construct the current page from the query string
+    page = page_cls.from_query_string(page_schema)
+
+    # perform the search; result is typically a tuple including items and a total count
+    result = some_search_func(page)
+
+    # transform the result into a paginated list and possibly response headers
+    paginated_list, headers = page.to_paginated_list(result, ns, operation)
+
+    # encode the result
+    paginated_list_schema = page_cls.make_paginated_list_schema_class(ns, foo_schema)()
+    return dump_response_Data(paginated_list_schema, paginated_list, headers=headers)
+
+"""
+from marshmallow import fields, Schema
+from flask import request
+
+from microcosm_flask.conventions.encoding import encode_count_header, load_query_string_data
 from microcosm_flask.linking import Link, Links
-from microcosm_flask.operations import Operation
 
 
 def identity(x):
@@ -17,38 +52,218 @@ def identity(x):
     return x
 
 
+# NB: lots of code currently uses `PageSchema` to refer to `OffsetLimitPageSchema`
+# keeping this (mis)naming for backwards compatibilty
 class PageSchema(Schema):
     offset = fields.Integer(missing=None)
     limit = fields.Integer(missing=None)
 
 
-def make_paginated_list_schema(ns, item_schema):
+class OffsetLimitPageSchema(PageSchema):
+    pass
+
+
+class PaginatedList(object):
     """
-    Generate a paginated list schema.
+    A list of items with knowledge of a page.
 
-    :param ns: a `Namespace` for the list's item type
-    :param item_schema: a `Schema` for the list's item type
+    Includes HAL-style links (e.g for the current or next page)
 
     """
+    def __init__(self, items, _page, _ns, _operation, _context):
+        self.items = items
+        self._page = _page
+        self._ns = _ns
+        self._operation = _operation
+        self._context = _context
 
-    class PaginatedListSchema(Schema):
-        __alias__ = "{}_list".format(ns.subject_name)
+    @property
+    def _links(self):
+        return self.links.to_dict()
 
-        offset = fields.Integer(required=True)
-        limit = fields.Integer(required=True)
-        count = fields.Integer(required=True)
-        items = fields.List(fields.Nested(item_schema), required=True)
-        _links = fields.Raw()
+    @property
+    def links(self):
+        """
+        Include a self link.
 
-    return PaginatedListSchema
+        """
+        links = Links()
+        links["self"] = Link.for_(
+            self._operation,
+            self._ns,
+            qs=self._page.to_items(),
+            **self._context
+        )
+        return links
+
+
+class OffsetLimitPaginatedList(PaginatedList):
+    """
+    A paginated list using offset/limit style paging.
+
+    """
+    def __init__(self, items, count, _page, _ns, _operation, _context):
+        super(OffsetLimitPaginatedList, self).__init__(
+            items=items,
+            _page=_page,
+            _ns=_ns,
+            _operation=_operation,
+            _context=_context,
+        )
+        self.count = count
+
+    @property
+    def offset(self):
+        return self._page.offset
+
+    @property
+    def limit(self):
+        return self._page.limit
+
+    @property
+    def links(self):
+        """
+        Include previous and next links.
+
+        """
+        links = super(OffsetLimitPaginatedList, self).links
+        if self._page.offset + self._page.limit < self.count:
+            links["next"] = Link.for_(
+                self._operation,
+                self._ns,
+                qs=self._page.next_page.to_items(),
+                **self._context
+            )
+        if self.offset > 0:
+            links["prev"] = Link.for_(
+                self._operation,
+                self._ns,
+                qs=self._page.prev_page.to_items(),
+                **self._context
+            )
+        return links
 
 
 class Page(object):
+    """
+    Encapsulates pagination information.
 
-    def __init__(self, offset=None, limit=None, **rest):
+    """
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def to_items(self, func=str):
+        """
+        Contruct a list of dictionary items.
+
+        The items are normalized using:
+          -  A sort function by key (for consistent results)
+          -  A transformation function for values
+
+        The transformation function will default to `str`, which is a good choice when encoding values
+        as part of a response; this requires that complex types (UUID, Enum, etc.) have a valid string
+        encoding.
+
+        The transformation function should be set to `identity` in cases where raw values are desired;
+        this is normally necessary when passing page data to controller functions as kwargs.
+
+        """
+        return [
+            (key, func(self.kwargs[key]))
+            for key in sorted(self.kwargs.keys())
+        ]
+
+    def to_dict(self, func=str):
+        return dict(self.to_items(func=func))
+
+    def to_paginated_list(self, result, _ns, _operation, **kwargs):
+        """
+        Convert a controller result to a paginated list.
+
+        The result format is assumed to meet the contract of this page class's `parse_result` function.
+
+        """
+        items, context = self.parse_result(result)
+        headers = dict()
+        paginated_list = PaginatedList(
+            items=items,
+            _page=self,
+            _ns=_ns,
+            _operation=_operation,
+            _context=context,
+        )
+        return paginated_list, headers
+
+    @classmethod
+    def parse_result(cls, result):
+        """
+        Parse a simple items result.
+
+        May either be two item tuple containing items and a context dictionary (see: relation convention)
+        or a list of items.
+
+        """
+        if isinstance(result, tuple) == 2:
+            items, context = result
+        else:
+            context = {}
+            items = result
+        return items, context
+
+    @classmethod
+    def from_query_string(cls, schema, qs=None):
+        """
+        Extract a page from the current query string.
+
+        :param qs: a query string dictionary (`request.args` will be used if omitted)
+
+        """
+        dct = load_query_string_data(schema, qs)
+        return cls.from_dict(dct)
+
+    @classmethod
+    def from_dict(cls, dct):
+        return cls(**dct)
+
+    @classmethod
+    def make_paginated_list_schema_class(cls, ns, item_schema):
+        """
+        Generate a schema class that represents a paginted list of items.
+
+        """
+        class PaginatedListSchema(Schema):
+            __alias__ = "{}_list".format(ns.subject_name)
+            items = fields.List(fields.Nested(item_schema), required=True)
+            _links = fields.Raw()
+
+        return PaginatedListSchema
+
+
+class OffsetLimitPage(Page):
+    """
+    Offset/limit based paging.
+
+    """
+    def __init__(self, offset=None, limit=None, **kwargs):
+        super(OffsetLimitPage, self).__init__(**kwargs)
         self.offset = self.default_offset if offset is None else offset
         self.limit = self.default_limit if limit is None else limit
-        self.rest = rest
+
+    @property
+    def next_page(self):
+        return OffsetLimitPage(
+            offset=self.offset + self.limit,
+            limit=self.limit,
+            **self.kwargs
+        )
+
+    @property
+    def prev_page(self):
+        return OffsetLimitPage(
+            offset=self.offset - self.limit,
+            limit=self.limit,
+            **self.kwargs
+        )
 
     @property
     def default_offset(self):
@@ -61,103 +276,50 @@ class Page(object):
         except:
             return 20
 
-    @classmethod
-    def from_query_string(cls, qs):
-        """
-        Create a page from a query string dictionary.
-
-        This dictionary should probably come from `PageSchema.from_request()`.
-
-        """
-        dct = qs.copy()
-        offset = dct.pop("offset", None)
-        limit = dct.pop("limit", None)
-        return cls(
-            offset=offset,
-            limit=limit,
-            **dct
-        )
-
-    def next(self):
-        return Page(
-            offset=self.offset + self.limit,
-            limit=self.limit,
-            **self.rest
-        )
-
-    def prev(self):
-        return Page(
-            offset=self.offset - self.limit,
-            limit=self.limit,
-            **self.rest
-        )
-
-    def to_dict(self, as_str=False):
-        return dict(self.to_tuples(as_str=as_str))
-
-    def to_tuples(self, as_str=True):
-        """
-        Convert to tuples for deterministic order when passed to urlencode.
-
-        """
-        value_func = str if as_str else identity
-
+    def to_items(self, func=str):
         return [
             ("offset", self.offset),
             ("limit", self.limit),
-        ] + [
-            (key, value_func(self.rest[key]))
-            for key in sorted(self.rest.keys())
-        ]
+        ] + super(OffsetLimitPage, self).to_items(func=func)
 
-
-class PaginatedList(object):
-
-    def __init__(self,
-                 ns,
-                 page,
-                 items,
-                 count,
-                 schema=None,
-                 operation=Operation.Search,
-                 **extra):
-        self.ns = ns
-        self.page = page
-        self.items = items
-        self.count = count
-        self.schema = schema
-        self.operation = operation
-        self.extra = extra
-
-    def to_dict(self):
-        return dict(
-            count=self.count,
-            items=[
-                self.schema.dump(item).data if self.schema else item
-                for item in self.items
-            ],
-            _links=self._links,
-            **self.page.to_dict(as_str=True)
+    def to_paginated_list(self, result, _ns, _operation, **kwargs):
+        items, count, context = self.parse_result(result)
+        headers = encode_count_header(count)
+        paginated_list = OffsetLimitPaginatedList(
+            items=items,
+            count=count,
+            _page=self,
+            _ns=_ns,
+            _operation=_operation,
+            _context=context,
         )
+        return paginated_list, headers
 
-    @property
-    def offset(self):
-        return self.page.offset
+    @classmethod
+    def parse_result(cls, result):
+        """
+        Parse an items + count tuple result.
 
-    @property
-    def limit(self):
-        return self.page.limit
+        May either be three item tuple containing items, count, and a context dictionary (see: relation convention)
+        or a two item tuyple containing only items and count.
 
-    @property
-    def _links(self):
-        return self.links.to_dict()
+        """
+        if len(result) == 3:
+            items, count, context = result
+        else:
+            context = {}
+            items, count = result
+        return items, count, context
 
-    @property
-    def links(self):
-        links = Links()
-        links["self"] = Link.for_(self.operation, self.ns, qs=self.page.to_tuples(), **self.extra)
-        if self.page.offset + self.page.limit < self.count:
-            links["next"] = Link.for_(self.operation, self.ns, qs=self.page.next().to_tuples(), **self.extra)
-        if self.page.offset > 0:
-            links["prev"] = Link.for_(self.operation, self.ns, qs=self.page.prev().to_tuples(), **self.extra)
-        return links
+    @classmethod
+    def make_paginated_list_schema_class(cls, ns, item_schema):
+        class PaginatedListSchema(Schema):
+            __alias__ = "{}_list".format(ns.subject_name)
+
+            offset = fields.Integer(required=True)
+            limit = fields.Integer(required=True)
+            count = fields.Integer(required=True)
+            items = fields.List(fields.Nested(item_schema), required=True)
+            _links = fields.Raw()
+
+        return PaginatedListSchema

--- a/microcosm_flask/paging.py
+++ b/microcosm_flask/paging.py
@@ -5,7 +5,7 @@ Most applications start with offset/limit pagination because it's simplest to im
 but other pagination schemes are possible and can be more performant especially in infinite
 scroll settings. This module encapsulates paging into a set of extensible, inter-related objects.
 
- -  A `Page` is represents information about a specific page (for example, the currently requested one)
+ -  A `Page` represents information about a specific page (for example, the currently requested one)
  -  A `PageSchema` defines a (marshmallow) schema for decoding a page from some data (e.g. the query string)
  -  A `PaginatedList` defines a list of items that knows about its current page and *may* define HAL-style
     links to other pages.
@@ -301,7 +301,7 @@ class OffsetLimitPage(Page):
         Parse an items + count tuple result.
 
         May either be three item tuple containing items, count, and a context dictionary (see: relation convention)
-        or a two item tuyple containing only items and count.
+        or a two item tuple containing only items and count.
 
         """
         if len(result) == 3:

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -15,7 +15,7 @@ from microcosm.api import create_object_graph
 from microcosm_flask.conventions.crud import configure_crud
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
-from microcosm_flask.paging import PageSchema
+from microcosm_flask.paging import OffsetLimitPageSchema
 from microcosm_flask.tests.conventions.fixtures import (
     Address,
     AddressSchema,
@@ -47,14 +47,14 @@ PERSON_MAPPINGS = {
     Operation.UpdateBatch: (person_update_batch, NewPersonBatchSchema(), PersonBatchSchema()),
     Operation.Replace: (person_replace, NewPersonSchema(), PersonSchema()),
     Operation.Retrieve: (person_retrieve, PersonLookupSchema(), PersonSchema()),
-    Operation.Search: (person_search, PageSchema(), PersonSchema()),
+    Operation.Search: (person_search, OffsetLimitPageSchema(), PersonSchema()),
     Operation.Update: (person_update, NewPersonSchema(), PersonSchema()),
 }
 
 
 ADDRESS_MAPPINGS = {
     Operation.Retrieve: (address_retrieve, AddressSchema()),
-    Operation.Search: (address_search, PageSchema(), AddressSchema()),
+    Operation.Search: (address_search, OffsetLimitPageSchema(), AddressSchema()),
 }
 
 

--- a/microcosm_flask/tests/test_paging.py
+++ b/microcosm_flask/tests/test_paging.py
@@ -2,205 +2,81 @@
 Paging tests.
 
 """
-from enum import Enum, unique
-from uuid import uuid4
+from hamcrest import assert_that, equal_to, has_entry, is_, is_not
+from marshmallow import Schema
 
-from hamcrest import (
-    assert_that,
-    equal_to,
-    is_,
-)
 from microcosm.api import create_object_graph
-
-from microcosm_flask.conventions.encoding import load_query_string_data
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
-from microcosm_flask.paging import Page, PageSchema, PaginatedList
+from microcosm_flask.paging import OffsetLimitPageSchema, OffsetLimitPage
 
 
-def test_page_from_query_string():
+def test_default_values_for_offset_limit_page():
+    page = OffsetLimitPage(foo="bar")
+    assert_that(page.offset, is_(equal_to(0)))
+    assert_that(page.limit, is_(equal_to(20)))
+    assert_that(page.kwargs, has_entry("foo", "bar"))
+
+
+def test_override_default_limit_from_request_header():
     graph = create_object_graph(name="example", testing=True)
-
-    with graph.flask.test_request_context():
-        qs = load_query_string_data(PageSchema())
-        page = Page.from_query_string(qs)
+    with graph.flask.test_request_context(headers={"X-Request-Limit": "2"}):
+        page = OffsetLimitPage.from_dict(dict(foo="bar"))
         assert_that(page.offset, is_(equal_to(0)))
+        assert_that(page.limit, is_(equal_to(2)))
+        assert_that(page.kwargs, has_entry("foo", "bar"))
+
+
+def test_offset_limit_page_to_from_dict():
+    page = OffsetLimitPage.from_dict(dict(offset=10, limit=10, foo="bar"))
+    assert_that(page.offset, is_(equal_to(10)))
+    assert_that(page.limit, is_(equal_to(10)))
+    assert_that(page.to_dict(), is_(equal_to(dict(offset=10, limit=10, foo="bar"))))
+
+
+def test_offset_limit_page_from_query_string():
+    graph = create_object_graph(name="example", testing=True)
+    with graph.flask.test_request_context(query_string="offset=1&foo=bar"):
+        page = OffsetLimitPage.from_query_string(OffsetLimitPageSchema())
+        assert_that(page.offset, is_(equal_to(1)))
         assert_that(page.limit, is_(equal_to(20)))
+        # schema filters out extra arguments
+        assert_that(page.to_dict(), is_not(has_entry("foo", "bar")))
 
 
-def test_page_defaults():
+def test_offset_limit_page_to_paginated_list():
     graph = create_object_graph(name="example", testing=True)
 
-    with graph.flask.test_request_context():
-        page = Page()
+    ns = Namespace("foo")
 
-    assert_that(page.to_dict(), is_(equal_to({
-        "offset": 0,
-        "limit": 20
-    })))
-
-
-def test_page_defaults_with_page_schema():
-    graph = create_object_graph(name="example", testing=True)
-
-    with graph.flask.test_request_context():
-        page = Page.from_query_string(PageSchema().load({}).data)
-
-    assert_that(page.to_dict(), is_(equal_to({
-        "offset": 0,
-        "limit": 20
-    })))
-
-
-def test_page_to_dict():
-    page = Page(0, 10)
-    assert_that(page.to_dict(), is_(equal_to({
-        "offset": 0,
-        "limit": 10
-    })))
-
-
-def test_page_next():
-    page = Page(0, 10).next()
-    assert_that(page.offset, is_(equal_to(10)))
-    assert_that(page.limit, is_(equal_to(10)))
-
-
-def test_page_prev():
-    page = Page(20, 10).prev()
-    assert_that(page.offset, is_(equal_to(10)))
-    assert_that(page.limit, is_(equal_to(10)))
-
-
-def test_paginated_list_to_dict():
-    graph = create_object_graph(name="example", testing=True)
-    ns = Namespace(subject="foo")
-
-    @graph.route(ns.collection_path, Operation.Search, ns)
-    def search_foo():
+    @graph.flask.route("/", methods=["GET"], endpoint="foo.search.v1")
+    def search():
         pass
 
-    paginated_list = PaginatedList(ns, Page(2, 2), ["1", "2"], 10)
-
     with graph.flask.test_request_context():
-        assert_that(paginated_list.to_dict(), is_(equal_to({
-            "count": 10,
-            "items": [
-                "1",
-                "2",
-            ],
-            "offset": 2,
-            "limit": 2,
-            "_links": {
-                "self": {
-                    "href": "http://localhost/api/foo?offset=2&limit=2",
-                },
-                "next": {
-                    "href": "http://localhost/api/foo?offset=4&limit=2",
-                },
-                "prev": {
-                    "href": "http://localhost/api/foo?offset=0&limit=2",
-                },
-            }
-        })))
+        page = OffsetLimitPage(
+            offset=10,
+            limit=10,
+            foo="bar",
+        )
+        result = [], 0
+        paginated_list, headers = page.to_paginated_list(result, _ns=ns, _operation=Operation.Search)
 
-
-def test_paginated_list_relation_to_dict():
-    graph = create_object_graph(name="example", testing=True)
-    ns = Namespace(subject="foo", object_="bar")
-
-    @graph.route(ns.relation_path, Operation.SearchFor, ns)
-    def search_foo():
-        pass
-
-    paginated_list = PaginatedList(
-        ns,
-        Page(2, 2),
-        ["1", "2"],
-        10,
-        operation=Operation.SearchFor,
-        foo_id="FOO_ID",
-    )
-
-    with graph.flask.test_request_context():
-        assert_that(paginated_list.to_dict(), is_(equal_to({
-            "count": 10,
-            "items": [
-                "1",
-                "2",
-            ],
-            "offset": 2,
-            "limit": 2,
-            "_links": {
-                "self": {
-                    "href": "http://localhost/api/foo/FOO_ID/bar?offset=2&limit=2",
-                },
-                "next": {
-                    "href": "http://localhost/api/foo/FOO_ID/bar?offset=4&limit=2",
-                },
-                "prev": {
-                    "href": "http://localhost/api/foo/FOO_ID/bar?offset=0&limit=2",
-                },
-            }
-        })))
-
-
-@unique
-class MyEnum(Enum):
-    ONE = u"ONE"
-    TWO = u"TWO"
-
-    def __str__(self):
-        return self.name
-
-
-def test_custom_paginated_list():
-    graph = create_object_graph(name="example", testing=True)
-    ns = Namespace(subject="foo", object_="bar")
-
-    @graph.route(ns.relation_path, Operation.SearchFor, ns)
-    def search_foo():
-        pass
-
-    uid = uuid4()
-    paginated_list = PaginatedList(
-        ns,
-        Page.from_query_string(dict(
-            offset=2,
-            limit=2,
-            baz="baz",
-            uid=uid,
-            value=MyEnum.ONE,
-        )),
-        ["1", "2"],
-        10,
-        operation=Operation.SearchFor,
-        foo_id="FOO_ID",
-    )
-
-    rest = "baz=baz&uid={}&value=ONE".format(uid)
-
-    with graph.flask.test_request_context():
-        assert_that(paginated_list.to_dict(), is_(equal_to({
-            "count": 10,
-            "items": [
-                "1",
-                "2",
-            ],
-            "offset": 2,
-            "limit": 2,
-            "_links": {
-                "self": {
-                    "href": "http://localhost/api/foo/FOO_ID/bar?offset=2&limit=2&{}".format(rest),
-                },
-                "next": {
-                    "href": "http://localhost/api/foo/FOO_ID/bar?offset=4&limit=2&{}".format(rest),
-                },
-                "prev": {
-                    "href": "http://localhost/api/foo/FOO_ID/bar?offset=0&limit=2&{}".format(rest),
-                },
-            },
-            "baz": "baz",
-            "uid": str(uid),
-            "value": "ONE",
-        })))
+        schema_cls = page.make_paginated_list_schema_class(ns, Schema())
+        data = schema_cls().dump(paginated_list).data
+        assert_that(
+            data,
+            is_(equal_to(dict(
+                offset=10,
+                limit=10,
+                count=0,
+                items=[],
+                _links=dict(
+                    self=dict(
+                        href="http://localhost/?offset=10&limit=10&foo=bar",
+                    ),
+                    prev=dict(
+                        href="http://localhost/?offset=0&limit=10&foo=bar",
+                    ),
+                ),
+            ))))


### PR DESCRIPTION
The earlier paging code worked, but was fragmented and very difficult to swap out.
The rewrite builds clearer abstractions and makes new paging types simpler.