### PR TITLE
GLOB-22271: support custom headers

### DIFF
--- a/microcosm_flask/errors.py
+++ b/microcosm_flask/errors.py
@@ -101,7 +101,13 @@ def extract_headers(error):
     Extract HTTP headers to include in response.
 
     """
-    return getattr(error, "headers",  {})
+    try:
+        return error.headers
+    except AttributeError:
+        try:
+            return error.get_headers()
+        except AttributeError:
+            return {}
 
 
 def extract_include_stack_trace(error):

--- a/microcosm_flask/tests/test_errors.py
+++ b/microcosm_flask/tests/test_errors.py
@@ -7,9 +7,10 @@ from json import loads
 from hamcrest import (
     assert_that,
     equal_to,
+    has_entry,
     is_,
 )
-from werkzeug.exceptions import InternalServerError, NotFound
+from werkzeug.exceptions import InternalServerError, NotFound, HTTPException
 
 from microcosm.api import create_object_graph
 
@@ -38,6 +39,17 @@ class MyConflictError(Exception):
 class NonNumericError(Exception):
     code = "foo"
 
+
+class AuthenticationError(HTTPException):
+    code = 401
+    description = "no trespassing"
+
+    def get_headers(self, environ=None):
+        return {
+            "Content-Type": "application/json",
+            "WWW-Authenticate": "Basic realm=outer-zone",
+        }
+ 
 
 def test_werkzeug_http_error():
     """
@@ -244,3 +256,25 @@ def test_non_numeric_error():
         "retryable": False,
         "context": {"errors": []},
     })))
+
+
+def test_custom_headers():
+    """
+    Custom headers are sent to the client
+
+    """
+    graph = create_object_graph(name="example", testing=True)
+
+    @graph.app.route("/foo")
+    @graph.audit
+    def foo():
+        raise AuthenticationError()
+
+    client = graph.app.test_client()
+
+    response = client.get("/foo")
+    data = loads(response.get_data())
+    assert_that(data,
+                has_entry("message", AuthenticationError.description))
+    www_authenticate = response.headers.get('www-authenticate')
+    assert_that(www_authenticate, equal_to('Basic realm=outer-zone'))

--- a/microcosm_flask/tests/test_errors.py
+++ b/microcosm_flask/tests/test_errors.py
@@ -49,7 +49,7 @@ class AuthenticationError(HTTPException):
             "Content-Type": "application/json",
             "WWW-Authenticate": "Basic realm=outer-zone",
         }
- 
+
 
 def test_werkzeug_http_error():
     """


### PR DESCRIPTION
According to http://werkzeug.pocoo.org/docs/0.14/exceptions/#custom-errors `get_headers()` is the right way to override headers in an `HTTPException` object. This makes sure we relay those headers if such an exception is raised.