### PR TITLE
GLOB-35427 Upgrade to marshmallow 3.0

### DIFF
--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -288,8 +288,7 @@ class CRUDConvention(Convention):
         @wraps(definition.func)
         def update(**path_data):
             headers = dict()
-            # NB: using partial here means that marshmallow will not validate required fields
-            request_data = load_request_data(definition.request_schema, partial=True)
+            request_data = load_request_data(definition.request_schema)
             response_data = require_response_data(definition.func(**merge_data(path_data, request_data)))
             definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
@@ -320,9 +319,7 @@ class CRUDConvention(Convention):
         @wraps(definition.func)
         def create_collection(**path_data):
             request_data = load_request_data(definition.request_schema)
-            # NB: if we don't filter the request body through an explicit page schema,
-            # we will leak other request arguments into the pagination query strings
-            page = self.page_cls.from_query_string(self.page_schema(), request_data)
+            page = self.page_cls.from_query_string(self.page_schema(), {})
 
             result = definition.func(**merge_data(
                 path_data,

--- a/microcosm_flask/conventions/encoding.py
+++ b/microcosm_flask/conventions/encoding.py
@@ -97,7 +97,13 @@ def load_query_string_data(request_schema, query_string_data=None):
     if query_string_data is None:
         query_string_data = request.args
 
-    return request_schema.load(query_string_data)
+    try:
+        return request_schema.load(query_string_data)
+    except ValidationError as error:
+        raise with_context(
+            UnprocessableEntity("Validation error"),
+            error.messages,
+        )
 
 
 def remove_null_values(data):

--- a/microcosm_flask/conventions/encoding.py
+++ b/microcosm_flask/conventions/encoding.py
@@ -4,6 +4,7 @@ Support for encoding and decoding request/response content.
 """
 from flask import request
 from inflection import camelize
+from marshmallow.exceptions import ValidationError
 from werkzeug.exceptions import NotFound, UnprocessableEntity
 
 from microcosm_flask.enums import ResponseFormats
@@ -55,7 +56,7 @@ def encode_headers(resource):
     return {}
 
 
-def load_request_data(request_schema, partial=False):
+def load_request_data(request_schema):
     """
     Load request data as JSON using the given schema.
 
@@ -68,20 +69,22 @@ def load_request_data(request_schema, partial=False):
     try:
         json_data = request.get_json(force=True) or {}
     except Exception:
-        # if `simplpejson` is installed, simplejson.scanner.JSONDecodeError will be raised
+        # if `simplejson` is installed, simplejson.scanner.JSONDecodeError will be raised
         # on malformed JSON, where as built-in `json` returns None
         json_data = {}
-    request_data = request_schema.load(json_data, partial=partial)
-    if request_data.errors:
-        # pass the validation errors back in the context
+    try:
+        return request_schema.load(json_data)
+    except ValidationError as error:
         raise with_context(
-            UnprocessableEntity("Validation error"), [{
-                "message": "Could not validate field: {}".format(field),
-                "field": field,
-                "reasons": reasons
-            } for field, reasons in request_data.errors.items()],
+            UnprocessableEntity("Validation error"),
+            [
+                {
+                    "message": "Could not validate field: {}".format(field),
+                    "field": field,
+                    "reasons": reasons,
+                } for field, reasons in error.messages.items()
+            ],
         )
-    return request_data.data
 
 
 def load_query_string_data(request_schema, query_string_data=None):
@@ -94,11 +97,7 @@ def load_query_string_data(request_schema, query_string_data=None):
     if query_string_data is None:
         query_string_data = request.args
 
-    request_data = request_schema.load(query_string_data)
-    if request_data.errors:
-        # pass the validation errors back in the context
-        raise with_context(UnprocessableEntity("Validation error"), dict(errors=request_data.errors))
-    return request_data.data
+    return request_schema.load(query_string_data)
 
 
 def remove_null_values(data):
@@ -128,7 +127,7 @@ def dump_response_data(response_schema,
 
     """
     if response_schema:
-        response_data = response_schema.dump(response_data).data
+        response_data = response_schema.dump(response_data)
 
     return make_response(response_data, response_schema, response_format, status_code, headers)
 

--- a/microcosm_flask/fields/enum_field.py
+++ b/microcosm_flask/fields/enum_field.py
@@ -27,7 +27,7 @@ class EnumField(Field):
         self.by_value = by_value
         super(EnumField, self).__init__(*args, **kwargs)
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         if value is None:
             return value
         elif isinstance(value, str) and not isinstance(value, Enum):
@@ -37,7 +37,7 @@ class EnumField(Field):
         else:
             return value.name
 
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, data, **kwargs):
         if value is None:
             return value
         elif self.by_value:

--- a/microcosm_flask/fields/language_field.py
+++ b/microcosm_flask/fields/language_field.py
@@ -21,9 +21,9 @@ class LanguageField(String):
             self.fail("invalid_language")
         return value
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         validated = str(self._validated(value)) if value is not None else None
         return super(LanguageField, self)._serialize(validated, attr, obj)
 
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, data, **kwargs):
         return self._validated(value)

--- a/microcosm_flask/fields/query_string_list.py
+++ b/microcosm_flask/fields/query_string_list.py
@@ -11,7 +11,7 @@ class PrintableList(list):
 
 
 class QueryStringList(List):
-    def _deserialize(self, value, attr, obj):
+    def _deserialize(self, value, attr, obj, **kwargs):
         """
         _deserialize handles multiple formats of query string parameter lists
         including:

--- a/microcosm_flask/fields/timestamp_field.py
+++ b/microcosm_flask/fields/timestamp_field.py
@@ -21,7 +21,7 @@ class TimestampField(Field):
         self.use_isoformat = use_isoformat
         super(TimestampField, self).__init__(*args, **kwargs)
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         """
         Serialize value as a timestamp, either as a Unix timestamp (in float second) or a UTC isoformat string.
 
@@ -34,7 +34,7 @@ class TimestampField(Field):
         else:
             return value
 
-    def _deserialize(self, value, attr, obj):
+    def _deserialize(self, value, attr, obj, **kwargs):
         """
         Deserialize value as a Unix timestamp (in float seconds).
 

--- a/microcosm_flask/fields/uri_field.py
+++ b/microcosm_flask/fields/uri_field.py
@@ -74,12 +74,12 @@ class URIField(Field):
     Marshmallow field for a normalized URI.
 
     """
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         if value is None:
             return None
         return self.normalize(value)
 
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, data, **kwargs):
         if value is None:
             return None
         return self.normalize(value)

--- a/microcosm_flask/swagger/parameters/list.py
+++ b/microcosm_flask/swagger/parameters/list.py
@@ -18,7 +18,7 @@ class ListParameterBuilder(ParameterBuilder):
         Parse the child item type for list fields, if any.
 
         """
-        return self.build_parameter(field.container)
+        return self.build_parameter(field.inner)
 
     def parse_type(self, field: Field) -> str:
         return "array"

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -62,7 +62,8 @@ class Schemas:
         """
         for name in sorted(schema.fields.keys()):
             field = schema.fields[name]
-            yield field.dump_to or name, field
+            # XXX: dump_to was removed; it wasn't being used anywhere? double-check
+            yield name, field
 
     def iter_schemas(self, schema: Schema) -> Iterable[Tuple[str, Any]]:
         """
@@ -81,9 +82,9 @@ class Schemas:
                 yield self.to_tuple(field.schema)
                 yield from self.iter_schemas(field.schema)
 
-            if isinstance(field, List) and isinstance(field.container, Nested):
-                yield self.to_tuple(field.container.schema)
-                yield from self.iter_schemas(field.container.schema)
+            if isinstance(field, List) and isinstance(field.inner, Nested):
+                yield self.to_tuple(field.inner.schema)
+                yield from self.iter_schemas(field.inner.schema)
 
     def to_tuple(self, schema: Schema) -> Tuple[str, Any]:
         return type_name(name_for(schema)), self.build(schema)

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -62,7 +62,6 @@ class Schemas:
         """
         for name in sorted(schema.fields.keys()):
             field = schema.fields[name]
-            # XXX: dump_to was removed; it wasn't being used anywhere? double-check
             yield name, field
 
     def iter_schemas(self, schema: Schema) -> Iterable[Tuple[str, Any]]:

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -123,11 +123,13 @@ def address_delete(address_id, address_clock):
 def address_search(offset, limit, list_param=None, enum_param=None):
     if list_param is None or enum_param is None:
         return [ADDRESS_1], 1
-    return Address(
-        ADDRESS_ID_1,
-        PERSON_ID_1,
-        ",".join(list_param) + str(len(list_param)) + enum_param.value
-    ), 1
+    return [
+        Address(
+            ADDRESS_ID_1,
+            PERSON_ID_1,
+            ",".join(list_param) + str(len(list_param)) + enum_param.value
+        ),
+    ], 1
 
 
 def person_create(**kwargs):

--- a/microcosm_flask/tests/conventions/test_create_collection.py
+++ b/microcosm_flask/tests/conventions/test_create_collection.py
@@ -1,5 +1,3 @@
-from json import dumps, loads
-
 from hamcrest import (
     all_of,
     assert_that,
@@ -22,7 +20,7 @@ from microcosm_flask.swagger.definitions import build_path
 
 
 def create_collection(text, offset, limit):
-    return dict(text=text), 1
+    return [dict(text=text)], 1
 
 
 class FooRequestSchema(Schema):
@@ -69,7 +67,7 @@ class TestCreateCollection:
     def test_swagger(self):
         response = self.client.get("/api/swagger")
         assert_that(response.status_code, is_(equal_to(200)))
-        data = loads(response.data)["paths"]["/foo"]["post"]
+        data = response.json["paths"]["/foo"]["post"]
 
         assert_that(
             data["parameters"],
@@ -109,11 +107,11 @@ class TestCreateCollection:
         text = "Some text..."
         response = self.client.post(
             "/api/foo",
-            data=dumps({"text": text}),
+            json={"text": text},
         )
 
         assert_that(response.status_code, is_(equal_to(200)))
-        assert_that(loads(response.data), is_(equal_to({
+        assert_that(response.json, is_(equal_to({
             "count": 1,
             "offset": 0,
             "limit": 20,

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -32,6 +32,7 @@ from microcosm_flask.tests.conventions.fixtures import (
     PersonBatchSchema,
     PersonLookupSchema,
     PersonSchema,
+    UpdatePersonSchema,
     address_delete,
     address_retrieve,
     address_search,
@@ -69,7 +70,7 @@ PERSON_MAPPINGS = {
     Operation.Replace: (person_replace, NewPersonSchema(), PersonSchema()),
     Operation.Retrieve: (person_retrieve, PersonLookupSchema(), PersonSchema()),
     Operation.Search: (person_search, OffsetLimitPageSchema(), PersonSchema()),
-    Operation.Update: (person_update, NewPersonSchema(), PersonSchema()),
+    Operation.Update: (person_update, UpdatePersonSchema(), PersonSchema()),
 }
 
 

--- a/microcosm_flask/tests/fields/test_enum_field.py
+++ b/microcosm_flask/tests/fields/test_enum_field.py
@@ -47,10 +47,10 @@ def test_load_enums():
         "int_value": TestIntEnum.Bar.value,
     })
 
-    assert_that(result.data["name"], is_(equal_to(TestEnum.Foo)))
-    assert_that(result.data["value"], is_(equal_to(TestEnum.Bar)))
-    assert_that(result.data["int_name"], is_(equal_to(TestIntEnum.Foo)))
-    assert_that(result.data["int_value"], is_(equal_to(TestIntEnum.Bar)))
+    assert_that(result["name"], is_(equal_to(TestEnum.Foo)))
+    assert_that(result["value"], is_(equal_to(TestEnum.Bar)))
+    assert_that(result["int_name"], is_(equal_to(TestIntEnum.Foo)))
+    assert_that(result["int_value"], is_(equal_to(TestIntEnum.Bar)))
 
 
 def test_dump_enums():
@@ -66,10 +66,10 @@ def test_dump_enums():
         "int_value": TestIntEnum.Bar,
     })
 
-    assert_that(result.data["name"], is_(equal_to(TestEnum.Foo.name)))
-    assert_that(result.data["value"], is_(equal_to(TestEnum.Bar.value)))
-    assert_that(result.data["int_name"], is_(equal_to(TestIntEnum.Foo.name)))
-    assert_that(result.data["int_value"], is_(equal_to(TestIntEnum.Bar.value)))
+    assert_that(result["name"], is_(equal_to(TestEnum.Foo.name)))
+    assert_that(result["value"], is_(equal_to(TestEnum.Bar.value)))
+    assert_that(result["int_name"], is_(equal_to(TestIntEnum.Foo.name)))
+    assert_that(result["int_value"], is_(equal_to(TestIntEnum.Bar.value)))
 
 
 def test_load_int_enum_as_string():
@@ -82,7 +82,7 @@ def test_load_int_enum_as_string():
         "int_value": str(TestIntEnum.Bar.value),
     })
 
-    assert_that(result.data["int_value"], is_(equal_to(TestIntEnum.Bar)))
+    assert_that(result["int_value"], is_(equal_to(TestIntEnum.Bar)))
 
 
 def test_dump_value_from_string():
@@ -92,7 +92,7 @@ def test_dump_value_from_string():
         "value": "bar",
     })
 
-    assert_that(result.data, is_(has_entries(
+    assert_that(result, is_(has_entries(
         name="foo",
         value="bar",
     )))

--- a/microcosm_flask/tests/fields/test_language_field.py
+++ b/microcosm_flask/tests/fields/test_language_field.py
@@ -26,33 +26,33 @@ VALID_LANGUAGES = [
 
 
 def test_dump():
-    schema = LanguageSchema(strict=True)
+    schema = LanguageSchema()
 
     for case in VALID_LANGUAGES:
         result = schema.dump(dict(
             language=case,
         ))
         assert_that(
-            result.data["language"],
+            result["language"],
             is_(equal_to(case)),
         )
 
 
 def test_load():
-    schema = LanguageSchema(strict=True)
+    schema = LanguageSchema()
 
     for case in VALID_LANGUAGES:
         result = schema.load(dict(
             language=case,
         ))
         assert_that(
-            result.data["language"],
+            result["language"],
             is_(equal_to(case)),
         )
 
 
 def test_dump_invalid():
-    schema = LanguageSchema(strict=True)
+    schema = LanguageSchema()
     assert_that(
         calling(schema.dump).with_args(dict(
             language="english",
@@ -62,7 +62,7 @@ def test_dump_invalid():
 
 
 def test_load_invalid():
-    schema = LanguageSchema(strict=True)
+    schema = LanguageSchema()
     assert_that(
         calling(schema.load).with_args(dict(
             language="english",

--- a/microcosm_flask/tests/fields/test_query_string_list.py
+++ b/microcosm_flask/tests/fields/test_query_string_list.py
@@ -31,7 +31,7 @@ def test_query_list_deserialize_items():
         ImmutableMultiDict([("foo_ids", "A,B")]),
     )
 
-    assert_that(result.data["foo_ids"], is_(equal_to([TestEnum.A, TestEnum.B])))
+    assert_that(result["foo_ids"], is_(equal_to([TestEnum.A, TestEnum.B])))
 
 
 def test_query_list_load_with_comma_separated_single_keys():
@@ -43,7 +43,7 @@ def test_query_list_load_with_comma_separated_single_keys():
         ImmutableMultiDict([("foo_ids", "a,b")]),
     )
 
-    assert_that(result.data["foo_ids"], is_(equal_to(["a", "b"])))
+    assert_that(result["foo_ids"], is_(equal_to(["a", "b"])))
 
 
 def test_query_list_load_with_duplicate_keys():
@@ -55,7 +55,7 @@ def test_query_list_load_with_duplicate_keys():
         ImmutableMultiDict([("foo_ids", "a"), ("foo_ids", "b")]),
     )
 
-    assert_that(result.data["foo_ids"], is_(equal_to(["a", "b"])))
+    assert_that(result["foo_ids"], is_(equal_to(["a", "b"])))
 
 
 def test_query_list_dump():
@@ -64,4 +64,4 @@ def test_query_list_dump():
         "foo_ids": ["a"],
     })
 
-    assert_that(result.data["foo_ids"], is_(equal_to(["a"])))
+    assert_that(result["foo_ids"], is_(equal_to(["a"])))

--- a/microcosm_flask/tests/fields/test_timestamp_field.py
+++ b/microcosm_flask/tests/fields/test_timestamp_field.py
@@ -4,11 +4,13 @@ Test timestamp field.
 """
 from hamcrest import (
     assert_that,
-    contains,
+    calling,
     equal_to,
     is_,
+    raises,
 )
 from marshmallow import Schema
+from marshmallow.exceptions import ValidationError
 
 from microcosm_flask.fields import TimestampField
 
@@ -37,8 +39,8 @@ def test_load_from_unix_timestamp_float():
         "iso": TIMESTAMP,
     })
 
-    assert_that(result.data["unix"], is_(equal_to(TIMESTAMP)))
-    assert_that(result.data["iso"], is_(equal_to(TIMESTAMP)))
+    assert_that(result["unix"], is_(equal_to(TIMESTAMP)))
+    assert_that(result["iso"], is_(equal_to(TIMESTAMP)))
 
 
 def test_load_from_unix_timestamp_int():
@@ -52,8 +54,8 @@ def test_load_from_unix_timestamp_int():
         "iso": int(TIMESTAMP),
     })
 
