### PR TITLE
Change internals for associated schemas

### DIFF
--- a/microcosm_flask/decorators/schemas.py
+++ b/microcosm_flask/decorators/schemas.py
@@ -34,6 +34,13 @@ def associated_schema_name(schema_cls, name_suffix):
     return f"{type_name(name_for(schema_cls))}{camelize(name_suffix)}Schema"
 
 
+def get_associated_schema(schema_cls, name_suffix):
+    associated_schemas = getattr(schema_cls, associated_schemas_attr_name(schema_cls), {})
+    if name_suffix in associated_schemas:
+        return associated_schemas[name_suffix]
+    raise KeyError(f"Schema {schema_cls} does not have an associated schema with suffix {name_suffix}")
+
+
 def add_associated_schema(name_suffix, selected_fields=()):
     """
     Derive a schema as a subset of fields from the schema class being decorated,
@@ -58,12 +65,15 @@ def add_associated_schema(name_suffix, selected_fields=()):
             associated_fields,
         )
         try:
-            getattr(schema_cls, attr_name).append(associated_schema)
+            associated_schemas = getattr(schema_cls, attr_name)
+            if name_suffix in associated_schemas:
+                raise ValueError(f"Schema {schema_cls} already has an associated schema for suffix {name_suffix}")
+            associated_schemas[name_suffix] = associated_schema
         except AttributeError:
             setattr(
                 schema_cls,
                 attr_name,
-                [associated_schema],
+                {name_suffix: associated_schema},
             )
         return schema_cls
 

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -77,7 +77,7 @@ class Schemas:
 
         yield self.to_tuple(schema)
 
-        for associated_schema in getattr(schema, associated_schemas_attr_name(schema.__class__), []):
+        for associated_schema in getattr(schema, associated_schemas_attr_name(schema.__class__), {}).values():
             yield self.to_tuple(associated_schema())
 
         for name, field in self.iter_fields(schema):

--- a/microcosm_flask/tests/conventions/test_schema_decorators.py
+++ b/microcosm_flask/tests/conventions/test_schema_decorators.py
@@ -1,0 +1,56 @@
+from hamcrest import (
+    assert_that,
+    calling,
+    equal_to,
+    raises,
+)
+
+from microcosm_flask.decorators.schemas import (
+    add_associated_schema,
+    associated_schema_name,
+    get_associated_schema,
+)
+from microcosm_flask.tests.conventions.fixtures import PersonSchema
+
+
+class TestDecorators:
+
+    def setup(self):
+        pass
+
+    def test_get_associated_schema(self):
+        """
+        Associated schemas can be retrieved by suffix
+
+        """
+        associated_schema = get_associated_schema(PersonSchema, "Foo")
+        assert_that(
+            associated_schema.__name__,
+            equal_to("PersonFooSchema"),
+        )
+
+        assert_that(
+            calling(get_associated_schema).with_args(PersonSchema, "Bar"),
+            raises(KeyError),
+        )
+
+    def test_associated_schema_name(self):
+        """
+        Associated schema name has the suffix insert before `-Schema`
+
+        """
+        assert_that(
+            associated_schema_name(PersonSchema, "Suffix"),
+            equal_to("PersonSuffixSchema"),
+        )
+
+    def test_raise_on_duplicate_suffix(self):
+        """
+        Registering an associated schema with an already-used suffix should raise
+
+        """
+        decorator = add_associated_schema("Foo", [])
+        assert_that(
+            calling(decorator).with_args(PersonSchema),
+            raises(ValueError),
+        )


### PR DESCRIPTION
Store associated schemas as a dictionary rather than a list, allowing to:
- Error on multiple registration for the same suffix.
- Retrieve associated schemas by suffix name.