### PR TITLE
url_extractor_factory

### DIFF
--- a/microcosm_flask/tests/test_url.py
+++ b/microcosm_flask/tests/test_url.py
@@ -17,7 +17,7 @@ from microcosm_flask.conventions.base import EndpointDefinition
 from microcosm_flask.conventions.crud import configure_crud
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
-from microcosm_flask.url import url_extractor_factory
+from microcosm_flask.url import base_url_extractor_factory, url_extractor_factory
 
 
 class CompanyController:
@@ -173,3 +173,17 @@ class TestUriExtractorFactory:
         with self.graph.app.test_request_context():
             url = extractor(controller, model)
         assert_that(url), is_(equal_to("http://localhost/api/v1/user/ID"))
+
+    def test_base_extractor(self):
+        controller = CompanyController(self.graph)
+        model = controller.retrieve()
+
+        extractor = base_url_extractor_factory(
+            operation=Operation.Search,
+            query_args_extractors=[
+                (lambda ctrl, model: model.name, lambda ctrl, model: model.name),
+            ],
+        )
+        with self.graph.app.test_request_context():
+            url = extractor(controller, model)
+        assert_that(url), is_(equal_to("http://localhost/api/v1/company?Name=Name"))

--- a/microcosm_flask/tests/test_url.py
+++ b/microcosm_flask/tests/test_url.py
@@ -11,6 +11,7 @@ from hamcrest import (
     raises,
 )
 from microcosm.api import binding, create_object_graph
+from werkzeug.routing import BuildError
 
 from microcosm_flask.conventions.base import EndpointDefinition
 from microcosm_flask.conventions.crud import configure_crud
@@ -116,7 +117,7 @@ class TestUriExtractorFactory:
         model = controller.retrieve()
 
         extractor = url_extractor_factory(
-            use_model_id=False,
+            use_model_identifier=False,
             company_id=lambda ctrl, model: model.name,
         )
         with self.graph.app.test_request_context():
@@ -130,14 +131,14 @@ class TestUriExtractorFactory:
 
         extractor = url_extractor_factory()
         with self.graph.app.test_request_context():
-            assert_that(calling(extractor).with_args(controller, model), raises(TypeError))
+            assert_that(calling(extractor).with_args(controller, model), raises(BuildError))
 
     def test_set_identifier_key(self):
         controller = CompanyController(self.graph)
         controller.identifier_key = None
         model = controller.retrieve()
 
-        extractor = url_extractor_factory(identifier_key="company_id")
+        extractor = url_extractor_factory(schema_identifier="company_id")
         with self.graph.app.test_request_context():
             url = extractor(controller, model)
         assert_that(url), is_(equal_to("http://localhost/api/v1/company/ID"))
@@ -168,7 +169,7 @@ class TestUriExtractorFactory:
         controller = CompanyController(self.graph)
         model = controller.retrieve()
 
-        extractor = url_extractor_factory(identifier_key="user_id", ns=Namespace(subject="user", version="v1"))
+        extractor = url_extractor_factory(schema_identifier="user_id", ns=Namespace(subject="user", version="v1"))
         with self.graph.app.test_request_context():
             url = extractor(controller, model)
         assert_that(url), is_(equal_to("http://localhost/api/v1/user/ID"))

--- a/microcosm_flask/tests/test_url.py
+++ b/microcosm_flask/tests/test_url.py
@@ -61,23 +61,17 @@ def configure_user(graph):
     return ns
 
 
-class TestPublishDecorator:
+class TestUriExtractorFactory:
 
     def setup(self):
-        def loader(metadata):
-            return dict(
-                sns_topic_arns=dict(
-                    default="default",
-                )
-            )
-        self.graph = create_object_graph("example", testing=True, loader=loader)
+        self.graph = create_object_graph("example", testing=True)
         self.graph.use(
             "configure_company_v1",
             "configure_user_v1",
         )
         self.graph.lock()
 
-    def test_publish(self):
+    def test_default_extractor(self):
         controller = CompanyController(self.graph)
         model = controller.retrieve()
 
@@ -97,12 +91,11 @@ class TestPublishDecorator:
 
     def test_set_url_string_args(self):
         controller = CompanyController(self.graph)