-    assert_that(result.data["unix"], is_(equal_to(int(TIMESTAMP))))
-    assert_that(result.data["iso"], is_(equal_to(int(TIMESTAMP))))
+    assert_that(result["unix"], is_(equal_to(int(TIMESTAMP))))
+    assert_that(result["iso"], is_(equal_to(int(TIMESTAMP))))
 
 
 def test_load_from_naive_isoformat():
@@ -67,8 +69,8 @@ def test_load_from_naive_isoformat():
         "iso": ISOFORMAT_NAIVE,
     })
 
-    assert_that(result.data["unix"], is_(equal_to(TIMESTAMP)))
-    assert_that(result.data["iso"], is_(equal_to(TIMESTAMP)))
+    assert_that(result["unix"], is_(equal_to(TIMESTAMP)))
+    assert_that(result["iso"], is_(equal_to(TIMESTAMP)))
 
 
 def test_load_from_naive_isoformat_extra_precision():
@@ -82,8 +84,8 @@ def test_load_from_naive_isoformat_extra_precision():
         "iso": ISOFORMAT_NAIVE_EXTRA_PRECISION,
     })
 
-    assert_that(result.data["unix"], is_(equal_to(TIMESTAMP_EXTRA_PRECISION)))
-    assert_that(result.data["iso"], is_(equal_to(TIMESTAMP_EXTRA_PRECISION)))
+    assert_that(result["unix"], is_(equal_to(TIMESTAMP_EXTRA_PRECISION)))
+    assert_that(result["iso"], is_(equal_to(TIMESTAMP_EXTRA_PRECISION)))
 
 
 def test_load_from_utc_isoformat():
