### PR TITLE
Handle string dumping of enums

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.13.0
+current_version = 1.13.1
 commit = False
 tag = False
 

--- a/microcosm_flask/fields/enum_field.py
+++ b/microcosm_flask/fields/enum_field.py
@@ -28,6 +28,8 @@ class EnumField(Field):
     def _serialize(self, value, attr, obj):
         if value is None:
             return value
+        elif isinstance(value, str):
+            return value
         elif self.by_value:
             return value.value
         else:

--- a/microcosm_flask/tests/fields/test_enum_field.py
+++ b/microcosm_flask/tests/fields/test_enum_field.py
@@ -7,6 +7,7 @@ from enum import Enum, IntEnum, unique
 from hamcrest import (
     assert_that,
     equal_to,
+    has_entries,
     is_,
 )
 from marshmallow import Schema
@@ -82,3 +83,16 @@ def test_load_int_enum_as_string():
     })
 
     assert_that(result.data["int_value"], is_(equal_to(TestIntEnum.Bar)))
+
+
+def test_dump_value_from_string():
+    schema = EnumSchema()
+    result = schema.dump({
+        "name": "foo",
+        "value": "bar",
+    })
+
+    assert_that(result.data, is_(has_entries(
+        name="foo",
+        value="bar",
+    )))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-flask"
-version = "1.13.0"
+version = "1.13.1"
 
 setup(
     name=project,


### PR DESCRIPTION
Enums should be enum-valued; if somehow they are strings, just move on