### PR TITLE
Handle empty string for QueryStringList

### DIFF
--- a/microcosm_flask/fields/query_string_list.py
+++ b/microcosm_flask/fields/query_string_list.py
@@ -18,17 +18,19 @@ class QueryStringList(List):
 
         /foo?bars=1,2
         /foo?bars[]=1&bars[]2
+        /foo?bars=&...
 
         and returns a list of values
 
         """
         if value is None:
             return None
+        if value == "":
+            return []
 
         try:
             attribute_elements = [attr_element.split(",") for attr_element in obj.getlist(attr)]
             attribute_params = [param for attr_param in attribute_elements for param in attr_param]
-
-            return PrintableList(super(QueryStringList, self)._deserialize(attribute_params, attr, obj))
+            return PrintableList(super()._deserialize(attribute_params, attr, obj))
         except ValueError:
             raise ValidationError("Invalid query string list argument")

--- a/microcosm_flask/tests/fields/test_query_string_list.py
+++ b/microcosm_flask/tests/fields/test_query_string_list.py
@@ -16,6 +16,10 @@ class QueryStringListSchema(Schema):
     foo_ids = QueryStringList(String())
 
 
+class NullableQueryStringListSchema(Schema):
+    foo_ids = QueryStringList(String(), allow_none=True)
+
+
 class TestEnum(Enum):
     A = "A"
     B = "B"
@@ -36,7 +40,7 @@ def test_query_list_deserialize_items():
 
 def test_query_list_load_with_comma_separated_single_keys():
     """
-    tests for support of /foo?foo_ids=1,2
+    tests for support of /foo?foo_ids=a,b
     """
     schema = QueryStringListSchema()
     result = schema.load(
@@ -48,7 +52,7 @@ def test_query_list_load_with_comma_separated_single_keys():
 
 def test_query_list_load_with_duplicate_keys():
     """
-    tests for support of /foo?foo_ids[]=1&foo_ids[]=2
+    tests for support of /foo?foo_ids[]=a&foo_ids[]=b
     """
     schema = QueryStringListSchema()
     result = schema.load(
@@ -56,6 +60,30 @@ def test_query_list_load_with_duplicate_keys():
     )
 
     assert_that(result["foo_ids"], is_(equal_to(["a", "b"])))
+
+
+def test_empty_query_list_load():
+    """
+    tests for support of /foo?foo_ids=&bar=...
+    """
+    schema = QueryStringListSchema()
+    result = schema.load(
+        ImmutableMultiDict([("foo_ids", "")]),
+    )
+
+    assert_that(result["foo_ids"], is_(equal_to([])))
+
+
+def test_none_query_list_load():
+    """
+    tests for support of /foo?foo_ids=&bar=...
+    """
+    schema = NullableQueryStringListSchema()
+    result = schema.load(
+        ImmutableMultiDict([("foo_ids", None)]),
+    )
+
+    assert_that(result["foo_ids"], is_(equal_to(None)))
 
 
 def test_query_list_dump():

--- a/microcosm_flask/tests/test_basic_auth.py
+++ b/microcosm_flask/tests/test_basic_auth.py
@@ -4,7 +4,13 @@ Basic Auth tests.
 """
 from json import loads
 
-from hamcrest import assert_that, equal_to, is_
+from hamcrest import (
+    assert_that,
+    equal_to,
+    has_entries,
+    is_,
+    starts_with,
+)
 from microcosm.api import create_object_graph
 
 from microcosm_flask.basic_auth import encode_basic_auth
@@ -32,14 +38,12 @@ def test_basic_auth():
     response = client.get("/unauthorized")
     assert_that(response.status_code, is_(equal_to(401)))
     data = loads(response.get_data().decode("utf-8"))
-    assert_that(data, is_(equal_to({
-        "code": 401,
-        "message": "The server could not verify that you are authorized to access the URL requested. "
-                   "You either supplied the wrong credentials (e.g. a bad password), or your browser "
-                   "doesn't understand how to supply the credentials required.",
-        "retryable": False,
-        "context": {"errors": []},
-    })))
+    assert_that(data, has_entries(dict(
+        code=401,
+        message=starts_with("The server could not verify that you are authorized to access the URL requested"),
+        retryable=False,
+        context={"errors": []},
+    )))
     assert_that(response.headers["WWW-Authenticate"], is_(equal_to('Basic realm="microcosm"')))
 
 
@@ -61,14 +65,12 @@ def test_basic_auth_default_realm():
     response = client.get("/unauthorized")
     assert_that(response.status_code, is_(equal_to(401)))
     data = loads(response.get_data().decode("utf-8"))
-    assert_that(data, is_(equal_to({
-        "code": 401,
-        "message": "The server could not verify that you are authorized to access the URL requested. "
-                   "You either supplied the wrong credentials (e.g. a bad password), or your browser "
-                   "doesn't understand how to supply the credentials required.",
-        "retryable": False,
-        "context": {"errors": []},
-    })))
+    assert_that(data, has_entries(dict(
+        code=401,
+        message=starts_with("The server could not verify that you are authorized to access the URL requested"),
+        retryable=False,
+        context={"errors": []},
+    )))
     assert_that(response.headers["WWW-Authenticate"], is_(equal_to('Basic realm="example"')))
 
 

