### PR TITLE
Add memory profiling support.

### DIFF
--- a/microcosm_flask/memory.py
+++ b/microcosm_flask/memory.py
@@ -1,0 +1,41 @@
+from logging import Logger
+from tracemalloc import start, take_snapshot
+
+from microcosm.api import binding, defaults, typed
+from microcosm.config.types import boolean
+
+
+@binding("memory_profiler")
+@defaults(
+    enabled=typed(boolean, False),
+    report_size_lines=typed(int, 10),
+)
+class MemoryProfiler:
+    logger: Logger
+
+    def __init__(self, graph):
+        self.enabled = graph.config.memory_profiler.enabled
+        self.report_size_lines = graph.config.memory_profiler.report_size_lines
+        self.logger = graph.logger
+
+        if not self.enabled:
+            self.logger.info("Skipping initialization because memory profiling is not enabled!")
+            return
+
+        start()
+        self.origin_snapshot = take_snapshot()
+
+    def take_snapshot(self, func):
+        def wrapped(*args, **kwargs):
+            result = func(*args, **kwargs)
+            if not self.enabled:
+                self.logger.debug("Memory profiling is disabled. Please enable to get snapshots.")
+                return result
+
+            latest_snapshot = take_snapshot()
+            difference = latest_snapshot.compare_to(self.origin_snapshot, "lineno")
+            top_ten = difference[:self.report_size_lines]
+            worst_offenders = "\n".join([str(memory_item) for memory_item in top_ten])
+            self.logger.info(f"Memory snapshot: \n {worst_offenders}")
+            return result
+        return wrapped

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -71,6 +71,9 @@ def configure_route_decorator(graph):
             if graph.route_metrics.enabled:
                 func = graph.route_metrics(endpoint)(func)
 
+            if graph.memory_profiler.enabled:
+                func = graph.memory_profiler.take_snapshot(func)
+
             # keep audit decoration last (before registering the route) so that
             # errors raised by other decorators are captured in the audit trail
             if enable_audit:

--- a/microcosm_flask/routing.py
+++ b/microcosm_flask/routing.py
@@ -72,7 +72,7 @@ def configure_route_decorator(graph):
                 func = graph.route_metrics(endpoint)(func)
 
             if graph.memory_profiler.enabled:
-                func = graph.memory_profiler.take_snapshot(func)
+                func = graph.memory_profiler.snapshot_at_intervals(func)
 
             # keep audit decoration last (before registering the route) so that
             # errors raised by other decorators are captured in the audit trail

--- a/microcosm_flask/tests/test_memory.py
+++ b/microcosm_flask/tests/test_memory.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from hamcrest import assert_that, equal_to, is_
+from microcosm.api import create_object_graph, load_from_dict
+
+
+def noop():
+    pass
+
+
+class TestMemorySampling:
+    """
+    Test capturing of memory info on API requests.
+
+    """
+    def setup(self):
+        self.loader = load_from_dict(
+            memory_profiler=dict(
+                enabled="true",
+            ),
+        )
+        self.graph = create_object_graph("example", testing=True, debug=True, loader=self.loader)
+        self.graph.use(
+            "flask",
+            "memory_profiler",
+        )
+
+        self.now = datetime.now()
+        self.last_sampling_time = self.now - timedelta(minutes=5)
+        self.graph.memory_profiler.last_sampling_time = self.last_sampling_time
+        print(self.graph.memory_profiler.last_sampling_time_delta)
+
+    def test_should_take_snapshot(self):
+        with patch.object(self.graph.memory_profiler, "get_now") as get_now:
+            new_now = self.now + timedelta(minutes=15)
+            get_now.return_value = new_now
+
+            assert_that(self.graph.memory_profiler.last_sampling_time, is_(equal_to(self.last_sampling_time)))
+
+            decorated = self.graph.memory_profiler.snapshot_at_intervals(noop)
+            decorated()
+
+            assert_that(self.graph.memory_profiler.last_sampling_time, is_(equal_to(new_now)))
+
+    def test_should_not_take_snapshot(self):
+        with patch.object(self.graph.memory_profiler, "get_now") as get_now:
+            new_now = self.now + timedelta(minutes=1)
+            get_now.return_value = new_now
+
+            assert_that(self.graph.memory_profiler.last_sampling_time, is_(equal_to(self.last_sampling_time)))
+
+            decorated = self.graph.memory_profiler.snapshot_at_intervals(noop)
+            decorated()
+
+            assert_that(self.graph.memory_profiler.last_sampling_time, is_(equal_to(self.last_sampling_time)))

--- a/microcosm_flask/tests/test_memory.py
+++ b/microcosm_flask/tests/test_memory.py
@@ -29,7 +29,6 @@ class TestMemorySampling:
         self.now = datetime.now()
         self.last_sampling_time = self.now - timedelta(minutes=5)
         self.graph.memory_profiler.last_sampling_time = self.last_sampling_time
-        print(self.graph.memory_profiler.last_sampling_time_delta)
 
     def test_should_take_snapshot(self):
         with patch.object(self.graph.memory_profiler, "get_now") as get_now:

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
             "route_metrics = microcosm_flask.metrics:RouteMetrics",
             "swagger_convention = microcosm_flask.conventions.swagger:configure_swagger",
             "uuid = microcosm_flask.converters:configure_uuid",
+            "memory_profiler = microcosm_flask.memory:MemoryProfiler",
         ],
     },
     tests_require=[


### PR DESCRIPTION
Why? We have excellent CPU profiling support, but no memory support.
Recently we enocuntered a memory leak integrating another third party
library and found ourselves blind to debugging the leak in our
environment.

This tooling is primitive but should be sufficient for identifying leaks
in the application. This approach is copied from:

https://superuser.blog/detect-memory-leak-python/

which uses a built-in python memory tracking library: `tracemalloc`.

I do have images of the logs this produces, but they use our internal/private services as an example so I don't want to post them here. If you work for Globality, you can see screenshots in #resilience-team.