### PR TITLE
Add profiling support

### DIFF
--- a/microcosm_flask/factories.py
+++ b/microcosm_flask/factories.py
@@ -10,6 +10,8 @@ import microcosm.opaque  # noqa
 
 @defaults(
     port=5000,
+    enable_profiling=False,
+    profile_dir=None,
 )
 def configure_flask(graph):
     """

--- a/microcosm_flask/profiling.py
+++ b/microcosm_flask/profiling.py
@@ -1,0 +1,22 @@
+from os import makedirs
+from os.path import exists, expanduser
+
+from werkzeug.contrib.profiler import ProfilerMiddleware
+
+
+def default_profile_dir(name):
+    return expanduser("~/.{name}/profile".format(name=name))
+
+
+def enable_profiling(graph):
+    profile_dir = graph.config.flask.profile_dir or default_profile_dir(name=graph.metadata.name)
+    if not exists(profile_dir):
+        makedirs(profile_dir)
+
+    graph.app.config['PROFILE'] = True
+    graph.app.wsgi_app = ProfilerMiddleware(
+        graph.app.wsgi_app,
+        profile_dir=profile_dir,
+    )
+
+    graph.app.logger.info("*** Profiling is ON, Will save profiling data to directory: {}".format(profile_dir))

--- a/microcosm_flask/runserver.py
+++ b/microcosm_flask/runserver.py
@@ -4,18 +4,26 @@ Support running the development server.
 """
 from argparse import ArgumentParser
 
+from microcosm_flask.profiling import enable_profiling
+
 
 def parse_args(graph):
     default_port = graph.config.flask.port
+    default_enable_profiling = graph.config.flask.enable_profiling
 
     parser = ArgumentParser()
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=default_port)
+    parser.add_argument("--with-profiling", action="store_true", default=default_enable_profiling)
     return parser.parse_args()
 
 
 def main(graph):
     args = parse_args(graph)
+
+    if args.with_profiling:
+        enable_profiling(graph)
+
     try:
         graph.flask.run(host=args.host, port=args.port)
     except KeyboardInterrupt:


### PR DESCRIPTION
This PR adds support for profiling flask app when running locally with runserver, via the inbuilt Werkzeug flask profiler middleware.

Usage:

```
runserver --with-profiling

```

When enabled, this will report that profiling is on along with the `profile_dir` directory:

```
--------------------------------------------------------------------------------
INFO in profiling [~/Development/globality/microcosm-flask/microcosm_flask/profiling.py:22]:
*** Profiling is ON, Will save profiling data to directory: ~/.babilonia/profile
--------------------------------------------------------------------------------
```

The `with_profiling` and  `profile_dir` settings are also configurable via `graph.config.flask`



See [here](http://www.alexandrejoseph.com/blog/2015-12-17-profiling-werkzeug-flask-app.html) for how the profiler output can be used.