### PR TITLE
Fix building OpenAPI definition for integer-valued ids

### DIFF
--- a/microcosm_flask/swagger/definitions.py
+++ b/microcosm_flask/swagger/definitions.py
@@ -17,6 +17,7 @@ Note that:
 
 """
 from logging import getLogger
+from typing import Set
 from urllib.parse import unquote
 
 from openapi import model as swagger
@@ -35,6 +36,8 @@ from microcosm_flask.swagger.naming import operation_name, type_name
 
 
 logger = getLogger("microcosm_flask.swagger")
+# Placeholder integer id used to build URIs in werkzeug before replacing with id param name.
+# Use a value that is unlikely to be present somewhere else in the URI.
 PLACEHOLDER_INTEGER_ID = 1111
 
 
@@ -121,7 +124,7 @@ def iter_definitions(definitions, operations):
         yield get_response_schema(func)
 
 
-def build_path_for_integer_param(ns, operation, arguments):
+def build_path_for_integer_param(ns, operation, arguments: Set):
     """
     Build an endpoint path when the parameters are integer-valued
 
@@ -138,10 +141,10 @@ def build_path_for_integer_param(ns, operation, arguments):
     them afterwards.
 
     """
-    sorted_args = list(arguments)
+    ordered_args = list(arguments)
     args_substitution = {
         PLACEHOLDER_INTEGER_ID + index: argument
-        for index, argument in enumerate(sorted_args)
+        for index, argument in enumerate(ordered_args)
     }
     uri_templates = {
         argument: f"{placeholder}"

--- a/microcosm_flask/swagger/definitions.py
+++ b/microcosm_flask/swagger/definitions.py
@@ -35,6 +35,7 @@ from microcosm_flask.swagger.naming import operation_name, type_name
 
 
 logger = getLogger("microcosm_flask.swagger")
+PLACEHOLDER_INTEGER_ID = 1111
 
 
 def build_swagger(graph, ns, operations):
@@ -120,21 +121,53 @@ def iter_definitions(definitions, operations):
         yield get_response_schema(func)
 
 
-def build_path(operation, ns):
+def build_path_for_integer_param(ns, operation, arguments):
     """
-    Build a path URI for an operation.
+    Build an endpoint path when the parameters are integer-valued
+
+    When building paths for swagger, parameter names are substituted for
+    path parameters. For example, the output will have '/api/v1/person/{person_id}'.
+    We still use werkzeug to build those paths with placeholders for params.
+
+    That works with UUID-valued ids but not integer-valued ones, due do a difference
+    between the UUIDConverter and NumberConverter's `to_url` methods
+    (see https://github.com/pallets/werkzeug/blob/master/src/werkzeug/routing.py#L1315
+    and https://github.com/pallets/werkzeug/blob/master/src/werkzeug/routing.py#L1234)
+
+    Here we instead use placeholder integers to use werkzeug functions, and replace
+    them afterwards.
 
     """
+    sorted_args = list(arguments)
+    args_substitution = {
+        PLACEHOLDER_INTEGER_ID + index: argument
+        for index, argument in enumerate(sorted_args)
+    }
+    uri_templates = {
+        argument: f"{placeholder}"
+        for placeholder, argument in args_substitution.items()
+    }
+    path = unquote(ns.url_for(operation, _external=False, **uri_templates))
+    for placeholder_integer, argument in args_substitution.items():
+        path = path.replace(str(placeholder_integer), f"{{{argument}}}")
+
+    return path
+
+
+def build_path(operation, ns):
     try:
         return ns.url_for(operation, _external=False)
     except BuildError as error:
-        # we are missing some URI path parameters
-        uri_templates = {
-            argument: "{{{}}}".format(argument)
-            for argument in error.suggested.arguments
-        }
-        # flask will sometimes try to quote '{' and '}' characters
-        return unquote(ns.url_for(operation, _external=False, **uri_templates))
+        if ns.identifier_type == "int":
+            return build_path_for_integer_param(ns, operation, error.suggested.arguments)
+        else:
+            # we are missing some URI path parameters
+            uri_templates = {
+                argument: f"{{{argument}}}"
+                for argument in error.suggested.arguments
+            }
+            # flask will sometimes try to quote '{' and '}' characters
+            return unquote(ns.url_for(operation, _external=False, **uri_templates))
 
 
 def body_param(schema):
@@ -181,6 +214,9 @@ def path_param(name, ns):
     if ns.identifier_type == "uuid":
         param_type = "string"
         param_format = "uuid"
+    elif ns.identifier_type == "int":
+        param_type = "integer"
+        param_format = None
     else:
         param_type = "string"
         param_format = None

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -15,7 +15,7 @@ from microcosm_flask.conventions.crud import configure_crud
 from microcosm_flask.conventions.registry import iter_endpoints
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
-from microcosm_flask.swagger.definitions import build_swagger
+from microcosm_flask.swagger.definitions import build_path_for_integer_param, build_swagger
 from microcosm_flask.tests.conventions.fixtures import (
     NewPersonSchema,
     Person,
@@ -290,6 +290,11 @@ def test_build_integer_valued_param():
     with graph.flask.test_request_context():
         operations = list(iter_endpoints(graph, match_function))
         swagger_schema = build_swagger(graph, ns, operations)
+
+        assert_that(
+            build_path_for_integer_param(ns, Operation.Update, set(["person_id"])),
+            equal_to("/api/v1/person/{person_id}"),
+        )
 
     assert_that(swagger_schema, has_entries(
         paths=has_entries(


### PR DESCRIPTION
**Why?**
The way we build OpenAPI definitions for flask routes breaks on non-string valued ids.
In particular, it breaks for integer-valued ids. This is because we use werkzeug functions to build paths in the OpenAPI definitions; using parameter names instead of actual values. This works fine for string-valued parameters, but not in other cases.
In particular, it breaks for integer-valued IDs.

**What?**
Use placeholder integers to build URIs using werkzeug functions, and replace placeholders with param names afterwards.