### PR TITLE
Make span names better for tracing.

### DIFF
--- a/microcosm_flask/context.py
+++ b/microcosm_flask/context.py
@@ -18,7 +18,8 @@ def context_wrapper(include_header_prefixes):
                 for prefix in include_header_prefixes
             ])
         }
-        context[SPAN_NAME] = str(request)
+        span_name = f"{request.method} {request.path}"
+        context[SPAN_NAME] = span_name
         return context
     return retrieve_context
 

--- a/microcosm_flask/tests/test_audit.py
+++ b/microcosm_flask/tests/test_audit.py
@@ -85,7 +85,7 @@ class TestRequestInfo:
                     operation="test_func",
                     method="GET",
                     func="test_func",
-                    span_name="<Request 'http://localhost/' [GET]>"
+                    span_name="GET /"
                 ))),
             )
 


### PR DESCRIPTION
Why? We were using this and found that the span names that we were
getting we including a lot of information we didn't want, e.g. query
params, etc and in some cases could be very long. This had consequences
for memory usage due to how `jaeger` tries to save information for
inter-process communication.