### PR TITLE
Introduce associated schemas

### DIFF
--- a/microcosm_flask/decorators/schemas.py
+++ b/microcosm_flask/decorators/schemas.py
@@ -1,0 +1,57 @@
+from copy import deepcopy
+
+from inflection import camelize, underscore
+from marshmallow import Schema
+
+from microcosm_flask.naming import name_for
+from microcosm_flask.swagger.naming import type_name
+
+
+def _get_fields_and_make_required(schema_cls, selected_fields):
+    associated_fields = {}
+    for field_name in selected_fields:
+        field = deepcopy(schema_cls._declared_fields[field_name])
+        field.required = True
+        associated_fields[field_name] = field
+
+    return associated_fields
+
+
+def associated_schemas_attr_name(schema_cls):
+    return f"_associated_schemas_{underscore(schema_cls.__name__)}"
+
+
+def associated_schema_name(schema_cls, name_suffix):
+    return f"{type_name(name_for(schema_cls))}{camelize(name_suffix)}Schema"
+
+
+def add_associated_schema(name_suffix, selected_fields=()):
+    """
+    Derive a schema as a subset of fields from the schema class being decorated,
+    and add that derived schema as an attribute on the decorated schema.
+    All fields from the derived schema are marked as required.
+
+    This allows us to expose the derived schema in the swagger definition.
+
+    """
+    def decorator(schema_cls):
+        associated_fields = _get_fields_and_make_required(schema_cls, selected_fields)
+
+        # Use the class name in the attribute name to avoid sharing with children classes
+        attr_name = associated_schemas_attr_name(schema_cls)
+        associated_schema = type(
+            associated_schema_name(schema_cls, name_suffix),
+            (Schema,),
+            associated_fields,
+        )
+        try:
+            getattr(schema_cls, attr_name).append(associated_schema)
+        except AttributeError:
+            setattr(
+                schema_cls,
+                attr_name,
+                [associated_schema],
+            )
+        return schema_cls
+
+    return decorator

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -13,6 +13,7 @@ from typing import (
 from marshmallow import Schema
 from marshmallow.fields import Field, List, Nested
 
+from microcosm_flask.decorators.schemas import associated_schemas_attr_name
 from microcosm_flask.naming import name_for
 from microcosm_flask.swagger.naming import type_name
 
@@ -75,6 +76,9 @@ class Schemas:
             return
 
         yield self.to_tuple(schema)
+
+        for associated_schema in getattr(schema, associated_schemas_attr_name(schema.__class__), []):
+            yield self.to_tuple(associated_schema())
 
         for name, field in self.iter_fields(schema):
             if isinstance(field, Nested):

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -83,13 +83,19 @@ class PersonCSVSchema(NewPersonSchema):
         return column_order
 
 
-@add_associated_schema(
-    "Foo",
-    [
-        "email",
-        "firstName",
-    ]
-)
+def pubsub_schema(fields):
+    """
+    Example usage of `add_associated_schema`, creating an additional decorator
+    that adds syntactic sugar and makes the intent clear
+
+    """
+    return add_associated_schema("PubsubMessage", fields)
+
+
+@pubsub_schema([
+    "email",
+    "firstName",
+])
 class PersonSchema(PersonCSVSchema):
     _links = fields.Method("get_links", dump_only=True)
 

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from marshmallow import Schema, fields
 
+from microcosm_flask.decorators.schemas import add_associated_schema
 from microcosm_flask.linking import Link, Links
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
@@ -33,6 +34,7 @@ class NewAddressSchema(Schema):
 class NewPersonSchema(Schema):
     firstName = fields.Str(attribute="first_name", required=True)
     lastName = fields.Str(attribute="last_name", required=True)
+    email = fields.Email()
 
     @property
     def csv_column_order(self):
@@ -81,6 +83,13 @@ class PersonCSVSchema(NewPersonSchema):
         return column_order
 
 
+@add_associated_schema(
+    "Foo",
+    [
+        "email",
+        "firstName",
+    ]
+)
 class PersonSchema(PersonCSVSchema):
     _links = fields.Method("get_links", dump_only=True)
 

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 from marshmallow import Schema, fields
 
-from microcosm_flask.decorators.schemas import add_associated_schema
+from microcosm_flask.decorators.schemas import SelectedField, add_associated_schema
 from microcosm_flask.linking import Link, Links
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
@@ -96,6 +96,14 @@ def pubsub_schema(fields):
     "email",
     "firstName",
 ])
