### PR TITLE
Allow skipping audit logging

### DIFF
--- a/microcosm_flask/audit.py
+++ b/microcosm_flask/audit.py
@@ -60,7 +60,8 @@ def should_skip_logging(func):
     Should we skip logging for this handler?
 
     """
-    return getattr(func, SKIP_LOGGING, False)
+    disabled = strtobool(request.headers.get("x-request-nolog", "false"))
+    return disabled or getattr(func, SKIP_LOGGING, False)
 
 
 @contextmanager
@@ -380,6 +381,6 @@ def configure_audit_decorator(graph):
                 include_path=include_path,
                 include_query_string=include_query_string,
             )
-            return _audit_request(options, func, graph.request_context,  *args, **kwargs)
+            return _audit_request(options, func, graph.request_context, *args, **kwargs)
         return wrapper
     return _audit

--- a/microcosm_flask/tests/test_audit.py
+++ b/microcosm_flask/tests/test_audit.py
@@ -17,7 +17,12 @@ from microcosm.api import create_object_graph
 from mock import MagicMock
 from werkzeug.exceptions import NotFound
 
-from microcosm_flask.audit import AuditOptions, RequestInfo, logging_levels
+from microcosm_flask.audit import (
+    AuditOptions,
+    RequestInfo,
+    logging_levels,
+    should_skip_logging,
+)
 
 
 def test_func(*args, **kwargs):
@@ -352,3 +357,14 @@ class TestRequestInfo(object):
             with logging_levels():
                 assert_that(getLogger().getEffectiveLevel(), is_(equal_to(DEBUG)))
         assert_that(getLogger().getEffectiveLevel(), is_(equal_to(NOTSET)))
+
+    def test_disable_logging(self):
+        """
+        Disable logging per request.
+
+        """
+        assert_that(getLogger().getEffectiveLevel(), is_(equal_to(NOTSET)))
+        with self.graph.flask.test_request_context("/", headers={"X-Request-NoLog": "true"}):
+            def func():
+                pass
+            assert_that(should_skip_logging(func), is_(equal_to(True)))


### PR DESCRIPTION
This covers disabling audit logs (e.g. from segundo). We'll have to assess whether daemon logs have a similarly easy solution.