### PR TITLE
Add convention to temporarily update logging levels.

### DIFF
--- a/microcosm_flask/conventions/logging_level.py
+++ b/microcosm_flask/conventions/logging_level.py
@@ -3,18 +3,32 @@ Expose/manage logging levels.
 
 """
 from collections import namedtuple
-from logging import PlaceHolder, root
+from logging import getLogger, PlaceHolder, root
+from time import time
 
 from marshmallow import fields, Schema
+from microcosm.api import defaults
+from microcosm_logging.levels import ConditionalLoggingLevel
+from werkzeug.exceptions import UnprocessableEntity
 
 from microcosm_flask.conventions.base import Convention, EndpointDefinition
-from microcosm_flask.conventions.encoding import dump_response_data
-from microcosm_flask.conventions.registry import response
+from microcosm_flask.conventions.encoding import dump_response_data, load_request_data
+from microcosm_flask.conventions.registry import request, response
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 
 
 Logger = namedtuple("Logger", ["name", "level", "logger", "children"])
+
+
+def dehumanize_level(value):
+    return {
+        "DEBUG": 10,
+        "INFO": 20,
+        "WARNING": 30,
+        "ERROR": 30,
+        "CRITICAL": 50,
+    }[value]
 
 
 def humanize_level(value):
@@ -37,6 +51,7 @@ def make_logger_node(name, logger, parent=None):
         level = parent.level
     else:
         level = humanize_level(logger.getEffectiveLevel())
+
     node = Logger(name, level, logger, [])
     if parent is not None:
         parent.children.append(node)
@@ -69,34 +84,113 @@ class LoggerSchema(Schema):
     children = fields.List(fields.Nested("LoggerSchema"), required=True)
 
 
-class LoggingLevel(object):
-    pass
+class UpdateConditionalLoggingLevelSchema(Schema):
+    duration = fields.Float(required=False, missing=300.0)
+    name = fields.String(required=True)
+    level = fields.String(
+        required=False,
+        missing="DEBUG",
+        validate=lambda level: level in ["DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"],
+    )
+
+
+class UntilDeadline(object):
+    """
+    Boolean-valued callable that returns true until a deadline is reached.
+
+    """
+    def __init__(self, when):
+        self.when = when
+
+    def __call__(self):
+        return self.now() < self.when
+
+    @staticmethod
+    def now():
+        """
+        Mock-friendly time function.
+
+        """
+        return time()
+
+    @classmethod
+    def of_seconds(cls, delta):
+        """
+        Construct a deadline that is `delta` seconds from now.
+
+        """
+        return cls(cls.now() + delta)
 
 
 class LoggingLevelConvention(Convention):
+    """
+    Convention that exposing logging configuration.
 
+    Includes a `GET` request to retrieve the current logging tree and a `PATCH` request
+    to (temporarily) change logging levels.
+
+    """
     def __init__(self, graph):
         super(LoggingLevelConvention, self).__init__(graph)
+        self.max_duration = float(graph.config.logging_level_convention.max_duration)
 
     def configure_retrieve(self, ns, definition):
         response_schema = definition.response_schema
 
         @self.add_route(ns.singleton_path, Operation.Retrieve, ns)
         @response(response_schema)
-        def current_health():
+        def retrieve():
             logger_tree = build_logger_tree()
             return dump_response_data(response_schema, logger_tree)
 
+    def configure_update(self, ns, definition):
+        request_schema = definition.request_schema
+        response_schema = definition.response_schema
 
+        @self.add_route(ns.singleton_path, Operation.Update, ns)
+        @request(request_schema)
+        @response(response_schema)
+        def update():
+            request_data = load_request_data(request_schema)
+
+            logger = getLogger(request_data["name"])
+            oldLevel = logger.getEffectiveLevel()
+            newLevel = dehumanize_level(request_data["level"])
+
+            duration = request_data["duration"]
+
+            if duration > self.max_duration:
+                raise UnprocessableEntity("Duration is more than {}".format(self.max_duration))
+
+            until_deadline = UntilDeadline.of_seconds(duration)
+
+            ConditionalLoggingLevel.setLevel(
+                logger,
+                newLevel,
+                oldLevel,
+                until_deadline,
+            )
+
+            logger_tree = build_logger_tree()
+            return dump_response_data(response_schema, logger_tree, Operation.Update.value.default_code)
+
+
+@defaults(
+    max_duration=300.0,
+)
 def configure_logging_level(graph):
     ns = Namespace(
-        subject=LoggingLevel,
+        subject="logging_level",
     )
 
     convention = LoggingLevelConvention(graph)
     convention.configure(
         ns,
         retrieve=EndpointDefinition(
+            response_schema=LoggerSchema(),
+        ),
+        update=EndpointDefinition(
+            request_schema=UpdateConditionalLoggingLevelSchema(),
             response_schema=LoggerSchema(),
         ),
     )

--- a/microcosm_flask/tests/conventions/test_logging_level.py
+++ b/microcosm_flask/tests/conventions/test_logging_level.py
@@ -2,7 +2,8 @@
 Logging level test convention.
 
 """
