### PR TITLE
Specify an explictly empty 'additionalProperties' in openAPI definitions

### DIFF
--- a/microcosm_flask/swagger/schema.py
+++ b/microcosm_flask/swagger/schema.py
@@ -231,7 +231,8 @@ def build_schema(marshmallow_schema):
         "properties": {
             field.dump_to or name: build_parameter(field)
             for name, field in fields
-        }
+        },
+        "additionalProperties": {},
     }
     if required_fields:
         schema["required"] = required_fields

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -139,6 +139,7 @@ def test_build_swagger():
                     "lastName",
                 ],
                 "type": "object",
+                "additionalProperties": {},
                 "properties": {
                     "lastName": {
                         "type": "string",
@@ -155,6 +156,7 @@ def test_build_swagger():
                     "lastName",
                 ],
                 "type": "object",
+                "additionalProperties": {},
                 "properties": {
                     "lastName": {
                         "type": "string",
@@ -173,6 +175,7 @@ def test_build_swagger():
             },
             "UpdatePerson": {
                 "type": "object",
+                "additionalProperties": {},
                 "properties": {
                     "lastName": {
                         "type": "string",
@@ -185,6 +188,7 @@ def test_build_swagger():
             "ErrorContext": {
                 "required": ["errors"],
                 "type": "object",
+                "additionalProperties": {},
                 "properties": {
                     "errors": {
                         "items": {
@@ -197,6 +201,7 @@ def test_build_swagger():
             "SubError": {
                 "required": ["message"],
                 "type": "object",
+                "additionalProperties": {},
                 "properties": {
                     "message": {
                         "type": "string",
@@ -210,6 +215,7 @@ def test_build_swagger():
                     "retryable",
                 ],
                 "type": "object",
+                "additionalProperties": {},
                 "properties": {
                     "message": {
                         "type": "string",

--- a/microcosm_flask/tests/swagger/test_schema.py
+++ b/microcosm_flask/tests/swagger/test_schema.py
@@ -67,6 +67,7 @@ def test_schema_generation():
                 "type": "string",
             },
         },
+        "additionalProperties": {},
         "required": [
             "firstName",
             "lastName",


### PR DESCRIPTION
When instantiating a subclass of `bravado_core.model.Model`, if `"additionalProperties"` is not specifed in the openAPI spec, then any additional property is accepted (see [bravado-core](https://github.com/Yelp/bravado-core/blob/master/bravado_core/model.py#L321)).

In practice, none of our models accept additional properties so we should explicitly specify that. This will allow us to better validate arguments passed to openAPI clients in unit tests.

See also [this StackOverflow answer](https://stackoverflow.com/a/41240118/1716531) on what `additionalProperties` are; the docs are not particularly useful there.