### PR TITLE
Add saved search convention

### DIFF
--- a/microcosm_flask/conventions/saved_search.py
+++ b/microcosm_flask/conventions/saved_search.py
@@ -1,0 +1,69 @@
+"""
+Saved search convention.
+
+"""
+from functools import wraps
+from inflection import pluralize
+
+from microcosm_flask.conventions.base import Convention
+from microcosm_flask.conventions.encoding import (
+    dump_response_data,
+    load_request_data,
+    merge_data,
+)
+from microcosm_flask.conventions.registry import request, response
+from microcosm_flask.operations import Operation
+from microcosm_flask.paging import identity, OffsetLimitPage
+
+
+class SavedSearchConvention(Convention):
+
+    @property
+    def page_cls(self):
+        return OffsetLimitPage
+
+    def configure_savedsearch(self, ns, definition):
+        """
+        Register a saved search endpoint.
+
+        The definition's func should be a search function, which must:
+        - accept kwargs for the request data
+        - return a tuple of (items, count) where count is the total number of items
+          available (in the case of pagination)
+
+        The definition's request_schema will be used to process query string arguments.
+
+        :param ns: the namespace
+        :param definition: the endpoint definition
+
+        """
+        paginated_list_schema = self.page_cls.make_paginated_list_schema_class(
+            ns,
+            definition.response_schema,
+        )()
+
+        @self.add_route(ns.collection_path, Operation.SavedSearch, ns)
+        @request(definition.request_schema)
+        @response(paginated_list_schema)
+        @wraps(definition.func)
+        def saved_search(**path_data):
+            request_data = load_request_data(definition.request_schema)
+            page = self.page_cls.from_dict(request_data)
+            request_data.update(page.to_dict(func=identity))
+            result = definition.func(**merge_data(path_data, request_data))
+            response_data, headers = page.to_paginated_list(result, ns, Operation.SavedSearch)
+            definition.header_func(headers, response_data)
+            response_format = self.negotiate_response_content(definition.response_formats)
+            return dump_response_data(
+                paginated_list_schema,
+                response_data,
+                headers=headers,
+                response_format=response_format,
+            )
+
+        saved_search.__doc__ = "Persist and return the search results of {}".format(pluralize(ns.subject_name))
+
+
+def configure_saved_search(graph, ns, mappings):
+    convention = SavedSearchConvention(graph)
+    convention.configure(ns, mappings)

--- a/microcosm_flask/operations.py
+++ b/microcosm_flask/operations.py
@@ -35,6 +35,7 @@ class Operation(Enum):
     Create = OperationInfo("create", "POST", NODE_PATTERN, 201)
     UpdateBatch = OperationInfo("update_batch", "PATCH", NODE_PATTERN, 200)
     CreateCollection = OperationInfo("create_collection", "POST", NODE_PATTERN, 200)