@@ -97,8 +99,8 @@ def test_load_from_utc_isoformat():
         "iso": ISOFORMAT_UTC,
     })
 
-    assert_that(result.data["unix"], is_(equal_to(TIMESTAMP)))
-    assert_that(result.data["iso"], is_(equal_to(TIMESTAMP)))
+    assert_that(result["unix"], is_(equal_to(TIMESTAMP)))
+    assert_that(result["iso"], is_(equal_to(TIMESTAMP)))
 
 
 def test_load_from_non_utc_isoformat():
@@ -107,13 +109,17 @@ def test_load_from_non_utc_isoformat():
 
     """
     schema = TimestampSchema()
-    result = schema.load({
-        "unix": ISOFORMAT_NON_UTC,
-        "iso": ISOFORMAT_NON_UTC,
-    })
 
-    assert_that(result.errors["unix"], contains("Timestamps must be defined in UTC"))
-    assert_that(result.errors["iso"], contains("Timestamps must be defined in UTC"))
+    assert_that(
+        calling(schema.load).with_args(
+            dict(
+                foo="example",
+                unix=ISOFORMAT_NON_UTC,
+                iso=ISOFORMAT_NON_UTC,
+            ),
+        ),
+        raises(ValidationError),
+    )
 
 
 def test_dump():
@@ -127,5 +133,5 @@ def test_dump():
         "iso": TIMESTAMP,
     })
 
-    assert_that(result.data["unix"], is_(equal_to(TIMESTAMP)))
-    assert_that(result.data["iso"], is_(equal_to(ISOFORMAT_NAIVE)))
+    assert_that(result["unix"], is_(equal_to(TIMESTAMP)))
+    assert_that(result["iso"], is_(equal_to(ISOFORMAT_NAIVE)))

--- a/microcosm_flask/tests/fields/test_uri_field.py
+++ b/microcosm_flask/tests/fields/test_uri_field.py
@@ -41,15 +41,15 @@ def test_normalize_uri():
 
 
 def test_uri_dump():
-    schema = URISchema(strict=True)
+    schema = URISchema()
     result = schema.dump(dict(
         foo="http://example.com",
     ))
-    assert_that(result.data["foo"], is_(equal_to("http://example.com")))
+    assert_that(result["foo"], is_(equal_to("http://example.com")))
 
 
 def test_uri_dump_malformed():
-    schema = URISchema(strict=True)
+    schema = URISchema()
     assert_that(
         calling(schema.dump).with_args(
             dict(
@@ -61,15 +61,15 @@ def test_uri_dump_malformed():
 
 
 def test_uri_load():
-    schema = URISchema(strict=True)
+    schema = URISchema()
     result = schema.load(dict(
         foo="http://example.com",
     ))
-    assert_that(result.data["foo"], is_(equal_to("http://example.com")))
+    assert_that(result["foo"], is_(equal_to("http://example.com")))
 
 
 def test_uri_load_malformed():
-    schema = URISchema(strict=True)
+    schema = URISchema()
     assert_that(
         calling(schema.load).with_args(
             dict(

--- a/microcosm_flask/tests/test_paging.py
+++ b/microcosm_flask/tests/test_paging.py
@@ -4,12 +4,14 @@ Paging tests.
 """
 from hamcrest import (
     assert_that,
+    calling,
     equal_to,
     has_entry,
     is_,
-    is_not,
+    raises,
 )
 from marshmallow import Schema
