### PR TITLE
Allow audit logging at debug.

### DIFF
--- a/microcosm_flask/audit.py
+++ b/microcosm_flask/audit.py
@@ -184,11 +184,12 @@ class RequestInfo:
             else:
                 logger.warning(dct)
         else:
-            # usually log at INFO; a raised exception can be an error or expected behavior (e.g. 404)
-            if self.options.log_as_debug:
-                logger.debug(self.to_dict())
-            else:
+            # usually log at INFO; a raised exception can be an error or
+            # expected behavior (e.g. 404)
+            if not self.options.log_as_debug:
                 logger.info(self.to_dict())
+            else:
+                logger.debug(self.to_dict())
 
     def capture_request(self):
         if not current_app.debug:

--- a/microcosm_flask/tests/test_audit.py
+++ b/microcosm_flask/tests/test_audit.py
@@ -49,6 +49,7 @@ class TestRequestInfo:
             include_response_body=True,
             include_path=True,
             include_query_string=True,
+            log_as_debug=False,
         )
 
     def test_base_info(self):
@@ -302,6 +303,32 @@ class TestRequestInfo:
                 method="GET",
                 func="test_func",
             ))
+            logger.warning.assert_not_called()
+
+    def test_log_debug(self):
+        """
+        Log at DEBUG when configured to.
+
+        """
+        debug_options = AuditOptions(
+            include_request_body=True,
+            include_response_body=True,
+            include_path=True,
+            include_query_string=True,
+            log_as_debug=True,
+        )
+
+        with self.graph.flask.test_request_context("/"):
+            request_info = RequestInfo(debug_options, test_func, None)
+
+            logger = MagicMock()
+            request_info.log(logger)
+            logger.debug.assert_called_with(dict(
+                operation="test_func",
+                method="GET",
+                func="test_func",
+            ))
+            logger.info.assert_not_called()
             logger.warning.assert_not_called()
 
     def test_log_path(self):


### PR DESCRIPTION
When we set out to add audit logging to microcosm we had a more naive
definition of audit logs. I think what we call "audit logs" are just
"request logs" and should be revisted later. For now, we need the
ability to turn some of these automatic logs off by lowering the logging
level to clean up our logs.