### PR TITLE
GLOB-36585 set query parameters to be required based on their schema

### DIFF
--- a/microcosm_flask/swagger/definitions.py
+++ b/microcosm_flask/swagger/definitions.py
@@ -160,7 +160,7 @@ def header_param(name, required=False, param_type="string"):
     })
 
 
-def query_param(name, field, required=False):
+def query_param(name, field):
     """
     Build a query parameter definition.
 
@@ -168,7 +168,7 @@ def query_param(name, field, required=False):
     parameter = build_parameter(field)
     parameter["name"] = name
     parameter["in"] = "query"
-    parameter["required"] = False
+    parameter["required"] = field.required
 
     return swagger.QueryParameterSubSchema(**parameter)
 

--- a/microcosm_flask/tests/conventions/test_query.py
+++ b/microcosm_flask/tests/conventions/test_query.py
@@ -120,7 +120,7 @@ class TestQuery:
                             "type": "string",
                         },
                         {
-                            "required": False,
+                            "required": True,
                             "type": "string",
                             "name": "value",
                             "in": "query",

--- a/microcosm_flask/tests/conventions/test_query.py
+++ b/microcosm_flask/tests/conventions/test_query.py
@@ -15,7 +15,8 @@ from microcosm_flask.operations import Operation
 
 
 class QueryStringSchema(Schema):
-    value = fields.String(required=True)
+    required_value = fields.String(required=True)
+    optional_value = fields.String(required=False)
 
 
 class QueryResultSchema(Schema):
@@ -38,7 +39,7 @@ def make_query(graph, ns, request_schema, response_schema):
         request_data = load_query_string_data(request_schema)
         response_data = dict(
             result=True,
-            value=request_data["value"],
+            value=request_data["required_value"],
         )
         return dump_response_data(response_schema, response_data, Operation.Query.value.default_code)
 
@@ -78,7 +79,7 @@ class TestQuery:
         """
         uri = "/api/v1/foo/get"
         query_string = {
-            "value": "bar",
+            "required_value": "bar",
         }
         response = self.client.get(uri, query_string=query_string)
         assert_that(response.status_code, is_(equal_to(200)))
@@ -120,9 +121,15 @@ class TestQuery:
                             "type": "string",
                         },
                         {
+                            "required": False,
+                            "type": "string",
+                            "name": "optional_value",
+                            "in": "query",
+                        },
+                        {
                             "required": True,
                             "type": "string",
-                            "name": "value",
+                            "name": "required_value",
                             "in": "query",
                         },
                     ],


### PR DESCRIPTION
Currently query parameters are always set as having `required=False` when building the operation for swagger. Either I'm missing some crucial understanding about how we use swagger, or this has been an unnoticed bug for 4 years.

I've changed it to be based on the field specification and updated the one test that checks this.