+from marshmallow.exceptions import ValidationError
 from microcosm.api import create_object_graph
 
 from microcosm_flask.namespaces import Namespace
@@ -42,12 +44,19 @@ def test_offset_limit_page_to_from_dict():
 
 def test_offset_limit_page_from_query_string():
     graph = create_object_graph(name="example", testing=True)
-    with graph.flask.test_request_context(query_string="offset=1&foo=bar"):
+    with graph.flask.test_request_context(query_string="offset=1"):
         page = OffsetLimitPage.from_query_string(OffsetLimitPageSchema())
         assert_that(page.offset, is_(equal_to(1)))
         assert_that(page.limit, is_(equal_to(20)))
-        # schema filters out extra arguments
-        assert_that(page.to_dict(), is_not(has_entry("foo", "bar")))
+
+
+def test_offset_limit_page_rejects_unknown_queries():
+    graph = create_object_graph(name="example", testing=True)
+    with graph.flask.test_request_context(query_string="offset=1&foo=bar"):
+        assert_that(
+            calling(OffsetLimitPage.from_query_string).with_args(OffsetLimitPageSchema()),
+            raises(ValidationError),
+        )
 
 
 def test_offset_limit_page_to_paginated_list():
@@ -69,7 +78,7 @@ def test_offset_limit_page_to_paginated_list():
         paginated_list, headers = page.to_paginated_list(result, _ns=ns, _operation=Operation.Search)
 
         schema_cls = page.make_paginated_list_schema_class(ns, Schema())
