### PR TITLE
Separate route path construction into its own component

### DIFF
--- a/microcosm_flask/conventions/swagger.py
+++ b/microcosm_flask/conventions/swagger.py
@@ -12,7 +12,6 @@ from microcosm_flask.conventions.encoding import make_response
 from microcosm_flask.conventions.registry import iter_endpoints
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
-from microcosm_flask.routing import make_path
 from microcosm_flask.swagger.definitions import build_swagger
 
 
@@ -35,7 +34,7 @@ class SwaggerConvention(Convention):
         def match_func(operation, ns, rule):
             # only expose endpoints that have the correct path prefix and operation
             return (
-                rule.rule.startswith(make_path(self.graph, swagger_ns.path)) and
+                rule.rule.startswith(self.graph.build_route_path(swagger_ns.path, swagger_ns.prefix)) and
                 operation in self.matching_operations
             )
 

--- a/microcosm_flask/namespaces.py
+++ b/microcosm_flask/namespaces.py
@@ -46,7 +46,7 @@ class Namespace:
         """
         :param subject: the target resource (or resource name) of this namespace
         :param object_: the subject resource (or resource name) of this namespace (e.g. for relations)
-        :param path: the path prefix for this namespace
+        :param path: the (absolute) prefix for this namespace
         :param controller: the object responsible for implementations associated with this namespace.
         :param version: the version of this namespace
         :param enable_basic_auth: enable basic auth for this namespace if it's not enabled globally
@@ -55,7 +55,7 @@ class Namespace:
         """
         self.subject = subject
         self.object_ = object_
-        self.prefix = prefix or ""
+        self.prefix = prefix
         self.qualifier = qualifier
         self.controller = controller
         self.version = version
@@ -71,8 +71,6 @@ class Namespace:
 
         """
         return "/".join([
-            self.prefix,
-        ] + [
             part
             for part in [
                 self.version,

--- a/microcosm_flask/paths.py
+++ b/microcosm_flask/paths.py
@@ -1,0 +1,34 @@
+"""
+Path building.
+
+"""
+from microcosm.api import defaults
+
+
+@defaults(
+    prefix="/api",
+)
+class RoutePathBuilder:
+
+    def __init__(self, graph):
+        self.prefix = graph.config.build_route_path.prefix
+
+    def __call__(self, path, prefix=None):
+        """
+        Generate a path for a route.
+
+        :param path: the route path; must not be None
+        :param prefix: overrides the default prefix if not None
+
+        """
+        return "/" + "/".join(filter(None, self.iter_path_parts(path, prefix)))
+
+    def iter_path_parts(self, path, prefix):
+        # use the provided prefix is not None
+        if prefix is not None:
+            yield prefix.strip("/")
+        else:
+            yield self.prefix.strip("/")
+
+        # use the path
+        yield path.strip("/")

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -11,10 +11,6 @@ from microcosm.api import defaults
 from microcosm_logging.decorators import context_logger
 
 
-def make_path(graph, path):
-    return graph.config.route.path_prefix + path
-
-
 @defaults(
     converters=[
         "uuid",
@@ -24,7 +20,6 @@ def make_path(graph, path):
     enable_context_logger="true",
     enable_cors="true",
     enable_metrics="false",
-    path_prefix="/api",
 )
 def configure_route_decorator(graph):
     """
@@ -57,7 +52,7 @@ def configure_route_decorator(graph):
         """
         def decorator(func):
             endpoint = ns.endpoint_for(operation)
-            endpoint_path = make_path(graph, path)
+            endpoint_path = graph.build_route_path(path, ns.prefix)
 
             if enable_cors:
                 func = cross_origin(supports_credentials=True)(func)

--- a/microcosm_flask/swagger/definitions.py
+++ b/microcosm_flask/swagger/definitions.py
@@ -30,7 +30,6 @@ from microcosm_flask.conventions.registry import (
 from microcosm_flask.errors import ErrorSchema, ErrorContextSchema, SubErrorSchema
 from microcosm_flask.naming import name_for
 from microcosm_flask.operations import Operation
-from microcosm_flask.routing import make_path
 from microcosm_flask.swagger.naming import operation_name, type_name
 from microcosm_flask.swagger.schema import build_parameter, iter_schemas
 
@@ -43,7 +42,7 @@ def build_swagger(graph, ns, operations):
     Build out the top-level swagger definition.
 
     """
