### PR TITLE
update test for new microcosm classifier behavior

### DIFF
--- a/microcosm_flask/tests/test_metrics.py
+++ b/microcosm_flask/tests/test_metrics.py
@@ -57,13 +57,15 @@ class TestRouteMetrics:
             tags=[
                 "endpoint:foo.search.v1",
                 "backend_type:microcosm_flask",
+                "classifier:200",
             ],
         )
         self.graph.metrics.increment.assert_called_with(
-            "route.200.count",
+            "route.call.count",
             tags=[
                 "endpoint:foo.search.v1",
                 "backend_type:microcosm_flask",
+                "classifier:200",
             ],
         )
 
@@ -85,13 +87,15 @@ class TestRouteMetrics:
             tags=[
                 "endpoint:foo.search.v1",
                 "backend_type:microcosm_flask",
+                "classifier:204",
             ],
         )
         self.graph.metrics.increment.assert_called_with(
-            "route.204.count",
+            "route.call.count",
             tags=[
                 "endpoint:foo.search.v1",
                 "backend_type:microcosm_flask",
+                "classifier:204",
             ],
         )
 
@@ -113,12 +117,14 @@ class TestRouteMetrics:
             tags=[
                 "endpoint:foo.search.v1",
                 "backend_type:microcosm_flask",
+                "classifier:404",
             ]
         )
         self.graph.metrics.increment.assert_called_with(
-            "route.404.count",
+            "route.call.count",
             tags=[
                 "endpoint:foo.search.v1",
                 "backend_type:microcosm_flask",
+                "classifier:404",
             ],
         )

--- a/microcosm_flask/tests/test_metrics.py
+++ b/microcosm_flask/tests/test_metrics.py
@@ -42,6 +42,7 @@ class TestRouteMetrics:
     def test_success_metrics(self):
         """
         A standard 200 response has both timing and counting metrics.
+        Classifier tag comes from StatusCodeClassifier
 
         """
         @self.graph.route(self.ns.collection_path, Operation.Search, self.ns)
@@ -72,6 +73,7 @@ class TestRouteMetrics:
     def test_different_status_code_metrics(self):
         """
         A different status code response has both timing and counting metrics.
+        Classifier tag comes from StatusCodeClassifier
 
         """
         @self.graph.route(self.ns.collection_path, Operation.Search, self.ns)
@@ -102,6 +104,7 @@ class TestRouteMetrics:
     def test_exception_metrics(self):
         """
         An exception response has both timing and counting metrics.
+        Classifier tag comes from StatusCodeClassifier
 
         """
         @self.graph.route(self.ns.collection_path, Operation.Search, self.ns)


### PR DESCRIPTION
test will only pass against version of microcosm-metrics sitting in pr - https://github.com/globality-corp/microcosm-metrics/pull/15
ref https://globality.atlassian.net/browse/DEVOPS-347