### PR TITLE
Allow explicit setting of the host to use for service `url_for` resolution

### DIFF
--- a/microcosm_flask/forwarding.py
+++ b/microcosm_flask/forwarding.py
@@ -19,21 +19,36 @@ def use_forwarded_port(graph):
     The URL adapter is used by `url_for` to build a URLs.
 
     """
-    forwarded_port = request.headers.get("X-Forwarded-Port")
-    if not forwarded_port:
-        return None
+    # There must be a better way!
+    context = _request_ctx_stack.top
 
     if _request_ctx_stack is None:
         return None
 
-    # There must be a better way!
-    context = _request_ctx_stack.top
-    context.url_adapter.server_name = "{}:{}".format(
-        context.url_adapter.server_name.split(":", 1)[0],
-        forwarded_port,
-    )
+    # determine the configured overrides
+    forwarded_host = graph.config.port_forwarding.get("host")
+    forwarded_port = request.headers.get("X-Forwarded-Port")
 
-    return forwarded_port
+    if not forwarded_port and not forwarded_host:
+        return None
+
+    # determine the current server name
+    if ":" in context.url_adapter.server_name:
+        server_host, server_port = context.url_adapter.server_name.split(":", 1)
+    else:
+        server_host = context.url_adapter.server_name
+        server_port = 443 if context.url_adapter.url_scheme == "https" else 80
+
+    # choose a new server name
+    if forwarded_host:
+        server_name = forwarded_host
+    elif server_port:
+        server_name = "{}:{}".format(server_host, forwarded_port)
+    else:
+        server_name = "{}:{}".format(server_host, server_port)
+
+    context.url_adapter.server_name = server_name
+    return server_name
 
 
 def configure_port_forwarding(graph):

--- a/microcosm_flask/tests/test_forwarding.py
+++ b/microcosm_flask/tests/test_forwarding.py
@@ -9,27 +9,52 @@ from hamcrest import (
     is_,
 )
 from microcosm.api import create_object_graph
+from microcosm.loaders import load_from_dict
 from six import b
 
 
-def test_forwarding():
-    graph = create_object_graph("test", testing=True)
-    graph.use(
-        "flask",
-        "port_forwarding",
-    )
+class TestForwarding(object):
 
-    @graph.app.route("/", endpoint="test")
-    def endpoint():
-        return url_for("test", _external=True)
+    def init(self, loader):
+        graph = create_object_graph("test", testing=True, loader=loader)
+        graph.use(
+            "flask",
+            "port_forwarding",
+        )
 
-    client = graph.app.test_client()
-    response = client.get(
-        "/",
-        headers={
-            "X-Forwarded-Port": "8080",
-        },
-    )
+        @graph.app.route("/", endpoint="test")
+        def endpoint():
+            return url_for("test", _external=True)
 
-    assert_that(response.status_code, is_(equal_to(200)))
-    assert_that(response.data, is_(equal_to(b("http://localhost:8080/"))))
+        return graph.app.test_client()
+
+    def test_port_forwarding(self):
+        loader = load_from_dict()
+        client = self.init(loader)
+        response = client.get(
+            "/",
+            headers={
+                "X-Forwarded-Port": "8080",
+            },
+        )
+
+        assert_that(response.status_code, is_(equal_to(200)))
+        assert_that(response.data, is_(equal_to(b("http://localhost:8080/"))))
+
+    def test_host_override(self):
+        loader = load_from_dict(
+            port_forwarding=dict(
+                host="service",
+            )
+        )
+        client = self.init(loader)
+
+        response = client.get(
+            "/",
+            headers={
+                "X-Forwarded-Port": "8080",
+            },
+        )
+
+        assert_that(response.status_code, is_(equal_to(200)))
+        assert_that(response.data, is_(equal_to(b("http://service/"))))


### PR DESCRIPTION
During some forwarding scenarios (ssh, docker), the inbound host isn't
reachable by the service; this means we can't use `url_for` verbatim