### PR TITLE
Add `x-nullable` for nullable fields.

### DIFF
--- a/microcosm_flask/swagger/parameters/base.py
+++ b/microcosm_flask/swagger/parameters/base.py
@@ -34,6 +34,7 @@ class ParameterBuilder(ABC):
             "$ref": self.parse_ref,
             "type": self.parse_type,
             "items": self.parse_items,
+            "x-nullable": self.parse_nullable,
         }
 
     def build(self, field: Field) -> Mapping[str, Any]:
@@ -67,6 +68,11 @@ class ParameterBuilder(ABC):
 
         """
         return field.default
+
+    def parse_nullable(self, field: Field) -> Optional[bool]:
+        if field.allow_none:
+            return True
+        return None
 
     def parse_description(self, field: Field) -> Optional[str]:
         """

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -106,6 +106,7 @@ def pubsub_schema(fields):
 )
 class PersonSchema(PersonCSVSchema):
     _links = fields.Method("get_links", dump_only=True)
+    email = fields.Email(allow_none=True)
 
     def get_links(self, obj):
         links = Links()

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -166,6 +166,7 @@ def test_build_swagger():
                     "email": {
                         "type": "string",
                         "format": "email",
+                        "x-nullable": True,
                     },
                     "lastName": {
                         "type": "string",
@@ -188,6 +189,7 @@ def test_build_swagger():
                     "email": {
                         "format": "email",
                         "type": "string",
+                        "x-nullable": True,
                     },
                     "firstName": {
                         "type": "string",
@@ -203,14 +205,12 @@ def test_build_swagger():
                     "email": {
                         "format": "email",
                         "type": "string",
+                        "x-nullable": True,
                     },
                     "firstName": {
                         "type": "string",
                     },
                 },
-                required=[
-                    "email",
-                ],
             ),
             UpdatePerson=dict(
                 type="object",


### PR DESCRIPTION
**Why?**
OpenAPI 2.0 doesn't support nullable fields natively, so we had taken the approach to mark those fields as non-required.
However, that approach doesn't cover all cases. Bravado supports the custom `x-nullable` flag for a field.

**What?**
Mark fields as `x-nullable` in the OpenAPI definition if they have `allow_none` set to `True` in their schema.