### PR TITLE
Fix swagger def generation for no version/no prefix case

### DIFF
--- a/microcosm_flask/swagger/definitions.py
+++ b/microcosm_flask/swagger/definitions.py
@@ -80,8 +80,10 @@ def add_paths(paths, base_path, operations):
         if not path.startswith(base_path):
             continue
         method = operation.value.method.lower()
+        # if there's no version number or prefix, then the root slash is also part of the path suffix
+        suffix_start = 0 if len(base_path) == 1 else len(base_path)
         paths.setdefault(
-            path[len(base_path):],
+            path[suffix_start:],
             swagger.PathItem(),
         )[method] = build_operation(operation, ns, rule, func)
 

--- a/microcosm_flask/swagger/definitions.py
+++ b/microcosm_flask/swagger/definitions.py
@@ -80,7 +80,9 @@ def add_paths(paths, base_path, operations):
         if not path.startswith(base_path):
             continue
         method = operation.value.method.lower()
-        # if there's no version number or prefix, then the root slash is also part of the path suffix
+        # If there is no version number or prefix, we'd expect the base path to be ""
+        # However, OpenAPI requires the minimal base path to be "/"
+        # This means we need branching logic for that special case
         suffix_start = 0 if len(base_path) == 1 else len(base_path)
         paths.setdefault(
             path[suffix_start:],


### PR DESCRIPTION
**Why?**
Though it's not something we've done before, one could want to have non-namespaced paths, i.e. all paths under the root without a prefix or version number.
One example is when paths are imposed by a third-party tool that will contact our API on a fixed path (e.g. building a container for AWS SageMaker).

Since a path suffix has a leading `/`, when the API prefix and version number are both empty we'd expect the base path to equal `""`. However, OpenAPI requires the base path to minimally be `"/"`, which requires a special case to generate a proper OpenAPI definition.

**What?**
- Fix paths in the OpenAPI definition to have a leading slash when the API prefix and version are empty strings.
- Add test for that particular case.