-        setattr(controller, "limit", 1)
         model = controller.retrieve()
 
         extractor = url_extractor_factory(
             name=lambda ctrl, model: model.name,
-            limit=lambda ctrl, model: ctrl.limit,
+            limit=lambda ctrl, model: 1,
         )
         with self.graph.app.test_request_context():
             url = extractor(controller, model)

--- a/microcosm_flask/tests/test_url.py
+++ b/microcosm_flask/tests/test_url.py
@@ -1,0 +1,181 @@
+"""
+url_extractor_factory tests.
+
+"""
+from collections import namedtuple
+from hamcrest import (
+    assert_that,
+    calling,
+    equal_to,
+    is_,
+    raises,
+)
+from microcosm.api import binding, create_object_graph
+
+from microcosm_flask.conventions.base import EndpointDefinition
+from microcosm_flask.conventions.crud import configure_crud
+from microcosm_flask.namespaces import Namespace
+from microcosm_flask.operations import Operation
+from microcosm_flask.url import url_extractor_factory
+
+
+class CompanyController:
+    def __init__(self, graph):
+        self.ns = Namespace(
+            subject="company",
+            version="v1",
+        )
+        self.identifier_key = "company_id"
+
+    def retrieve(sel):
+        return namedtuple("Company", "id name")("ID", "Name")
+
+
+@binding("configure_company_v1")
+def configure_company(graph):
+    ns = Namespace(
+        subject="company",
+        version="v1",
+    )
+    mappings = {
+        Operation.Create: EndpointDefinition(),
+        Operation.Retrieve: EndpointDefinition(),
+        Operation.Search: EndpointDefinition(),
+    }
+
+    configure_crud(graph, ns, mappings)
+    return ns
+
+
+@binding("configure_user_v1")
+def configure_user(graph):
+    ns = Namespace(
+        subject="user",
+        version="v1",
+    )
+    mappings = {
+        Operation.Retrieve: EndpointDefinition(),
+    }
+
+    configure_crud(graph, ns, mappings)
+    return ns
+
+
+class TestPublishDecorator:
+
+    def setup(self):
+        def loader(metadata):
+            return dict(
+                sns_topic_arns=dict(
+                    default="default",
+                )
+            )
+        self.graph = create_object_graph("example", testing=True, loader=loader)
+        self.graph.use(
+            "configure_company_v1",
+            "configure_user_v1",
+        )
+        self.graph.lock()
+
+    def test_publish(self):
+        controller = CompanyController(self.graph)
+        model = controller.retrieve()
+
+        extractor = url_extractor_factory()
+        with self.graph.app.test_request_context():
+            url = extractor(controller, model)
+        assert_that(url), is_(equal_to("http://localhost/api/v1/company/ID"))
+
+    def test_set_operation(self):
+        controller = CompanyController(self.graph)
+        model = controller.retrieve()
+
+        extractor = url_extractor_factory(operation=Operation.Search)
+        with self.graph.app.test_request_context():
+            url = extractor(controller, model)
+        assert_that(url), is_(equal_to("http://localhost/api/v1/company"))
+
+    def test_set_url_string_args(self):
+        controller = CompanyController(self.graph)
+        setattr(controller, "limit", 1)
+        model = controller.retrieve()
+
+        extractor = url_extractor_factory(
+            name=lambda ctrl, model: model.name,
+            limit=lambda ctrl, model: ctrl.limit,
+        )
+        with self.graph.app.test_request_context():
+            url = extractor(controller, model)
+        assert_that(url), is_(equal_to("http://localhost/api/v1/company/ID?name=Name&limit=1"))
+
+    def test_identifier_passed_twice(self):
+        controller = CompanyController(self.graph)
+        model = controller.retrieve()
+
+        extractor = url_extractor_factory(
+            company_id=lambda ctrl, model: model.name,
+        )
+        with self.graph.app.test_request_context():
+            assert_that(calling(extractor).with_args(controller, model), raises(TypeError))
+
+    def test_use_model_id_set_to_false(self):
+        controller = CompanyController(self.graph)
+        model = controller.retrieve()
+
+        extractor = url_extractor_factory(
+            use_model_id=False,
+            company_id=lambda ctrl, model: model.name,
+        )
+        with self.graph.app.test_request_context():
+            url = extractor(controller, model)
+        assert_that(url), is_(equal_to("http://localhost/api/v1/company/Name"))
+
+    def test_missing_identifier_key(self):
+        controller = CompanyController(self.graph)
+        controller.identifier_key = None
+        model = controller.retrieve()
+
+        extractor = url_extractor_factory()
+        with self.graph.app.test_request_context():
+            assert_that(calling(extractor).with_args(controller, model), raises(TypeError))
+
+    def test_set_identifier_key(self):
+        controller = CompanyController(self.graph)
+        controller.identifier_key = None
+        model = controller.retrieve()
+
+        extractor = url_extractor_factory(identifier_key="company_id")
+        with self.graph.app.test_request_context():
+            url = extractor(controller, model)
+        assert_that(url), is_(equal_to("http://localhost/api/v1/company/ID"))
+
+    def test_missing_ns(self):
+        controller = CompanyController(self.graph)
+        controller.ns = None
+        model = controller.retrieve()
+
+        extractor = url_extractor_factory()
+        with self.graph.app.test_request_context():
+            assert_that(calling(extractor).with_args(controller, model), raises(AttributeError))
+
+    def test_set_ns(self):
+        controller = CompanyController(self.graph)
+        controller.ns = None
+        model = controller.retrieve()
+
+        extractor = url_extractor_factory(ns=Namespace(
+            subject="company",
+            version="v1",
+        ))
+        with self.graph.app.test_request_context():
+            url = extractor(controller, model)
+        assert_that(url), is_(equal_to("http://localhost/api/v1/company/ID"))
+
+    def test_set_ns_and_identifier_key(self):
+        controller = CompanyController(self.graph)
+        model = controller.retrieve()
+
+        extractor = url_extractor_factory(identifier_key="user_id", ns=Namespace(subject="user", version="v1"))
+        with self.graph.app.test_request_context():
+            url = extractor(controller, model)
+        assert_that(url), is_(equal_to("http://localhost/api/v1/user/ID"))

