### PR TITLE
Remove basic auth and enabled flag.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.0
+current_version = 1.5.1
 commit = False
 tag = False
 

--- a/microcosm_flask/tests/conventions/test_config.py
+++ b/microcosm_flask/tests/conventions/test_config.py
@@ -14,7 +14,6 @@ from hamcrest import (
 from microcosm.api import create_object_graph
 from microcosm.loaders import load_from_dict
 from microcosm.loaders.compose import load_config_and_secrets
-from microcosm_flask.basic_auth import encode_basic_auth
 
 
 def test_config_discovery():
@@ -41,25 +40,11 @@ def test_config_discovery():
 
     response = client.get(
         "/api/config",
-        headers={"Authorization": encode_basic_auth("default", "secret")},
     )
     assert_that(response.status_code, is_(equal_to(200)))
     data = loads(response.get_data().decode("utf-8"))
 
     assert_that(data, has_entries(config_convention=dict(enabled="true")))
-
-
-def test_config_convention_disabled_by_default():
-    graph = create_object_graph(name="example", testing=True)
-    graph.use("config_convention")
-
-    client = graph.flask.test_client()
-
-    response = client.get(
-        "/api/config",
-        headers={"Authorization": encode_basic_auth("default", "secret")},
-    )
-    assert_that(response.status_code, is_(equal_to(404)))
 
 
 def test_non_json_keys_omitted():
@@ -81,7 +66,6 @@ def test_non_json_keys_omitted():
 
     response = client.get(
         "/api/config",
-        headers={"Authorization": encode_basic_auth("default", "secret")},
     )
     assert_that(response.status_code, is_(equal_to(200)))
     data = loads(response.get_data().decode("utf-8"))
@@ -107,7 +91,6 @@ def test_config_discovery_only_works_for_paritioned_loaders():
 
     response = client.get(
         "/api/config",
-        headers={"Authorization": encode_basic_auth("default", "secret")},
     )
     assert_that(response.status_code, is_(equal_to(200)))
     data = loads(response.get_data().decode("utf-8"))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-flask"
-version = "1.5.0"
+version = "1.5.1"
 
 setup(
     name=project,


### PR DESCRIPTION
Why? The enabled flag is redundant with deciding to include the component in the
first place, we decided not to share any secret information so basic auth isn't
necessary.