### PR TITLE
Add support for enum formatting

### DIFF
--- a/microcosm_flask/errors.py
+++ b/microcosm_flask/errors.py
@@ -25,7 +25,7 @@ class ErrorSchema(Schema):
     message = fields.String(required=True, default="Unknown Error")
     code = fields.Integer(required=True, default=500)
     retryable = fields.Boolean(required=True, default=False)
-    context = fields.Nested(ErrorContextSchema, required=False)
+    context = fields.Nested(ErrorContextSchema, required=False)  # type: ignore
 
 
 def as_retryable(error):

--- a/microcosm_flask/fields/enum_field.py
+++ b/microcosm_flask/fields/enum_field.py
@@ -25,7 +25,7 @@ class EnumField(Field):
     def __init__(self, enum, by_value=False, *args, **kwargs):
         self.enum = enum
         self.by_value = by_value
-        super(EnumField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _serialize(self, value, attr, obj, **kwargs):
         if value is None:

--- a/microcosm_flask/swagger/parameters/__init__.py
+++ b/microcosm_flask/swagger/parameters/__init__.py
@@ -36,7 +36,7 @@ class Parameters:
 
         builders: List[ParameterBuilder] = [
             builder_type(
-                build_parameter=self.build,
+                build_parameter=self.build,  # type: ignore
             )
             for builder_type in builder_types
         ]

--- a/microcosm_flask/swagger/parameters/enum.py
+++ b/microcosm_flask/swagger/parameters/enum.py
@@ -28,7 +28,7 @@ class EnumParameterBuilder(ParameterBuilder):
             return "enum"
         return None
 
-    def parse_type(self, field: EnumField) -> str:
+    def parse_type(self, field: Field) -> str:
         enum_values = self.parse_enum_values(field)
 
         if all((isinstance(enum_value, str) for enum_value in enum_values)):
@@ -38,9 +38,9 @@ class EnumParameterBuilder(ParameterBuilder):
         else:
             raise Exception(f"Cannot infer enum type for field: {field.name}")
 
-    def parse_enum_values(self, field: EnumField) -> Sequence:
+    def parse_enum_values(self, field: Field) -> Sequence:
         enum = getattr(field, "enum", None)
         return [
-            choice.value if field.by_value else choice.name
+            choice.value if field.by_value else choice.name  # type: ignore
             for choice in enum
         ]

--- a/microcosm_flask/swagger/parameters/enum.py
+++ b/microcosm_flask/swagger/parameters/enum.py
@@ -1,7 +1,8 @@
-from typing import Sequence
+from typing import Optional, Sequence
 
 from marshmallow.fields import Field
 
+from microcosm_flask.fields import EnumField
 from microcosm_flask.swagger.parameters.base import ParameterBuilder
 
 
@@ -22,7 +23,9 @@ class EnumParameterBuilder(ParameterBuilder):
     def supports_field(self, field: Field) -> bool:
         return bool(getattr(field, "enum", None))
 
-    def parse_format(self, field: Field) -> None:
+    def parse_format(self, field: Field) -> Optional[str]:
+        if isinstance(field, EnumField):
+            return "enum"
         return None
 
     def parse_type(self, field: Field) -> str:

--- a/microcosm_flask/swagger/parameters/enum.py
+++ b/microcosm_flask/swagger/parameters/enum.py
@@ -28,7 +28,7 @@ class EnumParameterBuilder(ParameterBuilder):
             return "enum"
         return None
 
-    def parse_type(self, field: Field) -> str:
+    def parse_type(self, field: EnumField) -> str:
         enum_values = self.parse_enum_values(field)
 
         if all((isinstance(enum_value, str) for enum_value in enum_values)):
@@ -38,7 +38,7 @@ class EnumParameterBuilder(ParameterBuilder):
         else:
             raise Exception(f"Cannot infer enum type for field: {field.name}")
 
-    def parse_enum_values(self, field: Field) -> Sequence:
+    def parse_enum_values(self, field: EnumField) -> Sequence:
         enum = getattr(field, "enum", None)
         return [
             choice.value if field.by_value else choice.name

--- a/microcosm_flask/swagger/parameters/list.py
+++ b/microcosm_flask/swagger/parameters/list.py
@@ -13,7 +13,7 @@ class ListParameterBuilder(ParameterBuilder):
     def supports_field(self, field: Field) -> bool:
         return isinstance(field, List)
 
-    def parse_items(self, field: Field) -> Mapping[str, Any]:
+    def parse_items(self, field: List) -> Mapping[str, Any]:
         """
         Parse the child item type for list fields, if any.
 

--- a/microcosm_flask/swagger/parameters/list.py
+++ b/microcosm_flask/swagger/parameters/list.py
@@ -13,12 +13,12 @@ class ListParameterBuilder(ParameterBuilder):
     def supports_field(self, field: Field) -> bool:
         return isinstance(field, List)
 
-    def parse_items(self, field: List) -> Mapping[str, Any]:
+    def parse_items(self, field: Field) -> Mapping[str, Any]:
         """
         Parse the child item type for list fields, if any.
 
         """
-        return self.build_parameter(field.inner)
+        return self.build_parameter(field.inner)  # type: ignore
 
     def parse_type(self, field: Field) -> str:
         return "array"

--- a/microcosm_flask/swagger/parameters/nested.py
+++ b/microcosm_flask/swagger/parameters/nested.py
@@ -13,12 +13,12 @@ class NestedParameterBuilder(ParameterBuilder):
     def supports_field(self, field: Field) -> bool:
         return isinstance(field, Nested)
 
-    def parse_ref(self, field: Nested) -> str:
+    def parse_ref(self, field: Field) -> str:
         """
         Parse the reference type for nested fields, if any.
 
         """
-        ref_name = type_name(name_for(field.schema))
+        ref_name = type_name(name_for(field.schema))  # type:ignore
         return f"#/definitions/{ref_name}"
 
     def parse_type(self, field: Field) -> None:

--- a/microcosm_flask/swagger/parameters/nested.py
+++ b/microcosm_flask/swagger/parameters/nested.py
@@ -13,7 +13,7 @@ class NestedParameterBuilder(ParameterBuilder):
     def supports_field(self, field: Field) -> bool:
         return isinstance(field, Nested)
 
-    def parse_ref(self, field: Field) -> str:
+    def parse_ref(self, field: Nested) -> str:
         """
         Parse the reference type for nested fields, if any.
 

--- a/microcosm_flask/swagger/parameters/timestamp.py
+++ b/microcosm_flask/swagger/parameters/timestamp.py
@@ -12,12 +12,12 @@ class TimestampParameterBuilder(ParameterBuilder):
     def supports_field(self, field: Field) -> bool:
         return isinstance(field, TimestampField)
 
-    def parse_format(self, field: TimestampField) -> str:
-        if field.use_isoformat:
+    def parse_format(self, field: Field) -> str:
+        if isinstance(field, TimestampField) and field.use_isoformat:
             return "date-time"
         return "timestamp"
 
-    def parse_type(self, field: TimestampField) -> str:
-        if field.use_isoformat:
+    def parse_type(self, field: Field) -> str:
+        if isinstance(field, TimestampField) and field.use_isoformat:
             return "string"
         return "float"

--- a/microcosm_flask/swagger/parameters/timestamp.py
+++ b/microcosm_flask/swagger/parameters/timestamp.py
@@ -12,12 +12,12 @@ class TimestampParameterBuilder(ParameterBuilder):
     def supports_field(self, field: Field) -> bool:
         return isinstance(field, TimestampField)
 
-    def parse_format(self, field: Field) -> str:
+    def parse_format(self, field: TimestampField) -> str:
         if field.use_isoformat:
             return "date-time"
         return "timestamp"
 
-    def parse_type(self, field: Field) -> str:
+    def parse_type(self, field: TimestampField) -> str:
         if field.use_isoformat:
             return "string"
         return "float"

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -22,7 +22,7 @@ class Schemas:
     Swagger schema builder.
 
     """
-    def __init__(self, build_parameter: Callable[[Schema], Mapping[str, Any]]):
+    def __init__(self, build_parameter: Callable[[Field], Mapping[str, Any]]):
         self.build_parameter = build_parameter
 
     def build(self, schema: Schema) -> Mapping[str, Any]:

--- a/microcosm_flask/tests/swagger/parameters/test_enum.py
+++ b/microcosm_flask/tests/swagger/parameters/test_enum.py
@@ -26,6 +26,7 @@ class TestSchema(Schema):
 def test_field_enum():
     parameter = build_parameter(TestSchema().fields["choice"])
     assert_that(parameter, is_(equal_to({
+        "format": "enum",
         "type": "string",
         "enum": [
             "Profit",
@@ -36,6 +37,7 @@ def test_field_enum():
 def test_field_int_enum():
     parameter = build_parameter(TestSchema().fields["value"])
     assert_that(parameter, is_(equal_to({
+        "format": "enum",
         "type": "integer",
         "enum": [
             1,


### PR DESCRIPTION
This will serve as a signal for downstream clients to know (during
request construction/validation) how to properly format enums.

Note that there's no logic here directly; this merely adds the `format` key to the swagger definition.

Further note: `format` isn't part of the OpenAPI spec for enums specifically: https://swagger.io/docs/specification/data-models/data-types/. It will be added as part of another (internal) PR.