--- a/microcosm_flask/url.py
+++ b/microcosm_flask/url.py
@@ -1,0 +1,58 @@
+"""
+Url fatories.
+
+"""
+
+from microcosm_flask.operations import Operation, NODE_PATTERN
+
+
+def url_extractor_factory(ns=None, operation=None, use_model_id=None, identifier_key=None, **url_string_args):
+    """
+    A factory that creates url extractors.
+    url extractor is an (component, model) -> string function that can generates url for relevant resources
+    The extractors can component.ns and component.identifier_key to easily generates relevant urls.
+
+    Simple examples:
+
+    class Controller:
+        def __init__(self, graph):
+            self.ns = Namespace(subject="company")
+            self.identifier_key = "company_id"
+    controller = Controller()
+    company = Company(id="ID", clock=3)
+
+    url_extractor_factory()(ctrl, company) -> '/api/v1/company/ID'
+    url_extractor_factory(min_clock=lambda cont, obj: obj.clock)(ctrl, company) -> '/api/v1/company/ID?min_clock=3'
+
+    :ns              - Model namespace. component.ns will get used instead if set to None.
+    :operation       - microcosm_flask.operations.Operation, default is Operation.Retrieve
+    :url_string_args - Allow to specify query args to use
+                       Passed as a dictionary of {arg_name: lambda component, model: action}
+                       For example: {
+                           company_event_id: lambda component, company_event: company_event.id
+                           min_clock: lambda component, company_event: company_event.clock
+                        }
+    :use_model_id    - Should use model.id to create the url.
+                       If is None, will use set to True for node operation (such as Retrieve, unlike Search)
+    :identifier_key  - Specify the object "id" schema key
+                       Cannot be used if use_model_id is set to false.
+                       component.identifier_key will get used instead if set to None.
+
+    """
+    operation_ = operation or Operation.Retrieve
+    use_model_id_ = use_model_id if use_model_id is not None else operation_.value.pattern == NODE_PATTERN
+
+    if identifier_key and not use_model_id_:
+        raise TypeError(f"No need to pass identifier_key if use_model_id is set to false")
+
+    def extract(component, model):
+        ns_ = ns or component.ns
+        url_params = {key: str(extractor(component, model)) for key, extractor in url_string_args.items()}
+        if use_model_id_:
+            identifier_key_ = identifier_key or component.identifier_key
+            if identifier_key_ in url_params:
+                raise TypeError(f"identifier_key is set to alredy set parameter {identifier_key_}")
+            url_params[identifier_key_] = model.id
+
+        return ns_.url_for(operation_, **url_params)
+    return extract

