### PR TITLE
GLOB-25359: Move the endpoint to tags rather than the name.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.15.0
+current_version = 1.16.0
 commit = False
 tag = False
 

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -77,10 +77,13 @@ def configure_route_decorator(graph):
 
             if enable_metrics or ns.enable_metrics:
                 from microcosm_flask.metrics import StatusCodeClassifier
-                func = graph.metrics_counting("microcosm_flask",
-                                              tags=["endpoint:" + endpoint],
-                                              classifier_cls=StatusCodeClassifier)(func)
-                func = graph.metrics_timing("microcosm_flask", tags=["endpoint:" + endpoint])(func)
+                tags = [f"endpoint:{endpoint}", "backend_type:microcosm_flask"]
+                func = graph.metrics_counting(
+                    "route",
+                    tags=tags,
+                    classifier_cls=StatusCodeClassifier,
+                )(func)
+                func = graph.metrics_timing("route", tags=tags)(func)
 
             # keep audit decoration last (before registering the route) so that
             # errors raised by other decorators are captured in the audit trail

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -77,8 +77,10 @@ def configure_route_decorator(graph):
 
             if enable_metrics or ns.enable_metrics:
                 from microcosm_flask.metrics import StatusCodeClassifier
-                func = graph.metrics_counting(endpoint, classifier_cls=StatusCodeClassifier)(func)
-                func = graph.metrics_timing(endpoint)(func)
+                func = graph.metrics_counting("microcosm_flask",
+                                              tags=["endpoint:" + endpoint],
+                                              classifier_cls=StatusCodeClassifier)(func)
+                func = graph.metrics_timing("microcosm_flask", tags=["endpoint:" + endpoint])(func)
 
             # keep audit decoration last (before registering the route) so that
             # errors raised by other decorators are captured in the audit trail

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-flask"
-version = "1.15.0"
+version = "1.16.0"
 
 setup(
     name=project,


### PR DESCRIPTION
Why?
We want to know that the metrics for different endpoints are "commensurate".
For example, we can add all the 200 counts to see how many total 200 counts we have.
This allows us whatever server pulls from the statsd server.