### PR TITLE
Control request header logging.

### DIFF
--- a/microcosm_flask/audit.py
+++ b/microcosm_flask/audit.py
@@ -14,9 +14,9 @@ from uuid import UUID
 from flask import current_app, g, request
 from inflection import underscore
 from microcosm.api import defaults
-from microcosm_flask.context import make_get_request_context, ALL_HEADER_LIST
 from microcosm_logging.timing import elapsed_time
 
+from microcosm_flask.context import ALL_HEADER_LIST, make_get_request_context
 from microcosm_flask.errors import (
     extract_context,
     extract_error_message,

--- a/microcosm_flask/audit.py
+++ b/microcosm_flask/audit.py
@@ -14,7 +14,7 @@ from uuid import UUID
 from flask import current_app, g, request
 from inflection import underscore
 from microcosm.api import defaults
-from microcosm_flask.context import get_request_context, ALL_HEADER_LIST
+from microcosm_flask.context import make_get_request_context, ALL_HEADER_LIST
 from microcosm_logging.timing import elapsed_time
 
 from microcosm_flask.errors import (
@@ -112,7 +112,12 @@ class RequestInfo:
     Capture of key information for requests.
 
     """
-    def __init__(self, options, func, request_info_func=get_request_context):
+    def __init__(
+        self,
+        options,
+        func,
+        request_info_func=make_get_request_context(ALL_HEADER_LIST),
+    ):
         self.options = options
         self.operation = request.endpoint
         self.func = func.__name__

--- a/microcosm_flask/context.py
+++ b/microcosm_flask/context.py
@@ -1,5 +1,6 @@
 from flask import request
 
+
 # This is the total set of Globality-proprietary headers
 ALL_HEADER_LIST = (
     "X-Request",  # These are values *invariant* to a user request, e.g. user-id, request-id, etc.

--- a/microcosm_flask/context.py
+++ b/microcosm_flask/context.py
@@ -1,13 +1,14 @@
 from flask import request
 
 
-# This is the total set of Globality-proprietary headers
+# Special headers reserved for use in `microcosm-` based applications:
 ALL_HEADER_LIST = (
-    "X-Request",  # These are values *invariant* to a user request, e.g. user-id, request-id, etc.
+    "X-Request",  # These are values *invariant* to a user request from UI
+                  # perspective, e.g. user-id, request-id, etc.
     "X-Client",  # These are values *specific* to a single HTTP Client call to a web service
 )
 
-# This is the list of internal Globality Headers we use which are safe for logging.
+# This is the list of internal Headers which should always be logged.
 LOGGABLE_HEADER_WHITE_LIST = ("X-Request")
 
 

--- a/microcosm_flask/context.py
+++ b/microcosm_flask/context.py
@@ -10,10 +10,12 @@ ALL_HEADER_LIST = (
 LOGGABLE_HEADER_WHITE_LIST = ("X-Request")
 
 
-def get_request_context(header_white_list=LOGGABLE_HEADER_WHITE_LIST):
-    return {
-        header: value
-        for prefix in header_white_list
-        for header, value in request.headers.items()
-        if header.startswith(prefix)
-    }
+def make_get_request_context(header_white_list=LOGGABLE_HEADER_WHITE_LIST):
+    def get_request_context():
+        return {
+            header: value
+            for prefix in header_white_list
+            for header, value in request.headers.items()
+            if header.startswith(prefix)
+        }
+    return get_request_context

--- a/microcosm_flask/context.py
+++ b/microcosm_flask/context.py
@@ -1,32 +1,19 @@
 from flask import request
-from microcosm.api import defaults
 
-
-X_REQUEST = "X-Request"
-
-
-def context_wrapper(include_header_prefix):
-    def retrieve_context():
-        return {
-            header: value
-            for header, value in request.headers.items()
-            if header.startswith(include_header_prefix)
-        }
-
-    return retrieve_context
-
-
-@defaults(
-    include_header_prefix=X_REQUEST,
+# This is the total set of Globality-proprietary headers
+ALL_HEADER_LIST = (
+    "X-Request",  # These are values *invariant* to a user request, e.g. user-id, request-id, etc.
+    "X-Client",  # These are values *specific* to a single HTTP Client call to a web service
 )
-def configure_request_context(graph):
-    """
-    Configure the flask context function which controls what data you want to associate
-    with your flask request context, e.g. headers, request body/response.
 
-    Usage:
-        graph.request_context()
+# This is the list of internal Globality Headers we use which are safe for logging.
+LOGGABLE_HEADER_WHITE_LIST = ("X-Request")
 
-    """
-    include_header_prefix = graph.config.request_context.include_header_prefix
-    return context_wrapper(include_header_prefix)
+
+def get_request_context(header_white_list=LOGGABLE_HEADER_WHITE_LIST):
+    return {
+        header: value
+        for prefix in header_white_list
+        for header, value in request.headers.items()
+        if header.startswith(prefix)
+    }

--- a/microcosm_flask/context.py
+++ b/microcosm_flask/context.py
@@ -5,7 +5,7 @@ from flask import request
 ALL_HEADER_LIST = (
     "X-Request",  # These are values *invariant* to a user request from UI
                   # perspective, e.g. user-id, request-id, etc.
-    "X-Client",  # These are values *specific* to a single HTTP Client call to a web service
+    "X-Client",   # These are values *specific* to a single HTTP Client call to a web service
 )
 
 # This is the list of internal Headers which should always be logged.

--- a/microcosm_flask/factories.py
+++ b/microcosm_flask/factories.py
@@ -40,7 +40,6 @@ def configure_flask_app(graph):
     """
     graph.use(
         "audit",
-        "request_context",
         "basic_auth",
         "error_handlers",
         "logger",

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -7,7 +7,7 @@ Intercepts Flask's normal route registration to inject conventions.
 from flask_cors import cross_origin
 from microcosm.api import defaults, typed
 from microcosm.config.types import boolean
-from microcosm_flask.context import get_request_context
+from microcosm_flask.context import make_get_request_context
 from microcosm_logging.decorators import context_logger
 
 
@@ -61,13 +61,13 @@ def configure_route_decorator(graph):
 
             if enable_context_logger and ns.controller is not None:
                 func = context_logger(
-                    get_request_context,
+                    make_get_request_context(),
                     func,
                     parent=ns.controller,
                 )
 
             # set the opaque component data_func to look at the flask request context
-            func = graph.opaque.initialize(get_request_context)(func)
+            func = graph.opaque.initialize(make_get_request_context())(func)
 
             if graph.route_metrics.enabled:
                 func = graph.route_metrics(endpoint)(func)

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -7,8 +7,9 @@ Intercepts Flask's normal route registration to inject conventions.
 from flask_cors import cross_origin
 from microcosm.api import defaults, typed
 from microcosm.config.types import boolean
-from microcosm_flask.context import make_get_request_context
 from microcosm_logging.decorators import context_logger
+
+from microcosm_flask.context import make_get_request_context
 
 
 @defaults(

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -7,6 +7,7 @@ Intercepts Flask's normal route registration to inject conventions.
 from flask_cors import cross_origin
 from microcosm.api import defaults, typed
 from microcosm.config.types import boolean
+from microcosm_flask.context import get_request_context
 from microcosm_logging.decorators import context_logger
 
 
@@ -60,13 +61,13 @@ def configure_route_decorator(graph):
 
             if enable_context_logger and ns.controller is not None:
                 func = context_logger(
-                    graph.request_context,
+                    get_request_context,
                     func,
                     parent=ns.controller,
                 )
 
             # set the opaque component data_func to look at the flask request context
-            func = graph.opaque.initialize(graph.request_context)(func)
+            func = graph.opaque.initialize(get_request_context)(func)
 
             if graph.route_metrics.enabled:
                 func = graph.route_metrics(endpoint)(func)

--- a/microcosm_flask/tests/test_audit.py
+++ b/microcosm_flask/tests/test_audit.py
@@ -38,7 +38,6 @@ class TestRequestInfo:
         self.graph = create_object_graph("example", testing=True, debug=True)
         self.graph.use(
             "flask",
-            "request_context",
         )
 
         self.graph.flask.route("/")(test_func)
@@ -74,7 +73,7 @@ class TestRequestInfo:
 
         """
         with self.graph.flask.test_request_context("/", headers={"X-Request-Id": "request-id"}):
-            request_info = RequestInfo(self.options, test_func, self.graph.request_context)
+            request_info = RequestInfo(self.options, test_func)
             dct = request_info.to_dict()
             request_id = dct.pop("X-Request-Id")
             assert_that(request_id, is_(equal_to("request-id")))

--- a/microcosm_flask/tests/test_context.py
+++ b/microcosm_flask/tests/test_context.py
@@ -20,6 +20,7 @@ def test_request_context():
         with graph.opaque.initialize(make_get_request_context()):
             assert_that(graph.opaque["X-Request-Id"], is_(equal_to("foo")))
 
+
 def test_make_get_request_context_respects_passed_headers():
     graph = create_object_graph(name="example", testing=True)
     graph.use(

--- a/microcosm_flask/tests/test_context.py
+++ b/microcosm_flask/tests/test_context.py
@@ -5,16 +5,17 @@ Test context.
 from hamcrest import assert_that, equal_to, is_
 from microcosm.api import create_object_graph
 
+from microcosm_flask.context import get_request_context
+
 
 def test_request_context():
     graph = create_object_graph(name="example", testing=True)
     graph.use(
         "opaque",
-        "request_context",
     )
 
     with graph.flask.test_request_context(headers={
             "X-Request-Id": "foo",
     }):
-        with graph.opaque.initialize(graph.request_context):
+        with graph.opaque.initialize(get_request_context):
             assert_that(graph.opaque["X-Request-Id"], is_(equal_to("foo")))

--- a/microcosm_flask/tests/test_context.py
+++ b/microcosm_flask/tests/test_context.py
@@ -5,7 +5,7 @@ Test context.
 from hamcrest import assert_that, equal_to, is_
 from microcosm.api import create_object_graph
 
-from microcosm_flask.context import get_request_context
+from microcosm_flask.context import make_get_request_context
 
 
 def test_request_context():
@@ -17,5 +17,19 @@ def test_request_context():
     with graph.flask.test_request_context(headers={
             "X-Request-Id": "foo",
     }):
-        with graph.opaque.initialize(get_request_context):
+        with graph.opaque.initialize(make_get_request_context()):
             assert_that(graph.opaque["X-Request-Id"], is_(equal_to("foo")))
+
+def test_make_get_request_context_respects_passed_headers():
+    graph = create_object_graph(name="example", testing=True)
+    graph.use(
+        "opaque",
+    )
+
+    with graph.flask.test_request_context(headers={
+            "X-Foo-Id": "foo",
+            "X-Bar-Id": "bar",
+    }):
+        with graph.opaque.initialize(make_get_request_context(["X-Bar"])):
+            assert_that(graph.opaque["X-Bar-Id"], is_(equal_to("bar")))
+            assert_that(graph.opaque.get("X-Foo-Id"), is_(equal_to(None)))

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
             "landing_convention = microcosm_flask.conventions.landing:configure_landing",
             "logging_level_convention = microcosm_flask.conventions.logging_level:configure_logging_level",
             "port_forwarding = microcosm_flask.forwarding:configure_port_forwarding",
-            "request_context = microcosm_flask.context:configure_request_context",
             "route = microcosm_flask.routing:configure_route_decorator",
             "route_metrics = microcosm_flask.metrics:RouteMetrics",
             "swagger_convention = microcosm_flask.conventions.swagger:configure_swagger",


### PR DESCRIPTION
We have two cases in microcosm-flask for inspecting request headers:
- In the audit log we want to log the appropriate Globality-specific
  headers.
- In the resulting actions of the web-route we want to pass along the
  appropriate headers in `graph.opaque`.

It turns out that these aren't always the same. In particular we define
two different sets of headers:

- `X-Request`: These are headers already used within microcosm for
tracking events across an entire user flow which may include *many* http
requests.
- `X-Client`: These are hreaders for tracking information across one
single HTTP request, usually only involving a single client and a single
server.

Before this PR we used the `graph` abstraction for getting `request_context`, but on looking at our code we only use `graph.request_context` from within this repo, so I decided to simplify the code a bit not to use the graph.