### PR TITLE
GLOB-25917: Make sure that a statsd client is configured

### DIFF
--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -77,6 +77,7 @@ def configure_route_decorator(graph):
 
             if enable_metrics or ns.enable_metrics:
                 from microcosm_flask.metrics import StatusCodeClassifier
+                graph.use("datadog_statsd")
                 tags = [f"endpoint:{endpoint}", "backend_type:microcosm_flask"]
                 func = graph.metrics_counting(
                     "route",


### PR DESCRIPTION
Why?

If `metrics_counting`/`metrics_timing` are going to be called,
we need to make sure that they have a statsd client on the graph
available as `graph.metrics`. Since the latest release of `microcosm_metrics`
only supports the DataDog client API, configure that right away
instead of hoping it will get taken care of at the application level.