### PR TITLE
Include request parameter in Delete requests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,14 @@
 [flake8]
 max-line-length = 120
 max-complexity = 15
+
+[isort]
+combine_as_imports=True
+enforce_white_space=True
+include_trailing_comma=True
+known_first_party=pythia
+known_standard_library=pkg_resources
+known_third_party=six,hamcrest,mock,nose_parameterized
+line_length=120
+lines_after_imports=2
+multi_line_output=3


### PR DESCRIPTION
- update crud convention to include request parameters for delete requests

Why?

Enables additional parameters to be included in delete requests. Now the only
parameter that is included is the id of the resource you are deleting.