### PR TITLE
Add landing page convention

### DIFF
--- a/microcosm_flask/conventions/landing.py
+++ b/microcosm_flask/conventions/landing.py
@@ -1,0 +1,22 @@
+"""
+Landing Page convention.
+
+"""
+from microcosm_flask.templates.landing import template
+from jinja2 import Template
+
+
+def configure_landing(graph):
+
+    @graph.flask.route("/")
+    def render_landing_page():
+        """
+        Render landing page
+
+        """
+        return Template(template).render(
+            service_name=graph.metadata.name,
+            swagger_version=graph.config.swagger_convention.version,
+            description=graph.config.get('description', None),
+            github=graph.config.get('github', None),
+        )

--- a/microcosm_flask/conventions/landing.py
+++ b/microcosm_flask/conventions/landing.py
@@ -2,11 +2,63 @@
 Landing Page convention.
 
 """
+from microcosm_flask.conventions.registry import iter_endpoints
 from microcosm_flask.templates.landing import template
 from jinja2 import Template
+from os.path import join
+from pkg_resources import working_set, Requirement
 
 
 def configure_landing(graph):
+
+    def get_properties():
+        """
+        Parse the properties from the package information
+
+        """
+        package = working_set.find(Requirement.parse(graph.metadata.name))
+        if not package:
+            return dict()
+        package_info = open(join(package.egg_info, 'PKG-INFO')).read().splitlines()
+        return dict(
+            info.split(": ")
+            for info in package_info
+        )
+
+    def get_description(properties):
+        """
+        Calculate the description based on the package properties
+
+        """
+        if not properties:
+            return None
+
+        return '. '.join([
+            field
+            for field in [properties["Summary"], properties["Description"]]
+            if field != "UNKNOWN"
+        ])
+
+    def get_swagger_versions():
+        """
+        Finds all swagger conventions that are bound to the graph
+
+        """
+        versions = []
+
+        def matches(operation, ns, rule):
+            """
+            Defines a condition to determine which endpoints are swagger type
+
+            """
+            if(ns.subject == graph.config.swagger_convention.name):
+                return True
+            return False
+
+        for operation, ns, rule, func in iter_endpoints(graph, matches):
+            versions.append(ns.version)
+
+        return versions
 
     @graph.flask.route("/")
     def render_landing_page():
@@ -14,9 +66,14 @@ def configure_landing(graph):
         Render landing page
 
         """
+        properties = get_properties()
+        description = get_description(properties)
+        swagger_versions = get_swagger_versions()
+
         return Template(template).render(
             service_name=graph.metadata.name,
-            swagger_version=graph.config.swagger_convention.version,
-            description=graph.config.get('description', None),
-            github=graph.config.get('github', None),
+            swagger_versions=swagger_versions,
+            description=description,
+            github=properties.get("Home-page"),
+            version=properties.get("Version"),
         )

