### PR TITLE
Enable ETag support and spooky hash extension

### DIFF
--- a/microcosm_flask/formatting/base.py
+++ b/microcosm_flask/formatting/base.py
@@ -3,8 +3,14 @@ Response formatting base class.
 
 """
 from abc import ABCMeta, abstractmethod
+from binascii import hexlify
+try:
+    import spooky
+except ImportError:
+    spooky = None
 
 from flask import Response
+from werkzeug.http import quote_etag
 from werkzeug.utils import get_content_type
 
 
@@ -19,6 +25,7 @@ class BaseFormatter(metaclass=ABCMeta):
         response = self.build_response(response_data)
         headers = self.build_headers(headers=headers or {}, **kwargs)
         response.headers.extend(headers)
+        self.build_etag(response, **kwargs)
         return response
 
     @property
@@ -37,3 +44,29 @@ class BaseFormatter(metaclass=ABCMeta):
 
     def build_headers(self, headers, **kwargs):
         return headers
+
+    def build_etag(self, response, include_etag=True, **kwargs):
+        """
+        Add an etag to the response body.
+
+        Uses spooky where possible because it is empirically fast and well-regarded.
+
+        See: http://blog.reverberate.org/2012/01/state-of-hash-functions-2012.html
+
+        """
+        if not include_etag:
+            return
+
+        if not spooky:
+            # use built-in md5
+            response.add_etag()
+            return
+
+        # use spooky
+        response.headers["ETag"] = quote_etag(
+            hexlify(
+                spooky.hash128(
+                    response.get_data(),
+                ).to_bytes(16, "little"),
+            ).decode("utf-8"),
+        )

--- a/microcosm_flask/tests/formatting/base.py
+++ b/microcosm_flask/tests/formatting/base.py
@@ -1,0 +1,12 @@
+"""
+Common formatting test code.
+
+"""
+
+
+def etag_for(md5_hash, spooky_hash):
+    try:
+        import spooky  # noqa: F401
+        return spooky_hash
+    except ImportError:
+        return md5_hash

--- a/microcosm_flask/tests/formatting/test_csv_formatter.py
+++ b/microcosm_flask/tests/formatting/test_csv_formatter.py
@@ -11,6 +11,7 @@ from hamcrest import (
 
 from microcosm_flask.formatting import CSVFormatter
 from microcosm_flask.tests.conventions.fixtures import PersonCSVSchema
+from microcosm_flask.tests.formatting.base import etag_for
 
 
 def test_make_response():
@@ -26,6 +27,10 @@ def test_make_response():
     assert_that(response.headers, contains_inanyorder(
         ("Content-Disposition", "attachment; filename=\"response.csv\""),
         ("Content-Type", "text/csv; charset=utf-8"),
+        ("ETag", etag_for(
+            md5_hash='"a2ead3516dd1be4a3c7f45716c0a0eb7"',
+            spooky_hash='"02dee263db4f9326a3fbee9135939717"',
+        )),
     ))
 
 
@@ -45,4 +50,8 @@ def test_make_response_ordered():
     assert_that(response.headers, contains_inanyorder(
         ("Content-Disposition", "attachment; filename=\"response.csv\""),
         ("Content-Type", "text/csv; charset=utf-8"),
+        ("ETag", etag_for(
+            md5_hash='"4480bd6748cf93740490ebeee7eae1fe"',
+            spooky_hash='"0a7f40b47efb0a197b180444c4911b17"',
+        )),
     ))

--- a/microcosm_flask/tests/formatting/test_html_formatter.py
+++ b/microcosm_flask/tests/formatting/test_html_formatter.py
@@ -10,6 +10,7 @@ from hamcrest import (
 )
 
 from microcosm_flask.formatting import HTMLFormatter
+from microcosm_flask.tests.formatting.base import etag_for
 
 
 def test_make_response():
@@ -21,4 +22,8 @@ def test_make_response():
     assert_that(response.headers, contains_inanyorder(
         ("Content-Length", "27"),
         ("Content-Type", "text/html; charset=utf-8"),
+        ("ETag", etag_for(
+            md5_hash='"016a5a134aceb7391754f03893d30e06"',
+            spooky_hash='"1a639cef905e11904ac33817c37997dd"',
+        )),
     ))

--- a/microcosm_flask/tests/formatting/test_json_formatter.py
+++ b/microcosm_flask/tests/formatting/test_json_formatter.py
@@ -12,6 +12,7 @@ from hamcrest import (
 from microcosm.api import create_object_graph
 
 from microcosm_flask.formatting import JSONFormatter
+from microcosm_flask.tests.formatting.base import etag_for
 
 
 def test_make_response():
@@ -25,4 +26,8 @@ def test_make_response():
     assert_that(response.content_type, is_(equal_to("application/json")))
     assert_that(response.headers, contains_inanyorder(
         ("Content-Type", "application/json"),
+        ("ETag", etag_for(
+            md5_hash='"a095a61c6e037bc3d4610645865ba35e"',
+            spooky_hash='"af072b51e1eb2a8d7b2ab84dab972674"',
+        )),
     ))

--- a/microcosm_flask/tests/formatting/test_text_formatter.py
+++ b/microcosm_flask/tests/formatting/test_text_formatter.py
@@ -10,6 +10,7 @@ from hamcrest import (
 )
 
 from microcosm_flask.formatting import TextFormatter
+from microcosm_flask.tests.formatting.base import etag_for
 
 
 def test_make_response():
@@ -21,4 +22,8 @@ def test_make_response():
     assert_that(response.headers, contains_inanyorder(
         ("Content-Length", "12"),
         ("Content-Type", "text/plain; charset=utf-8"),
+        ("ETag", etag_for(
+            md5_hash='"ed076287532e86365e841e92bfc50d8c"',
+            spooky_hash='"79aa5e0a1f595e330d662c97a7763cdc"',
+        )),
     ))

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     ],
     extras_require={
         "metrics": "microcosm-metrics>=1.0.0",
+        "spooky": "spooky>=2.0.0",
     },
     setup_requires=[
         "nose>=1.3.6",


### PR DESCRIPTION
By default, formatters should include ETags; these are cheap and useful.
If installed, spooky hash will be used for faster/better hashing than md5 (werkzeug default).