### PR TITLE
Another page for output qs generation + better serialization for QueryStringList

### DIFF
--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -54,9 +54,9 @@ class CRUDConvention(Convention):
         @qs(definition.request_schema)
         @response(paginated_list_schema)
         def search(**path_data):
-            page = self.page_cls.from_query_string(definition.request_schema)
-            result = definition.func(**merge_data(path_data, page.to_dict(func=identity)))
-            response_data, headers = page.to_paginated_list(result, ns, Operation.Search)
+            in_page, out_page = self.page_cls.from_query_string(definition.request_schema)
+            result = definition.func(**merge_data(path_data, in_page.to_dict(func=identity)))
+            response_data, headers = out_page.to_paginated_list(result, ns, Operation.Search)
             return dump_response_data(paginated_list_schema, response_data, headers=headers)
 
         search.__doc__ = "Search the collection of all {}".format(pluralize(ns.subject_name))
@@ -241,17 +241,17 @@ class CRUDConvention(Convention):
             request_data = load_request_data(definition.request_schema)
             # NB: if we don't filter the request body through an explicit page schema,
             # we will leak other request arguments into the pagination query strings
-            page = self.page_cls.from_query_string(self.page_schema(), request_data)
+            in_page, out_page = self.page_cls.from_query_string(self.page_schema(), request_data)
 
             result = definition.func(**merge_data(
                 path_data,
                 merge_data(
                     request_data,
-                    page.to_dict(func=identity),
+                    in_page.to_dict(func=identity),
                 ),
             ))
 
-            response_data, headers = page.to_paginated_list(result, ns, Operation.CreateCollection)
+            response_data, headers = out_page.to_paginated_list(result, ns, Operation.CreateCollection)
             return dump_response_data(paginated_list_schema, response_data, headers=headers)
 
         create_collection.__doc__ = "Create the collection of {}".format(pluralize(ns.subject_name))

--- a/microcosm_flask/conventions/discovery.py
+++ b/microcosm_flask/conventions/discovery.py
@@ -57,14 +57,14 @@ class DiscoveryConvention(Convention):
         @self.add_route("/", Operation.Discover, ns)
         def discover():
             # accept pagination limit from request
-            page = OffsetLimitPage.from_query_string(page_schema)
-            page.offset = 0
+            _, out_page = OffsetLimitPage.from_query_string(page_schema)
+            out_page.offset = 0
 
             response_data = dict(
                 _links=Links({
-                    "self": Link.for_(Operation.Discover, ns, qs=page.to_items()),
+                    "self": Link.for_(Operation.Discover, ns, qs=out_page.to_items()),
                     "search": [
-                        link for link in iter_links(self.find_matching_endpoints(ns), page)
+                        link for link in iter_links(self.find_matching_endpoints(ns), out_page)
                     ],
                 }).to_dict()
             )

--- a/microcosm_flask/conventions/relation.py
+++ b/microcosm_flask/conventions/relation.py
@@ -190,9 +190,9 @@ class RelationConvention(Convention):
         @response(paginated_list_schema)
         def search(**path_data):
             request_data = load_query_string_data(definition.request_schema)
-            page = self.page_cls.from_query_string(definition.request_schema)
+            _, out_page = self.page_cls.from_query_string(definition.request_schema)
             result = definition.func(**merge_data(path_data, request_data))
-            response_data, headers = page.to_paginated_list(result, ns, Operation.SearchFor)
+            response_data, headers = out_page.to_paginated_list(result, ns, Operation.SearchFor)
             return dump_response_data(paginated_list_schema, response_data, headers=headers)
 
         search.__doc__ = "Search for {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)

--- a/microcosm_flask/fields/query_string_list.py
+++ b/microcosm_flask/fields/query_string_list.py
@@ -27,3 +27,6 @@ class QueryStringList(List):
             return attribute_params
         except ValueError:
             raise ValidationError("Invalid query string list argument")
+
+    def _serialize(self, value, attr, obj):
+        return ",".join(str(val) for val in super(QueryStringList, self)._serialize(value, attr, obj))

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -95,8 +95,12 @@ def address_retrieve(id, person_id, address_id):
     return ADDRESS_1
 
 
-def address_search(person_id, offset, limit):
-    return [ADDRESS_1], 1, dict(person_id=person_id)
+def address_search(person_id, offset, limit, list_param=None, enum_param=None):
+    if list_param is None or enum_param is None:
+        return [ADDRESS_1], 1, dict(person_id=person_id)
+    return Address(ADDRESS_ID_1,
+                   PERSON_ID_1,
+                   ",".join(list_param) + str(len(list_param)) + enum_param.value), 1, dict(person_id=person_id)
 
 
 def person_create(**kwargs):

--- a/microcosm_flask/tests/fields/test_query_string_list.py
+++ b/microcosm_flask/tests/fields/test_query_string_list.py
@@ -42,10 +42,23 @@ def test_query_list_load_with_duplicate_keys():
     assert_that(result.data["foo_ids"], is_(equal_to(["a", "b"])))
 
 
+def test_reuse_list_dump():
+    schema = QueryStringListSchema()
+    result = schema.load(
+        ImmutableMultiDict([("foo_ids", "a,b")]),
+    )
+    result = schema.dump(result.data)
+    result = schema.load(
+        ImmutableMultiDict(result.data.items()),
+    )
+
+    assert_that(result.data["foo_ids"], is_(equal_to(["a", "b"])))
+
+
 def test_query_list_dump():
     schema = QueryStringListSchema()
     result = schema.dump({
         "foo_ids": ["a"],
     })
 
-    assert_that(result.data["foo_ids"], is_(equal_to(["a"])))
+    assert_that(result.data["foo_ids"], is_(equal_to("a")))

--- a/microcosm_flask/tests/test_paging.py
+++ b/microcosm_flask/tests/test_paging.py
@@ -37,11 +37,11 @@ def test_offset_limit_page_to_from_dict():
 def test_offset_limit_page_from_query_string():
     graph = create_object_graph(name="example", testing=True)
     with graph.flask.test_request_context(query_string="offset=1&foo=bar"):
-        page = OffsetLimitPage.from_query_string(OffsetLimitPageSchema())
-        assert_that(page.offset, is_(equal_to(1)))
-        assert_that(page.limit, is_(equal_to(20)))
+        in_page, _ = OffsetLimitPage.from_query_string(OffsetLimitPageSchema())
+        assert_that(in_page.offset, is_(equal_to(1)))
+        assert_that(in_page.limit, is_(equal_to(20)))
         # schema filters out extra arguments
-        assert_that(page.to_dict(), is_not(has_entry("foo", "bar")))
+        assert_that(in_page.to_dict(), is_not(has_entry("foo", "bar")))
 
 
 def test_offset_limit_page_to_paginated_list():


### PR DESCRIPTION
In case we can neglect wrong query strings in search REST response links I don't need this PR

1. when we send a list in query string e.g. `a,b,c` we got in the REST response self link `[a,b,c]` that cannot be parsed back by QueryStringList properly

2. when we want to send a list of enums in query string and this enum is int based e.g. https://github.com/globality-corp/marquez/blob/master/marquez/enums/chatroom_event.py#L9 we want to deserialize the incoming value into enum object but then we got values like `SystemNoun.MESSAGE` instead of `1` in the query string of links in the REST response (showing this require https://github.com/globality-corp/microcosm-flask/pull/129)