### PR TITLE
Expose function to set an associated schema

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.0
+current_version = 2.4.0
 commit = False
 tag = False
 

--- a/microcosm_flask/decorators/schemas.py
+++ b/microcosm_flask/decorators/schemas.py
@@ -41,6 +41,27 @@ def get_associated_schema(schema_cls, name_suffix):
     raise KeyError(f"Schema {schema_cls} does not have an associated schema with suffix {name_suffix}")
 
 
+def set_associated_schema(target_cls, name_suffix, associated_schema):
+    """
+    Add a derived schema as an attribute to a schema class, using conventions
+    that will result in the associated schema being exposed in the OpenAPI definition of the service.
+
+    """
+    # Use the class name in the attribute name to avoid sharing with children classes
+    attr_name = associated_schemas_attr_name(target_cls)
+    try:
+        associated_schemas = getattr(target_cls, attr_name)
+        if name_suffix in associated_schemas:
+            raise ValueError(f"Schema {target_cls} already has an associated schema for suffix {name_suffix}")
+        associated_schemas[name_suffix] = associated_schema
+    except AttributeError:
+        setattr(
+            target_cls,
+            attr_name,
+            {name_suffix: associated_schema},
+        )
+
+
 def add_associated_schema(name_suffix, selected_fields=(), inherits_from=(Schema,)):
     """
     Derive a schema as a subset of fields from the schema class being decorated,
@@ -57,25 +78,12 @@ def add_associated_schema(name_suffix, selected_fields=(), inherits_from=(Schema
     def decorator(schema_cls):
         associated_fields = _get_fields_from_schema(schema_cls, selected_fields)
 
-        # Use the class name in the attribute name to avoid sharing with children classes
-        attr_name = associated_schemas_attr_name(schema_cls)
-
         associated_schema = type(
             associated_schema_name(schema_cls, name_suffix),
             inherits_from,
             associated_fields,
         )
-        try:
-            associated_schemas = getattr(schema_cls, attr_name)
-            if name_suffix in associated_schemas:
-                raise ValueError(f"Schema {schema_cls} already has an associated schema for suffix {name_suffix}")
-            associated_schemas[name_suffix] = associated_schema
-        except AttributeError:
-            setattr(
-                schema_cls,
-                attr_name,
-                {name_suffix: associated_schema},
-            )
+        set_associated_schema(schema_cls, name_suffix, associated_schema)
         return schema_cls
 
     return decorator

--- a/microcosm_flask/decorators/schemas.py
+++ b/microcosm_flask/decorators/schemas.py
@@ -83,6 +83,7 @@ def add_associated_schema(name_suffix, selected_fields=(), inherits_from=(Schema
             inherits_from,
             associated_fields,
         )
+
         set_associated_schema(schema_cls, name_suffix, associated_schema)
         return schema_cls
 

--- a/microcosm_flask/decorators/schemas.py
+++ b/microcosm_flask/decorators/schemas.py
@@ -62,6 +62,14 @@ def set_associated_schema(target_cls, name_suffix, associated_schema):
         )
 
 
+def build_associated_schema(schema_cls, name_suffix, inherits_from, associated_fields):
+    return type(
+        associated_schema_name(schema_cls, name_suffix),
+        inherits_from,
+        associated_fields,
+    )
+
+
 def add_associated_schema(name_suffix, selected_fields=(), inherits_from=(Schema,)):
     """
     Derive a schema as a subset of fields from the schema class being decorated,
@@ -78,8 +86,9 @@ def add_associated_schema(name_suffix, selected_fields=(), inherits_from=(Schema
     def decorator(schema_cls):
         associated_fields = _get_fields_from_schema(schema_cls, selected_fields)
 
-        associated_schema = type(
-            associated_schema_name(schema_cls, name_suffix),
+        associated_schema = build_associated_schema(
+            schema_cls,
+            name_suffix,
             inherits_from,
             associated_fields,
         )

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -18,6 +18,10 @@ from microcosm_flask.naming import name_for
 from microcosm_flask.swagger.naming import type_name
 
 
+def definition_name_for_schema(schema_cls):
+    return type_name(name_for(schema_cls))
+
+
 class Schemas:
     """
     Swagger schema builder.
@@ -90,4 +94,4 @@ class Schemas:
                 yield from self.iter_schemas(field.inner.schema)
 
     def to_tuple(self, schema: Schema) -> Tuple[str, Any]:
-        return type_name(name_for(schema)), self.build(schema)
+        return definition_name_for_schema(schema), self.build(schema)

--- a/microcosm_flask/tests/conventions/test_schema_decorators.py
+++ b/microcosm_flask/tests/conventions/test_schema_decorators.py
@@ -11,6 +11,7 @@ from microcosm_flask.decorators.schemas import (
     add_associated_schema,
     associated_schema_name,
     get_associated_schema,
+    set_associated_schema,
 )
 from microcosm_flask.tests.conventions.fixtures import PersonSchema
 
@@ -71,4 +72,18 @@ class TestDecorators:
         assert_that(
             calling(decorator).with_args(PersonSchema),
             raises(ValueError),
+        )
+
+    def test_set_associated_schema(self):
+        class SomeSchema(Schema):
+            someField = fields.String(attribute="some_field")
+
+        class AnotherSchema(Schema):
+            anotherField = fields.Integer(attribute="another_field")
+
+        set_associated_schema(SomeSchema, "Suffix", AnotherSchema)
+
+        assert_that(
+            get_associated_schema(SomeSchema, "Suffix")._declared_fields,
+            has_key("anotherField"),
         )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-flask"
-version = "2.2.0"
+version = "2.4.0"
 
 
 setup(


### PR DESCRIPTION
- Adding an associated schema can be useful outside of the context of the `@add_associated_schema` decorator; separate that function out so as to expose it.
- Merge `master` back to `develop`.