### PR TITLE
Use headers to control debug logging instead of timing.

### DIFF
--- a/microcosm_flask/tests/conventions/test_logging_level.py
+++ b/microcosm_flask/tests/conventions/test_logging_level.py
@@ -2,8 +2,7 @@
 Logging level test convention.
 
 """
-from json import dumps, loads
-from time import time
+from json import loads
 
 from hamcrest import (
     assert_that,
@@ -13,9 +12,6 @@ from hamcrest import (
     is_,
 )
 from microcosm.api import create_object_graph
-from mock import patch
-
-from microcosm_flask.conventions.logging_level import UntilDeadline
 
 
 def test_retrieve_logging_levels():
@@ -52,60 +48,6 @@ def test_retrieve_logging_levels():
                 has_entries(
                     name="requests",
                     level="WARNING",
-                ),
-            ),
-        ),
-    )
-
-
-def test_update_conditional_logging_level():
-    """
-    Can update logging levels temporarily.
-
-    """
-    graph = create_object_graph(name="example", testing=True)
-    graph.use("logging_level_convention")
-    graph.lock()
-
-    client = graph.flask.test_client()
-
-    response = client.patch("/api/logging_level", data=dumps(dict(
-        duration=1.0,
-        name="requests",
-    )))
-    assert_that(response.status_code, is_(equal_to(200)))
-    data = loads(response.get_data().decode("utf-8"))
-    assert_that(
-        data,
-        # this is a partial match
-        has_entries(
-            children=has_items(
-                has_entries(
-                    name="requests",
-                    level="DEBUG",
-                ),
-            ),
-        ),
-    )
-
-    with patch.object(UntilDeadline, "now") as mocked:
-        mocked.return_value = time() + 2
-
-        response = client.patch("/api/logging_level", data=dumps(dict(
-            duration=1.0,
-            name="requests",
-        )))
-
-    assert_that(response.status_code, is_(equal_to(200)))
-    data = loads(response.get_data().decode("utf-8"))
-    assert_that(
-        data,
-        # this is a partial match
-        has_entries(
-            children=has_items(
-                has_entries(
-                    name="requests",
-                    level="DEBUG",
                 ),
             ),
         ),

--- a/microcosm_flask/tests/test_audit.py
+++ b/microcosm_flask/tests/test_audit.py
@@ -2,6 +2,8 @@
 Audit structure tests.
 
 """
+from logging import DEBUG, NOTSET, getLogger
+
 from flask import g
 from hamcrest import (
     assert_that,
@@ -14,7 +16,7 @@ from microcosm.api import create_object_graph
 from mock import MagicMock
 from werkzeug.exceptions import NotFound
 
-from microcosm_flask.audit import AuditOptions, RequestInfo
+from microcosm_flask.audit import AuditOptions, RequestInfo, logging_levels
 
 
 def test_func(*args, **kwargs):
@@ -290,20 +292,30 @@ class TestRequestInfo(object):
             ))
             logger.warning.assert_not_called()
 
-    def test_log_internal_server_error(self):
+    def test_root_logging_level(self):
         """
-        Log at WARNING on internal server error.
+        Enable DEBUG logging temporarily.
 
         """
-        with self.graph.flask.test_request_context("/"):
-            request_info = RequestInfo(self.options, test_func, None)
-            request_info.status_code = 500
+        assert_that(getLogger().getEffectiveLevel(), is_(equal_to(NOTSET)))
+        with self.graph.flask.test_request_context("/", headers={"X-Debug": "*"}):
+            with logging_levels():
+                assert_that(getLogger().getEffectiveLevel(), is_(equal_to(DEBUG)))
+        assert_that(getLogger().getEffectiveLevel(), is_(equal_to(NOTSET)))
 
-            logger = MagicMock()
-            request_info.log(logger)
-            logger.warning.assert_called_with(dict(
-                operation="test_func",
-                method="GET",
-                func="test_func",
-            ))
-            logger.info.assert_not_called()
+    def test_component_logging_level(self):
+        """
+        Enable DEBUG logging temporarily.
+
+        """
+        assert_that(getLogger("foo").getEffectiveLevel(), is_(equal_to(NOTSET)))
+        assert_that(getLogger("bar").getEffectiveLevel(), is_(equal_to(NOTSET)))
+        assert_that(getLogger("baz").getEffectiveLevel(), is_(equal_to(NOTSET)))
+        with self.graph.flask.test_request_context("/", headers={"X-Debug": "foo,baz"}):
+            with logging_levels():
+                assert_that(getLogger("foo").getEffectiveLevel(), is_(equal_to(DEBUG)))
+                assert_that(getLogger("bar").getEffectiveLevel(), is_(equal_to(NOTSET)))
+                assert_that(getLogger("baz").getEffectiveLevel(), is_(equal_to(DEBUG)))
+        assert_that(getLogger("foo").getEffectiveLevel(), is_(equal_to(NOTSET)))
+        assert_that(getLogger("bar").getEffectiveLevel(), is_(equal_to(NOTSET)))
+        assert_that(getLogger("baz").getEffectiveLevel(), is_(equal_to(NOTSET)))

--- a/microcosm_flask/tests/test_audit.py
+++ b/microcosm_flask/tests/test_audit.py
@@ -298,24 +298,7 @@ class TestRequestInfo(object):
 
         """
         assert_that(getLogger().getEffectiveLevel(), is_(equal_to(NOTSET)))
-        with self.graph.flask.test_request_context("/", headers={"X-Debug": "*"}):
+        with self.graph.flask.test_request_context("/", headers={"X-Request-Debug": "true"}):
             with logging_levels():
                 assert_that(getLogger().getEffectiveLevel(), is_(equal_to(DEBUG)))
         assert_that(getLogger().getEffectiveLevel(), is_(equal_to(NOTSET)))
-
-    def test_component_logging_level(self):
-        """
-        Enable DEBUG logging temporarily.
-
-        """
-        assert_that(getLogger("foo").getEffectiveLevel(), is_(equal_to(NOTSET)))
-        assert_that(getLogger("bar").getEffectiveLevel(), is_(equal_to(NOTSET)))
-        assert_that(getLogger("baz").getEffectiveLevel(), is_(equal_to(NOTSET)))
-        with self.graph.flask.test_request_context("/", headers={"X-Debug": "foo,baz"}):
-            with logging_levels():
-                assert_that(getLogger("foo").getEffectiveLevel(), is_(equal_to(DEBUG)))
-                assert_that(getLogger("bar").getEffectiveLevel(), is_(equal_to(NOTSET)))
-                assert_that(getLogger("baz").getEffectiveLevel(), is_(equal_to(DEBUG)))
-        assert_that(getLogger("foo").getEffectiveLevel(), is_(equal_to(NOTSET)))
-        assert_that(getLogger("bar").getEffectiveLevel(), is_(equal_to(NOTSET)))
-        assert_that(getLogger("baz").getEffectiveLevel(), is_(equal_to(NOTSET)))


### PR DESCRIPTION
It turned out that the log level update logic was very impractical because
a real world setting will have many instances spread across multiple processes;
updating the logging levels only takes place in one of these.

A better approach is enable logging per request by a header.