+# Other example not using the shorthand
+@add_associated_schema(
+    "Foo",
+    [
+        SelectedField("email", required=True),
+        SelectedField("firstName", required=False)
+    ]
+)
 class PersonSchema(PersonCSVSchema):
     _links = fields.Method("get_links", dump_only=True)
 

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -159,10 +159,18 @@ class TestCRUD:
         })
 
     def test_reuse_search_self_link(self):
-        uri = "/api/address?list_param=a,b,c&enum_param=A"
-        response = self.client.get(uri)
+        uri = "/api/address"
+        response = self.client.get(
+            uri,
+            query_string=dict(
+                list_param="a,b,c",
+                enum_param="A",
+            ),
+        )
         response_data = response.json
-        response = self.client.get(response_data["_links"]["self"]["href"])
+        response = self.client.get(
+            response_data["_links"]["self"]["href"],
+        )
         self.assert_response(response, 200, {
             "count": 1,
             "offset": 0,
@@ -184,8 +192,11 @@ class TestCRUD:
         })
 
     def test_delete_with_params(self):
-        uri = "/api/address/{}?address_clock=123".format(ADDRESS_ID_1)
-        response = self.client.delete(uri)
+        uri = f"/api/address/{ADDRESS_ID_1}"
+        response = self.client.delete(
+            uri,
+            query_string=dict(address_clock=123),
+        )
         self.assert_response(response, 204)
 
     def test_create(self):

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -136,7 +136,7 @@ class TestCRUD:
         assert_that(response.headers["X-Total-Count"], is_(equal_to(str(1))))
 
     def test_search_with_context(self):
-        uri = "/api/address".format(PERSON_ID_1)
+        uri = "/api/address"
         response = self.client.get(uri)
         self.assert_response(response, 200, {
             "count": 1,
@@ -159,7 +159,7 @@ class TestCRUD:
         })
 
     def test_reuse_search_self_link(self):
-        uri = "/api/address?list_param=a,b,c&enum_param=A".format(PERSON_ID_1)
+        uri = "/api/address?list_param=a,b,c&enum_param=A"
         response = self.client.get(uri)
         response_data = response.json
         response = self.client.get(response_data["_links"]["self"]["href"])

--- a/microcosm_flask/tests/swagger/test_api.py
+++ b/microcosm_flask/tests/swagger/test_api.py
@@ -19,6 +19,10 @@ def test_schema_generation():
             "lastName": {
                 "type": "string",
             },
+            "email": {
+                "format": "email",
+                "type": "string",
+            },
         },
         "required": [
             "firstName",

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -177,7 +177,7 @@ def test_build_swagger():
                     },
                 },
             ),
