### PR TITLE
Handle form body content during multipart upload

### DIFF
--- a/microcosm_flask/conventions/upload.py
+++ b/microcosm_flask/conventions/upload.py
@@ -75,7 +75,7 @@ class UploadConvention(Convention):
         @self.add_route(path, operation, ns)
         @wraps(definition.func)
         def upload(**path_data):
-            request_data = load_query_string_data(request_schema)
+            request_data = load_query_string_data(request_schema, merge_data(request.args, request.form))
 
             if not request.files:
                 raise BadRequest("No files were uploaded")


### PR DESCRIPTION
Handling JSON content would be nice too, but isn't easy to test using `flask/werkzeug`
since their [test clients](https://github.com/pallets/werkzeug/blob/master/werkzeug/test.py#L349) assume form-encoded for other content once files are present.