### PR TITLE
Include build info in default health check.

### DIFF
--- a/microcosm_flask/conventions/build_info.py
+++ b/microcosm_flask/conventions/build_info.py
@@ -22,15 +22,29 @@ class BuildInfo(object):
             sha1=self.sha1,
         )
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(
+            build_num=config.build_info_convention.build_num,
+            sha1=config.build_info_convention.sha1,
+        )
+
+    @staticmethod
+    def check_build_num(graph):
+        build_info = BuildInfo.from_config(graph.config)
+        return build_info.build_num or "undefined"
+
+    @staticmethod
+    def check_sha1(graph):
+        build_info = BuildInfo.from_config(graph.config)
+        return build_info.sha1 or "undefined"
+
 
 class BuildInfoConvention(Convention):
 
     def __init__(self, graph):
         super(BuildInfoConvention, self).__init__(graph)
-        self.build_info = BuildInfo(
-            build_num=graph.config.build_info_convention.build_num,
-            sha1=graph.config.build_info_convention.sha1,
-        )
+        self.build_info = BuildInfo.from_config(graph.config)
 
     def configure_retrieve(self, ns, definition):
 

--- a/microcosm_flask/tests/conventions/test_health.py
+++ b/microcosm_flask/tests/conventions/test_health.py
@@ -11,6 +11,7 @@ from hamcrest import (
 )
 
 from microcosm.api import create_object_graph
+from microcosm.loaders import load_from_dict
 
 
 def test_health_check():
@@ -18,7 +19,12 @@ def test_health_check():
     Default health check returns OK.
 
     """
-    graph = create_object_graph(name="example", testing=True)
+    loader = load_from_dict(
+        health_convention=dict(
+            include_build_info="false",
+        ),
+    )
+    graph = create_object_graph(name="example", testing=True, loader=loader)
     graph.use("health_convention")
 
     client = graph.flask.test_client()
@@ -32,12 +38,42 @@ def test_health_check():
     })))
 
 
+def test_health_check_with_build_info():
+    graph = create_object_graph(name="example", testing=True)
+    graph.use("health_convention")
+
+    client = graph.flask.test_client()
+
+    response = client.get("/api/health")
+    assert_that(response.status_code, is_(equal_to(200)))
+    data = loads(response.get_data().decode("utf-8"))
+    assert_that(data, is_(equal_to(dict(
+        name="example",
+        ok=True,
+        checks=dict(
+            build_num=dict(
+                message="undefined",
+                ok=True,
+            ),
+            sha1=dict(
+                message="undefined",
+                ok=True,
+            ),
+        ),
+    ))))
+
+
 def test_health_check_custom_check():
     """
     Should return Custom health check results.
 
     """
-    graph = create_object_graph(name="example", testing=True)
+    loader = load_from_dict(
+        health_convention=dict(
+            include_build_info="false",
+        ),
+    )
+    graph = create_object_graph(name="example", testing=True, loader=loader)
     graph.use("health_convention")
 
     client = graph.flask.test_client()
@@ -64,7 +100,12 @@ def test_health_check_custom_check_failed():
     Should return 503 on health check failure.
 
     """
-    graph = create_object_graph(name="example", testing=True)
+    loader = load_from_dict(
+        health_convention=dict(
+            include_build_info="false",
+        ),
+    )
+    graph = create_object_graph(name="example", testing=True, loader=loader)
     graph.use("health_convention")
 
     client = graph.flask.test_client()


### PR DESCRIPTION
We usually want to read build info when we query a health check, whereas
today we expose this information in two different endpoints.

Changes:

 -  Add a configuration parameter to include build info in health checks (default: true)
 -  Add build info as "always true" health checks