### PR TITLE
Allow per-endpoint header setting

### DIFF
--- a/microcosm_flask/conventions/base.py
+++ b/microcosm_flask/conventions/base.py
@@ -5,6 +5,10 @@ Convention base class.
 from microcosm_flask.operations import Operation
 
 
+def identity(x):
+    return x
+
+
 class RouteAlreadyRegisteredException(Exception):
     pass
 
@@ -14,13 +18,13 @@ class EndpointDefinition(tuple):
     A definition for an endpoint.
 
     """
-    def __new__(cls, func=None, request_schema=None, response_schema=None):
+    def __new__(cls, func=None, request_schema=None, response_schema=None, header_func=None):
         """
         :param func: a function to process request data and return response data
         :param request_schema: a marshmallow schema to decode/validate request data
         :param response_schema: a marshmallow schema to encode response data
         """
-        return tuple.__new__(EndpointDefinition, (func, request_schema, response_schema))
+        return tuple.__new__(EndpointDefinition, (func, request_schema, response_schema, header_func))
 
     @property
     def func(self):
@@ -33,6 +37,10 @@ class EndpointDefinition(tuple):
     @property
     def response_schema(self):
         return self[2]
+
+    @property
+    def header_func(self):
+        return self[3] or identity
 
 
 class Convention(object):
@@ -110,4 +118,11 @@ class Convention(object):
                 func=definition[0],
                 request_schema=definition[1],
                 response_schema=definition[2],
+            )
+        elif len(definition) == 4:
+            return EndpointDefinition(
+                func=definition[0],
+                request_schema=definition[1],
+                response_schema=definition[2],
+                header_func=definition[3],
             )

--- a/microcosm_flask/conventions/encoding.py
+++ b/microcosm_flask/conventions/encoding.py
@@ -47,6 +47,14 @@ def encode_id_header(resource):
     }
 
 
+def encode_headers(resource):
+    """
+    Generate headers from a resource.
+
+    """
+    return {}
+
+
 def load_request_data(request_schema, partial=False):
     """
     Load request data as JSON using the given schema.

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -59,8 +59,12 @@ class SearchAddressPageSchema(OffsetLimitPageSchema):
     enum_param = EnumField(TestEnum)
 
 
+def add_request_id(headers):
+    headers["X-Request-Id"] = "request-id"
+
+
 PERSON_MAPPINGS = {
-    Operation.Create: (person_create, NewPersonSchema(), PersonSchema()),
+    Operation.Create: (person_create, NewPersonSchema(), PersonSchema(), add_request_id),
     Operation.Delete: (person_delete,),
     Operation.UpdateBatch: (person_update_batch, NewPersonBatchSchema(), PersonBatchSchema()),
     Operation.Replace: (person_replace, NewPersonSchema(), PersonSchema()),
@@ -195,6 +199,7 @@ class TestCRUD(object):
             },
         })
         assert_that(response.headers["X-Person-Id"], is_(equal_to(str(PERSON_ID_2))))
+        assert_that(response.headers["X-Request-Id"], is_(equal_to("request-id")))
 
     def test_create_empty_object(self):
         response = self.client.post("/api/person", data='{}')


### PR DESCRIPTION
Provides an alternative to using flask hooks to update headers in responses.