-        data = schema_cls().dump(paginated_list).data
+        data = schema_cls().dump(paginated_list)
         assert_that(
             data,
             is_(equal_to(dict(

--- a/microcosm_flask/tests/test_paging.py
+++ b/microcosm_flask/tests/test_paging.py
@@ -11,8 +11,8 @@ from hamcrest import (
     raises,
 )
 from marshmallow import Schema
-from marshmallow.exceptions import ValidationError
 from microcosm.api import create_object_graph
+from werkzeug.exceptions import UnprocessableEntity
 
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
@@ -55,7 +55,7 @@ def test_offset_limit_page_rejects_unknown_queries():
     with graph.flask.test_request_context(query_string="offset=1&foo=bar"):
         assert_that(
             calling(OffsetLimitPage.from_query_string).with_args(OffsetLimitPageSchema()),
-            raises(ValidationError),
+            raises(UnprocessableEntity),
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,7 @@ setup(
         "Flask-BasicAuth>=0.2.0",
         "Flask-Cors>=3.0.7",
         "Flask-UUID>=0.2",
-        # Temporary upper cap; 3.0 has several backwards-incompatible changes
-        # that we still need to account for
-        # Internal tracking ticket: https://globality.atlassian.net/browse/GLOB-35427
-        "marshmallow>=2.18.1,<3.0.0",
+        "marshmallow>=3.0.0",
         "microcosm>=2.12.0",
         "microcosm-logging>=1.5.0",
         "openapi>=1.1.0",


### PR DESCRIPTION
Updates usages of marshmallow to account for several changes in marshmallow 3.0

Note that this effectively moves this repo to be python 3.5+ compatible-only, given that those are the versions that marshmallow itself supports.

Note: I haven't run this in another live service yet; I wouldn't be surprised if there are other subtle issues that may have cropped up here. I hadn't yet pored through every line in the [upgrade doc](https://marshmallow.readthedocs.io/en/stable/upgrading.html). I'll do some testing and read through that first before merging.