--- a/microcosm_flask/tests/test_errors.py
+++ b/microcosm_flask/tests/test_errors.py
@@ -5,8 +5,10 @@ Error handling tests.
 from hamcrest import (
     assert_that,
     equal_to,
+    has_entries,
     has_entry,
     is_,
+    starts_with,
 )
 from microcosm.api import create_object_graph
 from werkzeug.exceptions import HTTPException, InternalServerError, NotFound
@@ -65,15 +67,14 @@ def test_werkzeug_http_error():
     response = client.get("/not_found")
     assert_that(response.status_code, is_(equal_to(404)))
     data = response.json
-    assert_that(data, is_(equal_to({
-        "code": 404,
-        "context": {
+    assert_that(data, has_entries(dict(
+        code=404,
+        context={
             "errors": [],
         },
-        "message": "The requested URL was not found on the server. "
-                   "If you entered the URL manually please check your spelling and try again.",
-        "retryable": False,
-    })))
+        message=starts_with("The requested URL was not found on the server."),
+        retryable=False,
+    )))
 
 
 def test_no_route():
@@ -88,13 +89,12 @@ def test_no_route():
     response = client.get("/no_route")
     assert_that(response.status_code, is_(equal_to(404)))
     data = response.json
-    assert_that(data, is_(equal_to({
-        "code": 404,
-        "message": "The requested URL was not found on the server. "
-                   "If you entered the URL manually please check your spelling and try again.",
-        "retryable": False,
-        "context": {"errors": []},
-    })))
+    assert_that(data, has_entries(dict(
+        code=404,
+        message=starts_with("The requested URL was not found on the server."),
+        retryable=False,
+        context={"errors": []},
+    )))
 
 
 def test_werkzeug_http_error_custom_message():
@@ -114,12 +114,12 @@ def test_werkzeug_http_error_custom_message():
     response = client.get("/why_me")
     assert_that(response.status_code, is_(equal_to(500)))
     data = response.json
-    assert_that(data, is_(equal_to({
-        "code": 500,
-        "message": "Why me?",
-        "retryable": False,
-        "context": {"errors": []},
-    })))
+    assert_that(data, has_entries(dict(
+        code=500,
+        message="Why me?",
+        retryable=False,
+        context={"errors": []},
+    )))
 
 
 def test_custom_error():
@@ -139,12 +139,12 @@ def test_custom_error():
     response = client.get("/unexpected")
     assert_that(response.status_code, is_(equal_to(500)))
     data = response.json
-    assert_that(data, is_(equal_to({
-        "code": 500,
-        "message": "unexpected",
-        "retryable": False,
-        "context": {"errors": []},
-    })))
+    assert_that(data, has_entries(dict(
+        code=500,
+        message="unexpected",
+        retryable=False,
+        context={"errors": []},
+    )))
 
 
 def test_custom_error_status_code():
@@ -164,12 +164,12 @@ def test_custom_error_status_code():
     response = client.get("/malformed_syntax")
     assert_that(response.status_code, is_(equal_to(400)))
     data = response.json
-    assert_that(data, is_(equal_to({
-        "code": 400,
-        "message": "MyValidationError",
-        "retryable": False,
-        "context": {"errors": []},
-    })))
+    assert_that(data, has_entries(dict(
+        code=400,
+        message="MyValidationError",
+        retryable=False,
+        context={"errors": []},
+    )))
 
 
 def test_custom_error_retryable():
@@ -189,16 +189,16 @@ def test_custom_error_retryable():
     response = client.get("/conflict")
     assert_that(response.status_code, is_(equal_to(409)))
     data = response.json
-    assert_that(data, is_(equal_to({
-        "code": 409,
-        "message": "Conflict",
-        "retryable": True,
-        "context": {
+    assert_that(data, has_entries(dict(
+        code=409,
+        message="Conflict",
+        retryable=True,
+        context={
             "errors": [{
                 "message": "Banana!",
             }]
         },
-    })))
+    )))
 
 
 def test_error_wrap():
@@ -224,12 +224,12 @@ def test_error_wrap():
     response = client.get("/wrap")
     assert_that(response.status_code, is_(equal_to(500)))
     data = response.json
-    assert_that(data, is_(equal_to({
-        "code": 500,
-        "message": "fail",
-        "retryable": False,
-        "context": {"errors": []}
-    })))
+    assert_that(data, has_entries(dict(
+        code=500,
+        message="fail",
+        retryable=False,
+        context={"errors": []}
+    )))
 
 
 def test_non_numeric_error():
@@ -249,12 +249,12 @@ def test_non_numeric_error():
     response = client.get("/foo")
     assert_that(response.status_code, is_(equal_to(500)))
     data = response.json
-    assert_that(data, is_(equal_to({
-        "code": 500,
-        "message": "Hello",
-        "retryable": False,
-        "context": {"errors": []},
-    })))
+    assert_that(data, has_entries(dict(
+        code=500,
+        message="Hello",
+        retryable=False,
+        context={"errors": []},
+    )))
 
 
 def test_custom_headers():


### PR DESCRIPTION
- Handle the case where an empty query param is passed for a `QueryStringList` field.
- Fix test for authentication error.
- Use `has_entries` instead of `equal_to`, to get more precise messages on test failure.