### PR TITLE
Remove several deprecated code paths

### DIFF
--- a/microcosm_flask/conventions/build_info.py
+++ b/microcosm_flask/conventions/build_info.py
@@ -42,7 +42,6 @@ class BuildInfoConvention(Convention):
 
 
 @defaults(
-    path_prefix="",
     build_num=None,
     sha1=None,
 )
@@ -52,7 +51,6 @@ def configure_build_info(graph):
 
     """
     ns = Namespace(
-        path=graph.config.build_info_convention.path_prefix,
         subject=BuildInfo,
     )
 

--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -16,7 +16,6 @@ from microcosm_flask.conventions.encoding import (
     require_response_data,
 )
 from microcosm_flask.conventions.registry import qs, request, response
-from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 from microcosm_flask.paging import identity, OffsetLimitPage, OffsetLimitPageSchema
 
@@ -264,7 +263,7 @@ class CRUDConvention(Convention):
         create_collection.__doc__ = "Create the collection of {}".format(pluralize(ns.subject_name))
 
 
-def configure_crud(graph, ns, mappings, path_prefix=""):
+def configure_crud(graph, ns, mappings):
     """
     Register CRUD endpoints for a resource object.
 
@@ -281,6 +280,5 @@ def configure_crud(graph, ns, mappings, path_prefix=""):
         }
 
     """
-    ns = Namespace.make(ns, path=path_prefix)
     convention = CRUDConvention(graph)
     convention.configure(ns, mappings)

--- a/microcosm_flask/conventions/discovery.py
+++ b/microcosm_flask/conventions/discovery.py
@@ -76,7 +76,6 @@ class DiscoveryConvention(Convention):
     operations=[
         "search",
     ],
-    path_prefix="",
 )
 def configure_discovery(graph):
     """
@@ -84,7 +83,6 @@ def configure_discovery(graph):
 
     """
     ns = Namespace(
-        path=graph.config.discovery_convention.path_prefix,
         subject=graph.config.discovery_convention.name,
     )
     convention = DiscoveryConvention(graph)

--- a/microcosm_flask/conventions/health.py
+++ b/microcosm_flask/conventions/health.py
@@ -5,7 +5,6 @@ Reports service health and basic information from the "/api/health" endpoint,
 using HTTP 200/503 status codes to indicate healthiness.
 
 """
-from microcosm.api import defaults
 from microcosm_flask.audit import skip_logging
 from microcosm_flask.conventions.base import Convention
 from microcosm_flask.conventions.encoding import make_response
@@ -97,9 +96,6 @@ class HealthConvention(Convention):
             return make_response(response_data, status_code=status_code)
 
 
-@defaults(
-    path_prefix="",
-)
 def configure_health(graph):
     """
     Configure the health endpoint.
@@ -108,7 +104,6 @@ def configure_health(graph):
               manipulate health state.
     """
     ns = Namespace(
-        path=graph.config.health_convention.path_prefix,
         subject=Health,
     )
 

--- a/microcosm_flask/conventions/relation.py
+++ b/microcosm_flask/conventions/relation.py
@@ -18,7 +18,6 @@ from microcosm_flask.conventions.encoding import (
     require_response_data,
 )
 from microcosm_flask.conventions.registry import qs, request, response
-from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 from microcosm_flask.paging import OffsetLimitPage
 
@@ -205,11 +204,10 @@ class RelationConvention(Convention):
         search.__doc__ = "Search for {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
 
 
-def configure_relation(graph, ns, mappings, path_prefix=""):
+def configure_relation(graph, ns, mappings):
     """
     Register relation endpoint(s) between two resources.
 
     """
-    ns = Namespace.make(ns, path=path_prefix)
     convention = RelationConvention(graph)
     convention.configure(ns, mappings)

--- a/microcosm_flask/conventions/swagger.py
+++ b/microcosm_flask/conventions/swagger.py
@@ -72,7 +72,6 @@ class SwaggerConvention(Convention):
         "upload",
         "upload_for",
     ],
-    path_prefix="",
     version="",
 )
 def configure_swagger(graph):
@@ -81,7 +80,6 @@ def configure_swagger(graph):
 
     """
     ns = Namespace(
-        path=graph.config.swagger_convention.path_prefix,
         subject=graph.config.swagger_convention.name,
         version=graph.config.swagger_convention.version,
     )

--- a/microcosm_flask/linking.py
+++ b/microcosm_flask/linking.py
@@ -11,6 +11,7 @@ from werkzeug.routing import BuildError
 
 from microcosm_flask.namespaces import Namespace
 
+
 # NB: it would be nice to use marshmallow schemas in lieu of `to_dict()` functions here
 #
 # The main obstacles are:
@@ -87,9 +88,7 @@ class Link(object):
         :param kwargs: optional endpoint expansion arguments (e.g. for URI parameters)
         :raises BuildError: if link templating is needed and disallowed
         """
