### PR TITLE
Use self serializable list in QueryStringList

### DIFF
--- a/microcosm_flask/fields/query_string_list.py
+++ b/microcosm_flask/fields/query_string_list.py
@@ -27,8 +27,8 @@ class QueryStringList(List):
 
         try:
             attribute_elements = [attr_element.split(",") for attr_element in obj.getlist(attr)]
-            attribute_params = PrintableList(param for attr_param in attribute_elements for param in attr_param)
+            attribute_params = [param for attr_param in attribute_elements for param in attr_param]
 
-            return attribute_params
+            return PrintableList(super(QueryStringList, self)._deserialize(attribute_params, attr, obj))
         except ValueError:
             raise ValidationError("Invalid query string list argument")

--- a/microcosm_flask/fields/query_string_list.py
+++ b/microcosm_flask/fields/query_string_list.py
@@ -5,6 +5,11 @@ A list field field that supports query string parameter parsing.
 from marshmallow.fields import List, ValidationError
 
 
+class SelfSerializableList(list):
+    def __str__(self):
+        return ",".join(str(item) for item in self)
+
+
 class QueryStringList(List):
     def _deserialize(self, value, attr, obj):
         """
@@ -22,7 +27,7 @@ class QueryStringList(List):
 
         try:
             attribute_elements = [attr_element.split(",") for attr_element in obj.getlist(attr)]
-            attribute_params = [param for attr_param in attribute_elements for param in attr_param]
+            attribute_params = SelfSerializableList(param for attr_param in attribute_elements for param in attr_param)
 
             return attribute_params
         except ValueError:

--- a/microcosm_flask/fields/query_string_list.py
+++ b/microcosm_flask/fields/query_string_list.py
@@ -5,7 +5,7 @@ A list field field that supports query string parameter parsing.
 from marshmallow.fields import List, ValidationError
 
 
-class SelfSerializableList(list):
+class PrintableList(list):
     def __str__(self):
         return ",".join(str(item) for item in self)
 
@@ -27,7 +27,7 @@ class QueryStringList(List):
 
         try:
             attribute_elements = [attr_element.split(",") for attr_element in obj.getlist(attr)]
-            attribute_params = SelfSerializableList(param for attr_param in attribute_elements for param in attr_param)
+            attribute_params = PrintableList(param for attr_param in attribute_elements for param in attr_param)
 
             return attribute_params
         except ValueError:

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -98,9 +98,11 @@ def address_retrieve(id, person_id, address_id):
 def address_search(person_id, offset, limit, list_param=None, enum_param=None):
     if list_param is None or enum_param is None:
         return [ADDRESS_1], 1, dict(person_id=person_id)
-    return Address(ADDRESS_ID_1,
-                   PERSON_ID_1,
-                   ",".join(list_param) + str(len(list_param)) + enum_param.value), 1, dict(person_id=person_id)
+    return Address(
+        ADDRESS_ID_1,
+        PERSON_ID_1,
+        ",".join(list_param) + str(len(list_param)) + enum_param.value
+    ), 1, dict(person_id=person_id)
 
 
 def person_create(**kwargs):

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -95,8 +95,12 @@ def address_retrieve(id, person_id, address_id):
     return ADDRESS_1
 
 
-def address_search(person_id, offset, limit):
-    return [ADDRESS_1], 1, dict(person_id=person_id)
+def address_search(person_id, offset, limit, list_param=None, enum_param=None):
+    if list_param is None or enum_param is None:
+        return [ADDRESS_1], 1, dict(person_id=person_id)
+    return Address(ADDRESS_ID_1,
+                   PERSON_ID_1,
+                   ",".join(list_param) + str(len(list_param)) + enum_param.value), 1, dict(person_id=person_id)
 
 
 def person_create(**kwargs):

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -4,6 +4,8 @@ CRUD convention tests.
 """
 from json import dumps, loads
 
+from enum import Enum
+
 from hamcrest import (
     assert_that,
     contains_inanyorder,
@@ -11,11 +13,14 @@ from hamcrest import (
     is_,
 )
 
+from marshmallow.fields import String
+
 from microcosm.api import create_object_graph
 from microcosm_flask.conventions.crud import configure_crud
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 from microcosm_flask.paging import OffsetLimitPageSchema
+from microcosm_flask.fields import QueryStringList, EnumField
 from microcosm_flask.tests.conventions.fixtures import (
     Address,
     AddressSchema,
@@ -41,6 +46,19 @@ from microcosm_flask.tests.conventions.fixtures import (
 )
 
 
+class TestEnum(Enum):
+    A = "A"
+    B = "B"
+
+    def __str__(self):
+        return self.value
+
+
+class SearchAddressPageSchema(OffsetLimitPageSchema):
+    list_param = QueryStringList(String())
+    enum_param = EnumField(TestEnum)
+
+
 PERSON_MAPPINGS = {
     Operation.Create: (person_create, NewPersonSchema(), PersonSchema()),
     Operation.Delete: (person_delete,),
@@ -54,7 +72,7 @@ PERSON_MAPPINGS = {
 
 ADDRESS_MAPPINGS = {
     Operation.Retrieve: (address_retrieve, AddressSchema()),
-    Operation.Search: (address_search, OffsetLimitPageSchema(), AddressSchema()),
+    Operation.Search: (address_search, SearchAddressPageSchema(), AddressSchema()),
 }
 
 
@@ -131,6 +149,32 @@ class TestCrud(object):
             "_links": {
                 "self": {
                     "href": "http://localhost/api/person/{}/address?offset=0&limit=20".format(PERSON_ID_1),
+                }
+            }
+        })
+
+    def test_reuse_search_self_link(self):
+        uri = "/api/person/{}/address?list_param=a,b,c&enum_param=A".format(PERSON_ID_1)
+        response = self.client.get(uri)
+        response_data = loads(response.get_data().decode("utf-8"))
+        response = self.client.get(response_data["_links"]["self"]["href"])
+        self.assert_response(response, 200, {
+            "count": 1,
+            "offset": 0,
+            "limit": 20,
+            "items": [{
+                "id": str(ADDRESS_ID_1),
+                "addressLine": "a,b,c3A",
+                "_links": {
+                    "self": {
+                        "href": "http://localhost/api/person/{}/address/{}".format(PERSON_ID_1, ADDRESS_ID_1),
+                    }
+                },
+            }],
+            "_links": {
+                "self": {
+                    "href": "http://localhost/api/person/{}/address?offset=0&limit=20&enum_param=A&list_param=a%2Cb%2Cc"
+                            .format(PERSON_ID_1),
                 }
             }
         })


### PR DESCRIPTION
```
>>> from enum import Enum
>>> class A(Enum):
...     A = 1
...     def __str__(self):
...             return self.name
... 
>>> [A.A]
[<A.A: 1>]
>>> str([A.A])
'[<A.A: 1>]'
>>> str(A.A)
'A'
```