### PR TITLE
Support data_key usage for field names for generated swagger

### DIFF
--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -38,7 +38,7 @@ class Schemas:
         fields = list(self.iter_fields(schema))
 
         properties = {
-            field.name: self.build_parameter(field)
+            name: self.build_parameter(field)
             for name, field in fields
         }
 
@@ -67,7 +67,9 @@ class Schemas:
         """
         for name in sorted(schema.fields.keys()):
             field = schema.fields[name]
-            yield name, field
+            field_name = field.data_key or name
+
+            yield field_name, field
 
     def iter_schemas(self, schema: Schema) -> Iterable[Tuple[str, Any]]:
         """

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -28,12 +28,13 @@ class Person:
 
 
 class NewAddressSchema(Schema):
-    addressLine = fields.Str(attribute="address_line", required=True)
+    addressLine = fields.String(attribute="address_line", required=True)
 
 
 class NewPersonSchema(Schema):
-    firstName = fields.Str(attribute="first_name", required=True)
-    lastName = fields.Str(attribute="last_name", required=True)
+    # both attribute and data_key fields should result in the same swagger definition
+    firstName = fields.String(attribute="first_name", required=True)
+    last_name = fields.String(data_key="lastName", required=True)
     email = fields.Email()
 
     @property
@@ -46,8 +47,8 @@ class NewPersonBatchSchema(Schema):
 
 
 class UpdatePersonSchema(Schema):
-    firstName = fields.Str(attribute="first_name")
-    lastName = fields.Str(attribute="last_name")
+    firstName = fields.String(attribute="first_name")
+    last_name = fields.String(data_key="lastName")
 
 
 class AddressCSVSchema(NewAddressSchema):


### PR DESCRIPTION
The recommended method of specifying serialized names in marshmallow is
to use the `data_key` argument when specifying a field, instead of `attribute`
(which otherwise leads to the awkward inclusion of camelCased field names,
which is less than ideal).

Unfortunately, this otherwise breaks existing swagger definition
generation, as it didn't take this field into account.

This will use an existing `data_key` field if it exists as a name, but
otherwise fallback to the predefined name.

https://marshmallow.readthedocs.io/en/stable/quickstart.html#specifying-serialization-deserialization-keys