-        # ensure that we actually have a Namespace; many legacy code paths use strings or tuples
-        ns = Namespace.make(ns)
-
+        assert isinstance(ns, Namespace)
         try:
             href, templated = ns.href_for(operation, qs=qs, **kwargs), False
         except BuildError as error:

--- a/microcosm_flask/namespaces.py
+++ b/microcosm_flask/namespaces.py
@@ -32,11 +32,9 @@ class Namespace(object):
     object encapsulates the rest.
 
     """
-
     def __init__(self,
                  subject,
                  object_=None,
-                 path=None,
                  prefix=None,
                  controller=None,
                  version=None,
@@ -50,10 +48,12 @@ class Namespace(object):
         :param controller: the object responsible for implementations associated with this namespace.
         :param version: the version of this namespace
         :param enable_basic_auth: enable basic auth for this namespace if it's not enabled globally
+        :param identifier_type: the Flask data type to use for identifiers; usually `uuid` or `string`
+
         """
         self.subject = subject
         self.object_ = object_
-        self.prefix = prefix or path or ""
+        self.prefix = prefix or ""
         self.controller = controller
         self.version = version
         self.enable_basic_auth = enable_basic_auth
@@ -167,26 +167,3 @@ class Namespace(object):
             url,
             "{}{}".format(qs_character, urlencode(qs)) if qs else "",
         )
-
-    @classmethod
-    def make(cls, value, path=None):
-        """
-        Create a Namespace from a value.
-
-        Used to transition older APIs that relied on strings/objects/tuples/lists
-        to pass subject and object information instead of Namespace instances.
-
-        """
-        if isinstance(value, Namespace):
-            return value
-        elif isinstance(value, (tuple, list)):
-            return cls(
-                subject=value[0],
-                object_=value[1],
-                path=path,
-            )
-        else:
-            return cls(
-                subject=value,
-                path=path,
-            )

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -51,15 +51,9 @@ class AddressSchema(NewAddressSchema):
         links = Links()
         links["self"] = Link.for_(
             Operation.Retrieve,
-            ns=Namespace(
-                subject=Address,
-                path=Namespace(
-                    subject=Person,
-                ).instance_path,
-            ),
-            person_id=obj.person_id,
+            Namespace(subject=Address),
             address_id=obj.id,
-            )
+        )
         return links.to_dict()
 
 
@@ -69,7 +63,11 @@ class PersonSchema(NewPersonSchema):
 
     def get_links(self, obj):
         links = Links()
-        links["self"] = Link.for_(Operation.Retrieve, Person, person_id=obj.id)
+        links["self"] = Link.for_(
+            Operation.Retrieve,
+            Namespace(subject=Person),
+            person_id=obj.id,
+        )
         return links.to_dict()
 
 
@@ -91,18 +89,18 @@ PERSON_3 = Person(PERSON_ID_3, "Charlie", "Smith")
 ADDRESS_1 = Address(ADDRESS_ID_1, PERSON_ID_1, "21 Acme St., San Francisco CA 94110")
 
 
-def address_retrieve(id, person_id, address_id):
+def address_retrieve(id, address_id):
     return ADDRESS_1
 
 
-def address_search(person_id, offset, limit, list_param=None, enum_param=None):
+def address_search(offset, limit, list_param=None, enum_param=None):
     if list_param is None or enum_param is None:
-        return [ADDRESS_1], 1, dict(person_id=person_id)
+        return [ADDRESS_1], 1
     return Address(
         ADDRESS_ID_1,
         PERSON_ID_1,
         ",".join(list_param) + str(len(list_param)) + enum_param.value
-    ), 1, dict(person_id=person_id)
+    ), 1
 
 
 def person_create(**kwargs):

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -76,13 +76,13 @@ ADDRESS_MAPPINGS = {
 }
 
 
-class TestCrud(object):
+class TestCRUD(object):
 
     def setup(self):
         self.graph = create_object_graph(name="example", testing=True)
         person_ns = Namespace(subject=Person)
-        address_ns = Namespace(subject=Address, path=person_ns.instance_path)
-        configure_crud(self.graph, Person, PERSON_MAPPINGS)
+        address_ns = Namespace(subject=Address)
+        configure_crud(self.graph, person_ns, PERSON_MAPPINGS)
         configure_crud(self.graph, address_ns, ADDRESS_MAPPINGS)
         self.client = self.graph.flask.test_client()
 
