### PR TITLE
Add landing page convention

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.0
+current_version = 1.8.0
 commit = False
 tag = False
 

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,1 +1,0 @@
-extends: globality-opensource-defaults

--- a/microcosm_flask/conventions/base.py
+++ b/microcosm_flask/conventions/base.py
@@ -23,9 +23,24 @@ class EndpointDefinition(tuple):
     """
     def __new__(cls, func=None, request_schema=None, response_schema=None, header_func=None, response_formats=None):
         """
+        Define an API endpoint.
+
+        Defines the behavior of an API endpoint in conjunction with a `Namespace` and an `Operation`.
+
+        Supports a callbable `func`, request and response (marshmallow) schemas, a header-modifying function, and
+        optional response formats.
+
+        The callable `func` should accept `**kwargs` and return a marshmallow-compatible object or dictionary.
+
+        The callable `header_func` (if any) should accept a `headers` dictionary and the return value from the
+        callable `func`.
+
         :param func: a function to process request data and return response data
         :param request_schema: a marshmallow schema to decode/validate request data
         :param response_schema: a marshmallow schema to encode response data
+        :param header_func: a header-modifying function
+        :param response_formats: an optional list of support response formats
+
         """
         return tuple.__new__(
             EndpointDefinition,
@@ -46,7 +61,7 @@ class EndpointDefinition(tuple):
 
     @property
     def header_func(self):
-        return self[3] or identity
+        return self[3] or (lambda headers, response_data: headers)
 
     @property
     def response_formats(self):

--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -59,7 +59,7 @@ class CRUDConvention(Convention):
             page = self.page_cls.from_query_string(definition.request_schema)
             result = definition.func(**merge_data(path_data, page.to_dict(func=identity)))
             response_data, headers = page.to_paginated_list(result, ns, Operation.Search)
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 paginated_list_schema,
@@ -89,9 +89,10 @@ class CRUDConvention(Convention):
         @wraps(definition.func)
         def count(**path_data):
             request_data = load_query_string_data(definition.request_schema)
+            response_data = dict()
             count = definition.func(**merge_data(path_data, request_data))
             headers = encode_count_header(count)
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 None,
@@ -122,7 +123,7 @@ class CRUDConvention(Convention):
             request_data = load_request_data(definition.request_schema)
             response_data = definition.func(**merge_data(path_data, request_data))
             headers = encode_id_header(response_data)
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 definition.response_schema,
@@ -156,7 +157,7 @@ class CRUDConvention(Convention):
             headers = dict()
             request_data = load_request_data(definition.request_schema)
             response_data = definition.func(**merge_data(path_data, request_data))
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 definition.response_schema,
@@ -190,7 +191,7 @@ class CRUDConvention(Convention):
             headers = dict()
             request_data = load_query_string_data(request_schema)
             response_data = require_response_data(definition.func(**merge_data(path_data, request_data)))
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 definition.response_schema,
@@ -217,8 +218,8 @@ class CRUDConvention(Convention):
         @wraps(definition.func)
         def delete(**path_data):
             headers = dict()
-            require_response_data(definition.func(**path_data))
-            definition.header_func(headers)
+            response_data = require_response_data(definition.func(**path_data))
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 "",
@@ -253,7 +254,7 @@ class CRUDConvention(Convention):
             # enforce these semantics at the HTTP layer. If `func` returns falsey, we
             # will raise a 404.
             response_data = require_response_data(definition.func(**merge_data(path_data, request_data)))
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 definition.response_schema,
@@ -285,7 +286,7 @@ class CRUDConvention(Convention):
             # NB: using partial here means that marshmallow will not validate required fields
             request_data = load_request_data(definition.request_schema, partial=True)
             response_data = require_response_data(definition.func(**merge_data(path_data, request_data)))
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 definition.response_schema,
@@ -327,7 +328,7 @@ class CRUDConvention(Convention):
             ))
 
             response_data, headers = page.to_paginated_list(result, ns, Operation.CreateCollection)
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 paginated_list_schema,

--- a/microcosm_flask/conventions/relation.py
+++ b/microcosm_flask/conventions/relation.py
@@ -52,7 +52,7 @@ class RelationConvention(Convention):
             request_data = load_request_data(definition.request_schema)
             response_data = require_response_data(definition.func(**merge_data(path_data, request_data)))
             headers = encode_id_header(response_data)
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 definition.response_schema,
@@ -80,8 +80,9 @@ class RelationConvention(Convention):
         @wraps(definition.func)
         def delete(**path_data):
             headers = dict()
+            response_data = dict()
             require_response_data(definition.func(**path_data))
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 "",
@@ -120,7 +121,7 @@ class RelationConvention(Convention):
             headers = dict()
             request_data = load_request_data(definition.request_schema)
             response_data = require_response_data(definition.func(**merge_data(path_data, request_data)))
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 definition.response_schema,
@@ -159,7 +160,7 @@ class RelationConvention(Convention):
             headers = dict()
             request_data = load_request_data(definition.request_schema)
             response_data = require_response_data(definition.func(**merge_data(path_data, request_data)))
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 definition.response_schema,
@@ -195,7 +196,7 @@ class RelationConvention(Convention):
             headers = dict()
             request_data = load_query_string_data(request_schema)
             response_data = require_response_data(definition.func(**merge_data(path_data, request_data)))
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 definition.response_schema,
@@ -235,7 +236,7 @@ class RelationConvention(Convention):
             page = self.page_cls.from_query_string(definition.request_schema)
             result = definition.func(**merge_data(path_data, page.to_dict(func=identity)))
             response_data, headers = page.to_paginated_list(result, ns, Operation.SearchFor)
-            definition.header_func(headers)
+            definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
                 paginated_list_schema,

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -59,7 +59,7 @@ class SearchAddressPageSchema(OffsetLimitPageSchema):
     enum_param = EnumField(TestEnum)
 
 
-def add_request_id(headers):
+def add_request_id(headers, response_data):
     headers["X-Request-Id"] = "request-id"
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-flask"
-version = "1.7.0"
+version = "1.8.0"
 
 setup(
     name=project,


### PR DESCRIPTION
Why?

Useful for showing links to relevant configs and provide information about a service. Works in tandem with health check convention and config convention.