--- a/microcosm_flask/templates/landing.py
+++ b/microcosm_flask/templates/landing.py
@@ -67,9 +67,11 @@ template = """
                 <h2><a href="api/config">Config</a></h2>
                 <iframe src="/api/config"></iframe>
             </div>
-            <div class="section">
-                <h2><a href="api/{{ swagger_version }}/swagger">Swagger</a></h2>
-            </div>
+            {%- for swagger_version in swagger_versions -%}
+                <div class="section">
+                    <h2><a href="api/{{ swagger_version }}/swagger">Swagger ({{ swagger_version }})</a></h2>
+                </div>
+            {%- endfor -%}
             {%-if github -%}
                 <div class="section">
                     <h2><a href={{ github }}>GitHub</a></h2>

--- a/microcosm_flask/templates/landing.py
+++ b/microcosm_flask/templates/landing.py
@@ -1,0 +1,80 @@
+template = """
+    <!doctype html>
+    <html class="no-js" lang="">
+        <head>
+            <meta charset="utf-8">
+            <meta http-equiv="x-ua-compatible" content="ie=edge">
+            <title>{{ service_name }}</title>
+            <meta name="description" content="Landing">
+            <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+            <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">
+        </head>
+        <style>
+            html {
+                font-family: sans-serif;
+                -ms-text-size-adjust: 100%;
+                -webkit-text-size-adjust: 100%;
+                font-size: 10px;
+                -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+            }
+            body {
+                margin: 0;
+                font-family: "Open Sans", sans-serif;
+                font-size: 14px;
+                line-height: 1.42857143;
+                color: #333333;
+                background-color: #fff;
+            }
+            a {
+                background-color: transparent;
+                color: #337ab7;
+                text-decoration: none;
+            }
+
+            h1 {
+                font-weight: 500;
+                line-height: 1.1;
+                color: inherit;
+                text-align: center;
+                padding-top: 2%;
+                padding-bottom: 2%;
+                text-transform: capitalize;
+            }
+            iframe {
+                width: 100%;
+                height: 300px;
+                border-style: solid;
+                border-width: 1px;
+                background-color: #E8E8E8;
+            }
+            .section {
+                margin: 0 100px;
+            }
+        </style>
+        <body>
+            <h1>{{ service_name }}</h1>
+            {%-if description -%}
+                <div class="section">
+                    <h2>Description</h2>
+                    <p>{{ description }}</p>
+                </div>
+            {%- endif -%}
+            <div class="section">
+                <h2><a href="api/health">Health</a></h2>
+                <iframe src="/api/health"></iframe>
+            </div>
+            <div class="section">
+                <h2><a href="api/config">Config</a></h2>
+                <iframe src="/api/config"></iframe>
+            </div>
+            <div class="section">
+                <h2><a href="api/{{ swagger_version }}/swagger">Swagger</a></h2>
+            </div>
+            {%-if github -%}
+                <div class="section">
+                    <h2><a href={{ github }}>GitHub</a></h2>
+                </div>
+            {%- endif -%}
+        </body>
+    </html>
+"""

--- a/microcosm_flask/templates/landing.py
+++ b/microcosm_flask/templates/landing.py
@@ -63,20 +63,20 @@ template = """
                 <h2><a href="api/health">Health</a></h2>
                 <iframe src="/api/health"></iframe>
             </div>
-            <div class="section">
-                <h2><a href="api/config">Config</a></h2>
-                <iframe src="/api/config"></iframe>
-            </div>
             {%- for swagger_version in swagger_versions -%}
                 <div class="section">
                     <h2><a href="api/{{ swagger_version }}/swagger">Swagger ({{ swagger_version }})</a></h2>
                 </div>
             {%- endfor -%}
-            {%-if github -%}
+            {%-if homepage -%}
                 <div class="section">
-                    <h2><a href={{ github }}>GitHub</a></h2>
+                    <h2><a href={{ homepage }}>Home Page</a></h2>
                 </div>
             {%- endif -%}
+            <div class="section">
+                <h2><a href="api/config">Config</a></h2>
+                <iframe src="/api/config"></iframe>
+            </div>
         </body>
     </html>
 """

--- a/microcosm_flask/tests/conventions/test_landing.py
+++ b/microcosm_flask/tests/conventions/test_landing.py
@@ -1,0 +1,25 @@
+"""
+Landing convention tests.
+
+"""
+from hamcrest import (
+    assert_that,
+    equal_to,
+    is_,
+)
+
+from microcosm.api import create_object_graph
+
+
+def test_landing():
+    """
+    Default landing returns OK.
+
+    """
+    graph = create_object_graph(name="example", testing=True)
+    graph.use("landing_convention")
+
+    client = graph.flask.test_client()
+
+    response = client.get("/")
+    assert_that(response.status_code, is_(equal_to(200)))

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
             "flask = microcosm_flask.factories:configure_flask",
             "health_convention = microcosm_flask.conventions.health:configure_health",
             "config_convention = microcosm_flask.conventions.config:configure_config",
+            "landing_convention = microcosm_flask.conventions.landing:configure_landing",
             "logging_level_convention = microcosm_flask.conventions.logging_level:configure_logging_level",
             "port_forwarding = microcosm_flask.forwarding:configure_port_forwarding",
             "request_context = microcosm_flask.context:configure_request_context",


### PR DESCRIPTION
Why?

Useful for showing links to relevant configs and provide information about a service. Works in tandem with health check convention and config convention.
Can specify a description or github link by by binding 'description' or 'github' to the microcosm services config