### PR TITLE
Remove additional properties

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.18.0
+current_version = 1.18.1
 commit = False
 tag = False
 

--- a/microcosm_flask/swagger/schema.py
+++ b/microcosm_flask/swagger/schema.py
@@ -232,7 +232,6 @@ def build_schema(marshmallow_schema):
             field.dump_to or name: build_parameter(field)
             for name, field in fields
         },
-        "additionalProperties": {},
     }
     if required_fields:
         schema["required"] = required_fields

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -139,7 +139,6 @@ def test_build_swagger():
                     "lastName",
                 ],
                 "type": "object",
-                "additionalProperties": {},
                 "properties": {
                     "lastName": {
                         "type": "string",
@@ -156,7 +155,6 @@ def test_build_swagger():
                     "lastName",
                 ],
                 "type": "object",
-                "additionalProperties": {},
                 "properties": {
                     "lastName": {
                         "type": "string",
@@ -175,7 +173,6 @@ def test_build_swagger():
             },
             "UpdatePerson": {
                 "type": "object",
-                "additionalProperties": {},
                 "properties": {
                     "lastName": {
                         "type": "string",
@@ -188,7 +185,6 @@ def test_build_swagger():
             "ErrorContext": {
                 "required": ["errors"],
                 "type": "object",
-                "additionalProperties": {},
                 "properties": {
                     "errors": {
                         "items": {
@@ -201,7 +197,6 @@ def test_build_swagger():
             "SubError": {
                 "required": ["message"],
                 "type": "object",
-                "additionalProperties": {},
                 "properties": {
                     "message": {
                         "type": "string",
@@ -215,7 +210,6 @@ def test_build_swagger():
                     "retryable",
                 ],
                 "type": "object",
-                "additionalProperties": {},
                 "properties": {
                     "message": {
                         "type": "string",

--- a/microcosm_flask/tests/swagger/test_schema.py
+++ b/microcosm_flask/tests/swagger/test_schema.py
@@ -67,7 +67,6 @@ def test_schema_generation():
                 "type": "string",
             },
         },
-        "additionalProperties": {},
         "required": [
             "firstName",
             "lastName",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-flask"
-version = "1.18.0"
+version = "1.18.1"
 
 setup(
     name=project,


### PR DESCRIPTION
Release https://github.com/globality-corp/microcosm-flask/pull/201

Details:
Reverts #186
While in theory this change is great, in practice it's prevents us for deploying hotfixes to services.
Sometimes we do want to hotfix a service to expose new field, however - without updating the swagger definitions of all depend services - they will break.
