### PR TITLE
Deserialize QueryStringList items

### DIFF
--- a/microcosm_flask/fields/query_string_list.py
+++ b/microcosm_flask/fields/query_string_list.py
@@ -24,6 +24,6 @@ class QueryStringList(List):
             attribute_elements = [attr_element.split(",") for attr_element in obj.getlist(attr)]
             attribute_params = [param for attr_param in attribute_elements for param in attr_param]
 
-            return attribute_params
+            return super(QueryStringList, self)._deserialize(attribute_params, attr, obj)
         except ValueError:
             raise ValidationError("Invalid query string list argument")

--- a/microcosm_flask/tests/fields/test_query_string_list.py
+++ b/microcosm_flask/tests/fields/test_query_string_list.py
@@ -7,15 +7,34 @@ from hamcrest import (
     equal_to,
     is_,
 )
+from enum import Enum
 from werkzeug.datastructures import ImmutableMultiDict
 from marshmallow import Schema
 from marshmallow.fields import String
 
-from microcosm_flask.fields import QueryStringList
+from microcosm_flask.fields import QueryStringList, EnumField
 
 
 class QueryStringListSchema(Schema):
     foo_ids = QueryStringList(String())
+
+
+class TestEnum(Enum):
+    A = "A"
+    B = "B"
+
+
+class EnumQueryStringListSchema(Schema):
+    foo_ids = QueryStringList(EnumField(TestEnum))
+
+
+def test_query_list_deserialize_items():
+    schema = EnumQueryStringListSchema()
+    result = schema.load(
+        ImmutableMultiDict([("foo_ids", "A,B")]),
+    )
+
+    assert_that(result.data["foo_ids"], is_(equal_to([TestEnum.A, TestEnum.B])))
 
 
 def test_query_list_load_with_comma_separated_single_keys():


### PR DESCRIPTION
when we use `microcosm_flask.fields.query_string_list.QueryStringList` list items are not deserialized, please see the added test case