-from json import loads
+from json import dumps, loads
+from time import time
 
 from hamcrest import (
     assert_that,
@@ -12,9 +13,12 @@ from hamcrest import (
     is_,
 )
 from microcosm.api import create_object_graph
+from mock import patch
+
+from microcosm_flask.conventions.logging_level import UntilDeadline
 
 
-def test_logging_level_convention():
+def test_retrieve_logging_levels():
     """
     Default health check returns OK.
 
@@ -48,6 +52,60 @@ def test_logging_level_convention():
                 has_entries(
                     name="requests",
                     level="WARNING",
+                ),
+            ),
+        ),
+    )
+
+
+def test_create_conditional_logging_level():
+    """
+    Default health check returns OK.
+
+    """
+    graph = create_object_graph(name="example", testing=True)
+    graph.use("logging_level_convention")
+    graph.lock()
+
+    client = graph.flask.test_client()
+
+    response = client.patch("/api/logging_level", data=dumps(dict(
+        duration=1.0,
+        name="requests",
+    )))
+    assert_that(response.status_code, is_(equal_to(200)))
+    data = loads(response.get_data().decode("utf-8"))
+    assert_that(
+        data,
+        # this is a partial match
+        has_entries(
+            children=has_items(
+                has_entries(
+                    name="requests",
+                    level="DEBUG",
+                ),
+            ),
+        ),
+    )
+
+    with patch.object(UntilDeadline, "now") as mocked:
+        mocked.return_value = time() + 2
+
+        response = client.patch("/api/logging_level", data=dumps(dict(
+            duration=1.0,
+            name="requests",
+        )))
+
+    assert_that(response.status_code, is_(equal_to(200)))
+    data = loads(response.get_data().decode("utf-8"))
+    assert_that(
+        data,
+        # this is a partial match
+        has_entries(
+            children=has_items(
+                has_entries(
+                    name="requests",
+                    level="DEBUG",
                 ),
             ),
         ),

--- a/microcosm_flask/tests/conventions/test_logging_level.py
+++ b/microcosm_flask/tests/conventions/test_logging_level.py
@@ -20,7 +20,7 @@ from microcosm_flask.conventions.logging_level import UntilDeadline
 
 def test_retrieve_logging_levels():
     """
-    Default health check returns OK.
+    Can retrieve current logging levels.
 
     """
     graph = create_object_graph(name="example", testing=True)
@@ -58,9 +58,9 @@ def test_retrieve_logging_levels():
     )
 
 
-def test_create_conditional_logging_level():
+def test_update_conditional_logging_level():
     """
-    Default health check returns OK.
+    Can update logging levels temporarily.
 
     """
     graph = create_object_graph(name="example", testing=True)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "Flask-UUID>=0.2",
         "marshmallow>=2.12.2",
         "microcosm>=0.17.0",
-        "microcosm-logging>=0.12.0",
+        "microcosm-logging>=0.14.2",
         "openapi>=0.5.0",
         "python-dateutil>=2.5.2",
         "PyYAML>=3.11",


### PR DESCRIPTION
You can now `PATCH` the logging convention endpoint to set logging level for a period
of time. The duration can be capped (default: 5m) and *should* switch back because
of the `ConditionaLLoggingLevel` feature.