### PR TITLE
Allow different parent classes for associated schema

### DIFF
--- a/microcosm_flask/decorators/schemas.py
+++ b/microcosm_flask/decorators/schemas.py
@@ -14,7 +14,7 @@ class SelectedField:
     required: bool = True
 
 
-def _get_fields_and_make_required(schema_cls, selected_fields):
+def _get_fields_from_schema(schema_cls, selected_fields):
     associated_fields = {}
     for selected_field in selected_fields:
         if isinstance(selected_field, str):
@@ -41,7 +41,7 @@ def get_associated_schema(schema_cls, name_suffix):
     raise KeyError(f"Schema {schema_cls} does not have an associated schema with suffix {name_suffix}")
 
 
-def add_associated_schema(name_suffix, selected_fields=()):
+def add_associated_schema(name_suffix, selected_fields=(), inherits_from=(Schema,)):
     """
     Derive a schema as a subset of fields from the schema class being decorated,
     and add that derived schema as an attribute on the decorated schema.
@@ -55,13 +55,14 @@ def add_associated_schema(name_suffix, selected_fields=()):
 
     """
     def decorator(schema_cls):
-        associated_fields = _get_fields_and_make_required(schema_cls, selected_fields)
+        associated_fields = _get_fields_from_schema(schema_cls, selected_fields)
 
         # Use the class name in the attribute name to avoid sharing with children classes
         attr_name = associated_schemas_attr_name(schema_cls)
+
         associated_schema = type(
             associated_schema_name(schema_cls, name_suffix),
-            (Schema,),
+            inherits_from,
             associated_fields,
         )
         try:

--- a/microcosm_flask/tests/conventions/test_schema_decorators.py
+++ b/microcosm_flask/tests/conventions/test_schema_decorators.py
@@ -2,8 +2,10 @@ from hamcrest import (
     assert_that,
     calling,
     equal_to,
+    has_key,
     raises,
 )
+from marshmallow import Schema, fields
 
 from microcosm_flask.decorators.schemas import (
     add_associated_schema,
@@ -42,6 +44,22 @@ class TestDecorators:
         assert_that(
             associated_schema_name(PersonSchema, "Suffix"),
             equal_to("PersonSuffixSchema"),
+        )
+
+    def test_override_inheritance(self):
+        """
+        Registering an associated schema with an already-used suffix should raise
+
+        """
+        class ParentSchema(Schema):
+            someField = fields.String(attribute="some_field")
+
+        add_associated_schema("Bar", [], (ParentSchema,))(PersonSchema)
+        associated_schema = get_associated_schema(PersonSchema, "Bar")
+
+        assert_that(
+            associated_schema._declared_fields,
+            has_key("someField"),
         )
 
     def test_raise_on_duplicate_suffix(self):


### PR DESCRIPTION
Allow overriding the base class when defining an associated schema.