-    base_path = make_path(graph, ns.path)
+    base_path = graph.build_route_path(ns.path, ns.prefix)
     schema = swagger.Swagger(
         swagger="2.0",
         info=swagger.Info(

--- a/microcosm_flask/tests/conventions/test_alias.py
+++ b/microcosm_flask/tests/conventions/test_alias.py
@@ -57,7 +57,9 @@ class TestAlias:
     def setup(self):
         self.graph = create_object_graph(name="example", testing=True)
 
-        self.ns = Namespace(subject=Person)
+        self.ns = Namespace(
+            subject=Person,
+        )
         configure_crud(self.graph, self.ns, PERSON_MAPPINGS)
         configure_alias(self.graph, self.ns, PERSON_MAPPINGS)
         self.graph.config.swagger_convention.operations.append("alias")

--- a/microcosm_flask/tests/conventions/test_discovery.py
+++ b/microcosm_flask/tests/conventions/test_discovery.py
@@ -27,7 +27,7 @@ def test_discovery():
 
     client = graph.flask.test_client()
 
-    response = client.get("/api/")
+    response = client.get("/api")
     assert_that(response.status_code, is_(equal_to(200)))
     data = loads(response.get_data().decode("utf-8"))
     assert_that(data, is_(equal_to({
@@ -37,7 +37,7 @@ def test_discovery():
                 "type": "foo",
             }],
             "self": {
-                "href": "http://localhost/api/?offset=0&limit=20",
+                "href": "http://localhost/api?offset=0&limit=20",
             },
         }
     })))

--- a/microcosm_flask/tests/test_paths.py
+++ b/microcosm_flask/tests/test_paths.py
@@ -1,0 +1,62 @@
+"""
+Test path building.
+
+"""
+from hamcrest import assert_that, equal_to, is_
+from microcosm.api import create_object_graph
+
+
+class TestRoutePathBuilder:
+
+    def setup(self):
+        self.graph = create_object_graph("microcosm-path", testing=True)
+        self.build_route_path = self.graph.build_route_path
+        self.graph.lock()
+
+    def test_simple_path(self):
+        assert_that(
+            self.build_route_path("foo"),
+            is_(equal_to("/api/foo")),
+        )
+
+    def test_simple_path_with_leading_slash(self):
+        assert_that(
+            self.build_route_path("/foo"),
+            is_(equal_to("/api/foo")),
+        )
+
+    def test_simple_path_with_trailing_slash(self):
+        assert_that(
+            self.build_route_path("foo/"),
+            is_(equal_to("/api/foo")),
+        )
+
+    def test_slash(self):
+        assert_that(
+            self.build_route_path("/"),
+            is_(equal_to("/api")),
+        )
+
+    def test_empty(self):
+        assert_that(
+            self.build_route_path(""),
+            is_(equal_to("/api")),
+        )
+
+    def test_override_prefix(self):
+        assert_that(
+            self.build_route_path("/ping", "/foo"),
+            is_(equal_to("/foo/ping")),
+        )
+
+    def test_override_slash_prefix(self):
+        assert_that(
+            self.build_route_path("ping", "/"),
+            is_(equal_to("/ping")),
+        )
+
+    def test_override_empty_prefix(self):
+        assert_that(
+            self.build_route_path("/ping", ""),
+            is_(equal_to("/ping")),
+        )

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
             "audit = microcosm_flask.audit:configure_audit_decorator",
             "basic_auth = microcosm_flask.basic_auth:configure_basic_auth_decorator",
             "build_info_convention = microcosm_flask.conventions.build_info:configure_build_info",
+            "build_route_path = microcosm_flask.paths:RoutePathBuilder",
             "discovery_convention = microcosm_flask.conventions.discovery:configure_discovery",
             "error_handlers = microcosm_flask.errors:configure_error_handlers",
             "flask = microcosm_flask.factories:configure_flask",


### PR DESCRIPTION
Path construction is difficult to modify today, in part because the `make_path` function
is not exposed and is not customizable.

This PR takes the first step of putting path construction into a graph component, adding
more exhaustive tests, and improving (read: regressing) a few behaviors. Customization
is possible via a `prefix` override parameter, but the builder cannot be swapped out yet.

There are two backwards imcompatible changes here:

 - `Namespace.prefix` is no longer used for the namespace's own path calculation; it is instead
   used by the `RoutePathBuilder` component. By inspection, there are no obvious usages of this
   parameter in our code any more (we use `version` instead), so this should be safe.

 - Trailing slashes are removed from paths. This means that the current discovery convention
   that handles `/api/` will handle `/api` instead. No code should depend on this endpoint and
   the new usage should be better for humans.