### PR TITLE
Make request context capture jaeger headers

### DIFF
--- a/microcosm_flask/context.py
+++ b/microcosm_flask/context.py
@@ -8,23 +8,23 @@ JAEGER_TRACE_ID = "Uber-Trace-Id"
 HEADER_PREFIXES = [X_REQUEST, JAEGER_TRACE_ID]
 
 
-def context_wrapper(include_header_prefix):
+def context_wrapper(include_header_prefixes):
     def retrieve_context():
         context = {
             header: value
             for header, value in request.headers.items()
             if any([
                 header.startswith(prefix)
-                for prefix in HEADER_PREFIXES
+                for prefix in include_header_prefixes
             ])
         }
+        context["span_name"] = str(request)
         return context
-
     return retrieve_context
 
 
 @defaults(
-    include_header_prefix=X_REQUEST,
+    include_header_prefixes=HEADER_PREFIXES,
 )
 def configure_request_context(graph):
     """
@@ -35,5 +35,5 @@ def configure_request_context(graph):
         graph.request_context()
 
     """
-    include_header_prefix = graph.config.request_context.include_header_prefix
-    return context_wrapper(include_header_prefix)
+    include_header_prefixes = graph.config.request_context.include_header_prefixes
+    return context_wrapper(include_header_prefixes)

--- a/microcosm_flask/context.py
+++ b/microcosm_flask/context.py
@@ -1,11 +1,10 @@
 from flask import request
 from microcosm.api import defaults
+from microcosm.tracing import TRACE_ID, SPAN_NAME
 
 
 X_REQUEST = "X-Request"
-JAEGER_TRACE_ID = "Uber-Trace-Id"
-
-HEADER_PREFIXES = [X_REQUEST, JAEGER_TRACE_ID]
+HEADER_PREFIXES = [X_REQUEST, TRACE_ID]
 
 
 def context_wrapper(include_header_prefixes):
@@ -14,11 +13,11 @@ def context_wrapper(include_header_prefixes):
             header: value
             for header, value in request.headers.items()
             if any([
-                header.startswith(prefix)
+                header.lower().startswith(prefix.lower())
                 for prefix in include_header_prefixes
             ])
         }
-        context["span_name"] = str(request)
+        context[SPAN_NAME] = str(request)
         return context
     return retrieve_context
 

--- a/microcosm_flask/context.py
+++ b/microcosm_flask/context.py
@@ -1,10 +1,11 @@
 from flask import request
+from jaeger_client.constants import TRACE_ID_HEADER
 from microcosm.api import defaults
-from microcosm.tracing import TRACE_ID, SPAN_NAME
+from microcosm.tracing import SPAN_NAME
 
 
 X_REQUEST = "X-Request"
-HEADER_PREFIXES = [X_REQUEST, TRACE_ID]
+HEADER_PREFIXES = [X_REQUEST, TRACE_ID_HEADER]
 
 
 def context_wrapper(include_header_prefixes):

--- a/microcosm_flask/context.py
+++ b/microcosm_flask/context.py
@@ -3,15 +3,22 @@ from microcosm.api import defaults
 
 
 X_REQUEST = "X-Request"
+JAEGER_TRACE_ID = "Uber-Trace-Id"
+
+HEADER_PREFIXES = [X_REQUEST, JAEGER_TRACE_ID]
 
 
 def context_wrapper(include_header_prefix):
     def retrieve_context():
-        return {
+        context = {
             header: value
             for header, value in request.headers.items()
-            if header.startswith(include_header_prefix)
+            if any([
+                header.startswith(prefix)
+                for prefix in HEADER_PREFIXES
+            ])
         }
+        return context
 
     return retrieve_context
 

--- a/microcosm_flask/tests/test_audit.py
+++ b/microcosm_flask/tests/test_audit.py
@@ -85,6 +85,7 @@ class TestRequestInfo:
                     operation="test_func",
                     method="GET",
                     func="test_func",
+                    span_name="<Request 'http://localhost/' [GET]>"
                 ))),
             )
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "Flask-Cors>=3.0.7",
         "Flask-UUID>=0.2",
         "marshmallow>=2.18.1",
-        "microcosm>=2.9.0",
+        "microcosm>=2.10.0",
         "microcosm-logging>=1.5.0",
         "openapi>=1.1.0",
         "python-dateutil>=2.7.3",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "Flask-Cors>=3.0.7",
         "Flask-UUID>=0.2",
         "marshmallow>=2.18.1",
-        "microcosm>=2.6.0",
+        "microcosm>=2.9.0",
         "microcosm-logging>=1.5.0",
         "openapi>=1.1.0",
         "python-dateutil>=2.7.3",


### PR DESCRIPTION
There only `jaeger` specific change is adding the `jaeger` header to the `microcosm-flask` whitelist of headers. Today the white list is a single header, so there is a generalization to support a list of prefixes.