### PR TITLE
Add a convention to expose logging level.

### DIFF
--- a/microcosm_flask/conventions/logging_level.py
+++ b/microcosm_flask/conventions/logging_level.py
@@ -1,0 +1,103 @@
+"""
+Expose/manage logging levels.
+
+"""
+from collections import namedtuple
+from logging import PlaceHolder, root
+
+from marshmallow import fields, Schema
+
+from microcosm_flask.conventions.base import Convention, EndpointDefinition
+from microcosm_flask.conventions.encoding import dump_response_data
+from microcosm_flask.conventions.registry import response
+from microcosm_flask.namespaces import Namespace
+from microcosm_flask.operations import Operation
+
+
+Logger = namedtuple("Logger", ["name", "level", "logger", "children"])
+
+
+def humanize_level(value):
+    try:
+        return {
+            0: "NOTSET",
+            10: "DEBUG",
+            20: "INFO",
+            30: "WARNING",
+            40: "ERROR",
+            50: "CRITICAL",
+        }[int(value)]
+    except:
+        return value
+
+
+def make_logger_node(name, logger, parent=None):
+    if isinstance(logger, PlaceHolder):
+        # some loggers are instances of logging.PlaceHolder
+        level = parent.level
+    else:
+        level = humanize_level(logger.getEffectiveLevel())
+    node = Logger(name, level, logger, [])
+    if parent is not None:
+        parent.children.append(node)
+    return node
+
+
+def build_logger_tree():
+    """
+    Build a DFS tree representing the logger layout.
+
+    Adapted with much appreciation from: https://github.com/brandon-rhodes/logging_tree
+
+    """
+    cache = {}
+    tree = make_logger_node("", root)
+    for name, logger in sorted(root.manager.loggerDict.items()):
+        if "." in name:
+            parent_name = ".".join(name.split(".")[:-1])
+            parent = cache[parent_name]
+        else:
+            parent = tree
+
+        cache[name] = make_logger_node(name, logger, parent)
+    return tree
+
+
+class LoggerSchema(Schema):
+    name = fields.String(required=True)
+    level = fields.String(required=True)
+    children = fields.List(fields.Nested("LoggerSchema"), required=True)
+
+
+class LoggingLevel(object):
+    pass
+
+
+class LoggingLevelConvention(Convention):
+
+    def __init__(self, graph):
+        super(LoggingLevelConvention, self).__init__(graph)
+
+    def configure_retrieve(self, ns, definition):
+        response_schema = definition.response_schema
+
+        @self.add_route(ns.singleton_path, Operation.Retrieve, ns)
+        @response(response_schema)
+        def current_health():
+            logger_tree = build_logger_tree()
+            return dump_response_data(response_schema, logger_tree)
+
+
+def configure_logging_level(graph):
+    ns = Namespace(
+        subject=LoggingLevel,
+    )
+
+    convention = LoggingLevelConvention(graph)
+    convention.configure(
+        ns,
+        retrieve=EndpointDefinition(
+            response_schema=LoggerSchema(),
+        ),
+    )
+    return ns

--- a/microcosm_flask/tests/conventions/test_logging_level.py
+++ b/microcosm_flask/tests/conventions/test_logging_level.py
@@ -1,0 +1,54 @@
+"""
+Logging level test convention.
+
+"""
+from json import loads
+
+from hamcrest import (
+    assert_that,
+    equal_to,
+    has_entries,
+    has_items,
+    is_,
+)
+from microcosm.api import create_object_graph
+
+
+def test_logging_level_convention():
+    """
+    Default health check returns OK.
+
+    """
+    graph = create_object_graph(name="example", testing=True)
+    graph.use("logging_level_convention")
+    graph.lock()
+
+    client = graph.flask.test_client()
+
+    response = client.get("/api/logging_level")
+    assert_that(response.status_code, is_(equal_to(200)))
+    data = loads(response.get_data().decode("utf-8"))
+    assert_that(
+        data,
+        # this is a partial match
+        has_entries(
+            name="",
+            level="INFO",
+            children=has_items(
+                has_entries(
+                    name="bravado",
+                    level="INFO",
+                    children=has_items(
+                        has_entries(
+                            name="bravado.requests_client",
+                            level="ERROR",
+                        ),
+                    ),
+                ),
+                has_entries(
+                    name="requests",
+                    level="WARNING",
+                ),
+            ),
+        ),
+    )

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
             "error_handlers = microcosm_flask.errors:configure_error_handlers",
             "flask = microcosm_flask.factories:configure_flask",
             "health_convention = microcosm_flask.conventions.health:configure_health",
+            "logging_level_convention = microcosm_flask.conventions.logging_level:configure_logging_level",
             "port_forwarding = microcosm_flask.forwarding:configure_port_forwarding",
             "request_context = microcosm_flask.context:configure_request_context",
             "route = microcosm_flask.routing:configure_route_decorator",


### PR DESCRIPTION
Next up: allow runtime changes

Example (subset of a large) output :

```
{
  "children": [
    {
      "children": [], 
      "level": "INFO", 
      "name": "SNSProducer"
    }, 
    {
      "children": [], 
      "level": "INFO", 
      "name": "SQSMessageDispatcher"
    }, 
    {
      "children": [], 
      "level": "INFO", 
      "name": "SQSMessageHandlerRegistry"
    }, 
    {
      "children": [], 
      "level": "INFO", 
      "name": "SleepPolicy"
    },
    {
      "children": [
        {
          "children": [], 
          "level": "WARNING", 
          "name": "swagger_spec_validator.ref_validators"
        }, 
        {
          "children": [], 
          "level": "WARNING", 
          "name": "swagger_spec_validator.util"
        }, 
        {
          "children": [], 
          "level": "WARNING", 
          "name": "swagger_spec_validator.validator12"
        }, 
        {
          "children": [], 
          "level": "WARNING", 
          "name": "swagger_spec_validator.validator20"
        }
      ], 
      "level": "WARNING", 
      "name": "swagger_spec_validator"
    }, 
    {
      "children": [], 
      "level": "INFO", 
      "name": "werkzeug"
    }
  ], 
  "level": "INFO", 
  "name": ""
}