@@ -131,7 +131,7 @@ class TestCrud(object):
         assert_that(response.headers["X-Total-Count"], is_(equal_to(str(1))))
 
     def test_search_with_context(self):
-        uri = "/api/person/{}/address".format(PERSON_ID_1)
+        uri = "/api/address".format(PERSON_ID_1)
         response = self.client.get(uri)
         self.assert_response(response, 200, {
             "count": 1,
@@ -142,19 +142,19 @@ class TestCrud(object):
                 "addressLine": "21 Acme St., San Francisco CA 94110",
                 "_links": {
                     "self": {
-                        "href": "http://localhost/api/person/{}/address/{}".format(PERSON_ID_1, ADDRESS_ID_1),
+                        "href": "http://localhost/api/address/{}".format(ADDRESS_ID_1),
                     }
                 },
             }],
             "_links": {
                 "self": {
-                    "href": "http://localhost/api/person/{}/address?offset=0&limit=20".format(PERSON_ID_1),
+                    "href": "http://localhost/api/address?offset=0&limit=20",
                 }
             }
         })
 
     def test_reuse_search_self_link(self):
-        uri = "/api/person/{}/address?list_param=a,b,c&enum_param=A".format(PERSON_ID_1)
+        uri = "/api/address?list_param=a,b,c&enum_param=A".format(PERSON_ID_1)
         response = self.client.get(uri)
         response_data = loads(response.get_data().decode("utf-8"))
         response = self.client.get(response_data["_links"]["self"]["href"])
@@ -167,14 +167,13 @@ class TestCrud(object):
                 "addressLine": "a,b,c3A",
                 "_links": {
                     "self": {
-                        "href": "http://localhost/api/person/{}/address/{}".format(PERSON_ID_1, ADDRESS_ID_1),
+                        "href": "http://localhost/api/address/{}".format(ADDRESS_ID_1),
                     }
                 },
             }],
             "_links": {
                 "self": {
-                    "href": "http://localhost/api/person/{}/address?offset=0&limit=20&enum_param=A&list_param=a%2Cb%2Cc"
-                            .format(PERSON_ID_1),
+                    "href": "http://localhost/api/address?offset=0&limit=20&enum_param=A&list_param=a%2Cb%2Cc",
                 }
             }
         })

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -36,7 +36,7 @@ def test_build_swagger():
         subject=Person,
         version="v1",
     )
-    configure_crud(graph, ns.subject, PERSON_MAPPINGS, ns.path)
+    configure_crud(graph, ns, PERSON_MAPPINGS)
 
     # match all (of the one) operations
     def match_function(operation, obj, rule):

--- a/microcosm_flask/tests/test_linking.py
+++ b/microcosm_flask/tests/test_linking.py
@@ -47,7 +47,7 @@ def test_templated_link_to_dict():
 
 def test_link_for_operation():
     graph = create_object_graph(name="example", testing=True)
-    ns = Namespace("foo")
+    ns = Namespace(subject="foo")
 
     @graph.route(ns.collection_path, Operation.Search, ns)
     def func():
@@ -60,20 +60,20 @@ def test_link_for_operation():
 
 def test_link_for_operation_without_namespace():
     graph = create_object_graph(name="example", testing=True)
-    ns = Namespace("foo")
+    ns = Namespace(subject="foo")
 
     @graph.route(ns.collection_path, Operation.Search, ns)
     def func():
         pass
 
     with graph.app.test_request_context():
-        link = Link.for_(Operation.Search, "foo")
+        link = Link.for_(Operation.Search, ns)
         assert_that(link.href, is_(equal_to("http://localhost/api/foo")))
 
 
 def test_link_for_operation_with_query_string():
     graph = create_object_graph(name="example", testing=True)
-    ns = Namespace("foo")
+    ns = Namespace(subject="foo")
 
     @graph.route(ns.collection_path, Operation.Search, ns)
     def func():
@@ -86,7 +86,7 @@ def test_link_for_operation_with_query_string():
 
 def test_link_for_operation_templated():
     graph = create_object_graph(name="example", testing=True)
-    ns = Namespace("foo")
+    ns = Namespace(subject="foo")
 
     @graph.route(ns.instance_path, Operation.Retrieve, ns)
     def func():


### PR DESCRIPTION
 - Stop using "path" for namespaces; use prefix instead
 - Stop trying to configure conventions with custom prefixes
 - Stop trying to auto-generate Namespaces