-            PersonFoo=has_entries(
+            PersonPubsubMessage=has_entries(
                 type="object",
                 properties={
                     "email": {

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -193,6 +193,21 @@ def test_build_swagger():
                     "firstName",
                 ],
             ),
+            PersonFoo=has_entries(
+                type="object",
+                properties={
+                    "email": {
+                        "format": "email",
+                        "type": "string",
+                    },
+                    "firstName": {
+                        "type": "string",
+                    },
+                },
+                required=[
+                    "email",
+                ],
+            ),
             UpdatePerson=dict(
                 type="object",
                 properties={

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -204,6 +204,27 @@ def test_build_swagger():
                     }
                 }
             ),
+            ErrorContext=has_entries(
+                required=["errors"],
+                type="object",
+                properties={
+                    "errors": {
+                        "items": {
+                            "$ref": "#/definitions/SubError",
+                        },
+                        "type": "array",
+                    },
+                },
+            ),
+            SubError=has_entries(
+                required=["message"],
+                type="object",
+                properties={
+                    "message": {
+                        "type": "string",
+                    },
+                },
+            ),
             Error=has_entries(
                 required=[
                     "code",
@@ -226,27 +247,6 @@ def test_build_swagger():
                     },
                     "retryable": {
                         "type": "boolean",
-                    },
-                },
-            ),
-            ErrorContext=has_entries(
-                required=["errors"],
-                type="object",
-                properties={
-                    "errors": {
-                        "items": {
-                            "$ref": "#/definitions/SubError",
-                        },
-                        "type": "array",
-                    },
-                },
-            ),
-            SubError=has_entries(
-                required=["message"],
-                type="object",
-                properties={
-                    "message": {
-                        "type": "string",
                     },
                 },
             ),

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -2,7 +2,7 @@
 Test Swagger definition construction.
 
 """
-from hamcrest import assert_that, equal_to, is_
+from hamcrest import assert_that, equal_to, has_entries
 from microcosm.api import create_object_graph
 from microcosm.loaders import load_from_dict
 
@@ -44,12 +44,12 @@ def test_build_swagger():
         operations = list(iter_endpoints(graph, match_function))
         swagger_schema = build_swagger(graph, ns, operations)
 
-    assert_that(swagger_schema, is_(equal_to({
-        "info": {
+    assert_that(swagger_schema, has_entries(
+        info={
             "version": "v1",
             "title": "example",
         },
-        "paths": {
+        paths={
             "/person": {
                 "post": {
                     "tags": ["person"],
@@ -127,17 +127,21 @@ def test_build_swagger():
                 },
             },
         },
-        "produces": [
+        produces=[
             "application/json",
         ],
-        "definitions": {
-            "NewPerson": {
-                "required": [
+        definitions=has_entries(
+            NewPerson=has_entries(
+                required=[
                     "firstName",
                     "lastName",
                 ],
-                "type": "object",
-                "properties": {
+                type="object",
+                properties={
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                    },
                     "lastName": {
                         "type": "string",
                     },
@@ -145,15 +149,19 @@ def test_build_swagger():
                         "type": "string",
                     }
                 }
-            },
-            "Person": {
-                "required": [
+            ),
+            Person=has_entries(
+                required=[
                     "firstName",
                     "id",
                     "lastName",
                 ],
-                "type": "object",
-                "properties": {
+                type="object",
+                properties={
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                    },
                     "lastName": {
                         "type": "string",
                     },
@@ -168,10 +176,26 @@ def test_build_swagger():
                         "type": "string",
                     },
                 },
-            },
-            "UpdatePerson": {
-                "type": "object",
-                "properties": {
+            ),
+            PersonFoo=has_entries(
+                type="object",
+                properties={
+                    "email": {
+                        "format": "email",
+                        "type": "string",
+                    },
+                    "firstName": {
+                        "type": "string",
+                    },
+                },
+                required=[
+                    "email",
+                    "firstName",
+                ],
+            ),
+            UpdatePerson=dict(
+                type="object",
+                properties={
                     "lastName": {
                         "type": "string",
                     },
@@ -179,36 +203,15 @@ def test_build_swagger():
                         "type": "string",
                     }
                 }
-            },
-            "ErrorContext": {
-                "required": ["errors"],
-                "type": "object",
-                "properties": {
-                    "errors": {
-                        "items": {
-                            "$ref": "#/definitions/SubError",
-                        },
-                        "type": "array",
-                    },
-                },
-            },
-            "SubError": {
-                "required": ["message"],
-                "type": "object",
-                "properties": {
-                    "message": {
-                        "type": "string",
-                    },
-                },
-            },
-            "Error": {
-                "required": [
+            ),
+            Error=has_entries(
+                required=[
                     "code",
                     "message",
                     "retryable",
                 ],
-                "type": "object",
-                "properties": {
+                type="object",
+                properties={
                     "message": {
                         "type": "string",
                         "default": "Unknown Error",
@@ -225,14 +228,35 @@ def test_build_swagger():
                         "type": "boolean",
                     },
                 },
-            },
-        },
-        "basePath": "/api/v1",
-        "swagger": "2.0",
-        "consumes": [
+            ),
+            ErrorContext=has_entries(
+                required=["errors"],
+                type="object",
+                properties={
+                    "errors": {
+                        "items": {
+                            "$ref": "#/definitions/SubError",
+                        },
+                        "type": "array",
+                    },
+                },
+            ),
+            SubError=has_entries(
+                required=["message"],
+                type="object",
+                properties={
+                    "message": {
+                        "type": "string",
+                    },
+                },
+            ),
+        ),
+        basePath="/api/v1",
+        swagger="2.0",
+        consumes=[
             "application/json",
         ],
-    })))
+    ))
 
 
 def test_no_prefix_no_version_path():


### PR DESCRIPTION
Currently, schema definitions that we expose in the swagger convention are all tied to a route.
Here we introduce the concept of an "associated schema", which is derived from another resource but not tied to a route.

One use case we have is for pubsub: our pubsub messages are closely tied to our route resources; however we don't necessarily send all of a resource fields in a pubsub message. The mechanism introduced here will allow us to use swagger schemas to define those message schemas.

- Introduce `add_associated_schema` decorator.
- Use a schema's associated schemas when generating swagger definitions.