+    SavedSearch = OperationInfo("saved_search", "POST", NODE_PATTERN, 200)
 
     # instance operations
     Retrieve = OperationInfo("retrieve", "GET", NODE_PATTERN, 200)

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -2,8 +2,6 @@
 CRUD convention tests.
 
 """
-from json import dumps, loads
-
 from enum import Enum
 
 from hamcrest import (
@@ -98,7 +96,7 @@ class TestCRUD:
         if status_code == 204:
             response_data = None
         else:
-            response_data = loads(response.get_data().decode("utf-8"))
+            response_data = response.json
 
         # validate data if provided
         if response_data is not None and data is not None:
@@ -160,7 +158,7 @@ class TestCRUD:
     def test_reuse_search_self_link(self):
         uri = "/api/address?list_param=a,b,c&enum_param=A".format(PERSON_ID_1)
         response = self.client.get(uri)
-        response_data = loads(response.get_data().decode("utf-8"))
+        response_data = response.json
         response = self.client.get(response_data["_links"]["self"]["href"])
         self.assert_response(response, 200, {
             "count": 1,
@@ -187,7 +185,7 @@ class TestCRUD:
             "firstName": "Bob",
             "lastName": "Jones",
         }
-        response = self.client.post("/api/person", data=dumps(request_data))
+        response = self.client.post("/api/person", json=request_data)
         self.assert_response(response, 201, {
             "id": str(PERSON_ID_2),
             "firstName": "Bob",
@@ -204,7 +202,7 @@ class TestCRUD:
     def test_create_empty_object(self):
         response = self.client.post("/api/person", data='{}')
         self.assert_response(response, 422)
-        response_data = loads(response.get_data().decode("utf-8"))
+        response_data = response.json
         assert_that(response_data["context"]["errors"], contains_inanyorder(
             {
                 "message": "Could not validate field: lastName",
@@ -225,7 +223,7 @@ class TestCRUD:
         request_data = {
             "lastName": "Jones",
         }
-        response = self.client.post("/api/person", data=dumps(request_data))
+        response = self.client.post("/api/person", json=request_data)
         self.assert_response(response, 422, {
             "code": 422,
             "message": "Validation error",
@@ -248,7 +246,7 @@ class TestCRUD:
                 "lastName": "Jones",
             }],
         }
-        response = self.client.patch("/api/person", data=dumps(request_data))
+        response = self.client.patch("/api/person", json=request_data)
         self.assert_response(response, 200, {
             "items": [{
                 "id": str(PERSON_ID_2),
@@ -311,7 +309,7 @@ class TestCRUD:
             "firstName": "Bob",
             "lastName": "Jones",
         }
-        response = self.client.put(uri, data=dumps(request_data))
+        response = self.client.put(uri, json=request_data)
         self.assert_response(response, 200, {
             "id": str(PERSON_ID_1),
             "firstName": "Bob",
@@ -328,7 +326,7 @@ class TestCRUD:
         request_data = {
             "firstName": "Bob",
         }
-        response = self.client.patch(uri, data=dumps(request_data))
+        response = self.client.patch(uri, json=request_data)
         self.assert_response(response, 200, {
             "id": str(PERSON_ID_1),
             "firstName": "Bob",
@@ -345,5 +343,5 @@ class TestCRUD:
         request_data = {
             "firstName": "Bob",
         }
-        response = self.client.patch(uri, data=dumps(request_data))
+        response = self.client.patch(uri, json=request_data)
         self.assert_response(response, 404)

--- a/microcosm_flask/tests/conventions/test_saved_search.py
+++ b/microcosm_flask/tests/conventions/test_saved_search.py
@@ -1,0 +1,64 @@
+from hamcrest import (
+    assert_that,
+    contains,
+    has_entries,
+    equal_to,
+    is_,
+)
+
+from microcosm.api import create_object_graph
+from microcosm_flask.namespaces import Namespace
+from microcosm_flask.operations import Operation
+from microcosm_flask.paging import OffsetLimitPageSchema
+from microcosm_flask.conventions.crud import configure_crud
+from microcosm_flask.conventions.saved_search import configure_saved_search
+from microcosm_flask.tests.conventions.fixtures import (
+    person_retrieve,
+    person_search,
+    Person,
+    PersonLookupSchema,
+    PersonSchema,
+    PERSON_ID_1,
+)
+
+
+class PersonSearch:
+    pass
+
+
+class TestSavedSearch:
+
+    def setup(self):
+        self.graph = create_object_graph(name="example", testing=True)
+        self.person_ns = Namespace(subject=Person)
+        self.ns = Namespace(subject=PersonSearch)
+        # ensure that link hrefs work
+        configure_crud(self.graph, self.person_ns, {
+            Operation.Retrieve: (person_retrieve, PersonLookupSchema(), PersonSchema()),
+        })
+        # enable saved search
+        configure_saved_search(self.graph, self.ns, {
+            Operation.SavedSearch: (person_search, OffsetLimitPageSchema(), PersonSchema()),
+        })
+        self.client = self.graph.flask.test_client()
+
+    def test_saved_search(self):
+        uri = "/api/person_search"
+        response = self.client.post(uri)
+
+        assert_that(response.status_code, is_(equal_to(200)))
+        assert_that(
+            response.json,
+            has_entries(
+                count=1,
+                limit=20,
+                offset=0,
+                items=contains(
+                    has_entries(
+                        id=str(PERSON_ID_1),
+                        firstName="Alice",
+                        lastName="Smith",
+                    ),
+                ),
+            ),
+        )


### PR DESCRIPTION
Emulate the search convention with POST. Useful for searches with persistent side-effects