--- a/microcosm_flask/url.py
+++ b/microcosm_flask/url.py
@@ -6,7 +6,7 @@ Url fatories.
 from microcosm_flask.operations import Operation, NODE_PATTERN
 
 
-def url_extractor_factory(ns=None, operation=None, use_model_id=None, identifier_key=None, **kwargs):
+def url_extractor_factory(ns=None, operation=Operation.Retrieve, use_model_id=None, identifier_key=None, **kwargs):
     """
     A factory that creates url extractors.
     url extractor is an (component, model) -> string function that can generates url for relevant resources
@@ -37,8 +37,7 @@ def url_extractor_factory(ns=None, operation=None, use_model_id=None, identifier
                        component.identifier_key will get used instead if set to None.
 
     """
-    operation_ = operation or Operation.Retrieve
-    use_model_id_ = use_model_id if use_model_id is not None else operation_.value.pattern == NODE_PATTERN
+    use_model_id_ = use_model_id if use_model_id is not None else operation.value.pattern == NODE_PATTERN
 
     if identifier_key and not use_model_id_:
         raise TypeError(f"No need to pass identifier_key if use_model_id is set to false")
@@ -56,5 +55,5 @@ def url_extractor_factory(ns=None, operation=None, use_model_id=None, identifier
                 raise TypeError(f"identifier_key is set to alredy set parameter {identifier_key_}")
             url_params[identifier_key_] = model.id
 
-        return ns_.url_for(operation_, **url_params)
+        return ns_.url_for(operation, **url_params)
     return extract

--- a/microcosm_flask/url.py
+++ b/microcosm_flask/url.py
@@ -2,15 +2,58 @@
 Url fatories.
 
 """
-
 from microcosm_flask.operations import Operation, NODE_PATTERN
 
 
-def url_extractor_factory(ns=None, operation=Operation.Retrieve, use_model_id=None, identifier_key=None, **kwargs):
+def basic_url_extractor_factory(ns=None, operation=Operation.Retrieve, query_args_extractors=None):
     """
     A factory that creates url extractors.
     url extractor is an (component, model) -> string function that can generates url for relevant resources
-    The extractors can component.ns and component.identifier_key to easily generates relevant urls.
+
+    Simple examples:
+
+    class Controller:
+        def __init__(self, graph):
+            self.ns = Namespace(subject="company")
+    controller = Controller()
+    company = Company(id="ID", clock=3)
+
+    url_extractor_factory(operation=Operation.Search, min_clock=3)(ctrl, company) -> '/api/v1/company?min_clock=3'
+
+    :ns                    - Model namespace. Will use component.ns if ns is unspecified.
+    :operation             - microcosm_flask.operations.Operation, default is Operation.Retrieve
+                             If the operation is a node operation, an identifier extractor should be passed.
+    :query_args_extractors - Allow to specify query args to use. Passed as a list of (key, value) tuples.
+                             Both the key and the value can be either strings or string extractors functions:
+                             Extractor function is an (lambda component, model: action) function
+
+    """
+    def extract(component, model):
+        ns_ = ns or component.ns
+        if not query_args_extractors:
+            return ns_.url_for(operation)
+        url_params = dict()
+        for extractor_key, extractor_value in query_args_extractors:
+            key = str((extractor_key(component, model) if callable(extractor_key) else extractor_key))
+            value = str((extractor_value(component, model) if callable(extractor_value) else extractor_value))
+            if key in url_params:
+                raise TypeError(f"Extractor key {key} is passed more then once")
+            url_params[key] = value
+        return ns_.url_for(operation, **url_params)
+    return extract
+
+
+def url_extractor_factory(
+    ns=None,
+    operation=Operation.Retrieve,
+    use_model_identifier=None,
+    model_identifier="id",
+    schema_identifier=None,
+    **kwargs
+):
+    """
+    A factory that creates url extractors with id extractor.
+    url extractor is an (component, model) -> string function that can generates url for relevant resources
 
     Simple examples:
 
@@ -22,38 +65,28 @@ def url_extractor_factory(ns=None, operation=Operation.Retrieve, use_model_id=No
     company = Company(id="ID", clock=3)
 
     url_extractor_factory()(ctrl, company) -> '/api/v1/company/ID'
-    url_extractor_factory(min_clock=lambda cont, obj: obj.clock)(ctrl, company) -> '/api/v1/company/ID?min_clock=3'
 
-    :ns              - Model namespace. component.ns will get used instead if set to None.
-    :operation       - microcosm_flask.operations.Operation, default is Operation.Retrieve
-    :kwargs          - Allow to specify query args to use
-                       Passed as a dictionary of strings or extractors (lambda component, model: action)
-                       Extractor xample:
-                       * min_clock: lambda component, company_event: company_event.clock
-    :use_model_id    - Should use model.id to create the url.
-                       If is None, will use set to True for node operation (such as Retrieve, unlike Search)
-    :identifier_key  - Specify the object "id" schema key
-                       Cannot be used if use_model_id is set to false.
-                       component.identifier_key will get used instead if set to None.
+    :ns                   - Model namespace. component.ns will get used instead if set to None.
+    :operation            - microcosm_flask.operations.Operation, default is Operation.Retrieve
+    :kwargs               - Allow to specify query args to use
+                            Passed as a dictionary of strings or extractors (lambda component, model: action)
+                            Extractor Example:
+                            * min_clock: lambda component, company_event: company_event.clock
+    :use_model_identifier - Should use model.model_identifier to create the url.
+                            Default value dpeneds on the operation:
+                            True for node operations (True for Retrieve, False for Search)
+    :model_identifier     -
+    :schema_identifier    - Specify the object "id" schema key
+                            Cannot be used if use_model_identifier is set to false.
+                            component.identifier_key will get used instead if set to None.
+
 
     """
-    use_model_id_ = use_model_id if use_model_id is not None else operation.value.pattern == NODE_PATTERN
+    query_args_extractors = list(kwargs.items())
+    if use_model_identifier or (use_model_identifier is None and operation.value.pattern == NODE_PATTERN):
+        query_args_extractors.append((
+            (schema_identifier if schema_identifier is not None else lambda component, _: component.identifier_key),
+            lambda component, model: getattr(model, model_identifier),
+        ))
 
-    if identifier_key and not use_model_id_:
-        raise TypeError(f"No need to pass identifier_key if use_model_id is set to false")
-
-    def extract(component, model):
-        ns_ = ns or component.ns
-        url_params = {
-            key: str((kwarg(component, model) if callable(kwarg) else kwarg))
-            for key, kwarg
-            in kwargs.items()
-        }
-        if use_model_id_:
-            identifier_key_ = identifier_key or component.identifier_key
-            if identifier_key_ in url_params:
-                raise TypeError(f"identifier_key is set to alredy set parameter {identifier_key_}")
-            url_params[identifier_key_] = model.id
-
-        return ns_.url_for(operation, **url_params)
-    return extract
+    return basic_url_extractor_factory(ns, operation, query_args_extractors)

--- a/microcosm_flask/url.py
+++ b/microcosm_flask/url.py
@@ -5,7 +5,7 @@ Url fatories.
 from microcosm_flask.operations import Operation, NODE_PATTERN
 
 
-def basic_url_extractor_factory(ns=None, operation=Operation.Retrieve, query_args_extractors=None):
+def base_url_extractor_factory(ns=None, operation=Operation.Retrieve, query_args_extractors=None):
     """
     A factory that creates url extractors.
     url extractor is an (component, model) -> string function that can generates url for relevant resources
@@ -89,4 +89,4 @@ def url_extractor_factory(
             lambda component, model: getattr(model, model_identifier),
         ))
 
-    return basic_url_extractor_factory(ns, operation, query_args_extractors)
+    return base_url_extractor_factory(ns, operation, query_args_extractors)


### PR DESCRIPTION
Based on the idea in https://github.com/globality-corp/microcosm-pubsub/pull/85
A factory that creates url extractors.
url extractor is an `(component, model)-> str`  function that generates url for relevant resources
    The extractors can component.ns and component.identifier_key to easily generates urls for crud EPs. Can be combined with https://github.com/globality-corp/microcosm-pubsub/pull/86 to publish messages. 

Examples:
```

    class Controller:
        def __init__(self, graph):
            self.ns = Namespace(subject="company")
            self.identifier_key = "company_id"
    controller = Controller()
    company = Company(id="ID", clock=3)

    url_extractor_factory()(ctrl, company) -> '/api/v1/company/ID'
    url_extractor_factory(min_clock=lambda cont, obj: obj.clock)(ctrl, company) -> '/api/v1/company/ID?min_clock=3'
```