### PR TITLE
Add DeleteBatch operation

### DIFF
--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -195,8 +195,8 @@ class CRUDConvention(Convention):
             definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
             return dump_response_data(
-                "",
-                None,
+                response_schema="",
+                response_data=None,
                 status_code=operation.value.default_code,
                 headers=headers,
                 response_format=response_format,

--- a/microcosm_flask/operations.py
+++ b/microcosm_flask/operations.py
@@ -32,6 +32,7 @@ class Operation(Enum):
     Search = OperationInfo("search", "GET", NODE_PATTERN, 200)
     Count = OperationInfo("count", "HEAD", NODE_PATTERN, 200)
     Create = OperationInfo("create", "POST", NODE_PATTERN, 201)
+    DeleteBatch = OperationInfo("delete_batch", "DELETE", NODE_PATTERN, 204)
     UpdateBatch = OperationInfo("update_batch", "PATCH", NODE_PATTERN, 200)
     CreateCollection = OperationInfo("create_collection", "POST", NODE_PATTERN, 200)
     SavedSearch = OperationInfo("saved_search", "POST", NODE_PATTERN, 200)

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -187,6 +187,10 @@ def person_delete(person_id):
     return person_id == PERSON_ID_1
 
 
+def person_delete_batch():
+    return True
+
+
 def person_replace(person_id, **kwargs):
     return Person(id=person_id, **kwargs)
 

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -38,6 +38,7 @@ from microcosm_flask.tests.conventions.fixtures import (
     address_search,
     person_create,
     person_delete,
+    person_delete_batch,
     person_replace,
     person_retrieve,
     person_search,
@@ -66,6 +67,7 @@ def add_request_id(headers, response_data):
 PERSON_MAPPINGS = {
     Operation.Create: (person_create, NewPersonSchema(), PersonSchema(), add_request_id),
     Operation.Delete: (person_delete,),
+    Operation.DeleteBatch: (person_delete_batch,),
     Operation.UpdateBatch: (person_update_batch, NewPersonBatchSchema(), PersonBatchSchema()),
     Operation.Replace: (person_replace, NewPersonSchema(), PersonSchema()),
     Operation.Retrieve: (person_retrieve, PersonLookupSchema(), PersonSchema()),
@@ -278,6 +280,10 @@ class TestCRUD:
                 },
             }],
         })
+
+    def test_delete_batch(self):
+        response = self.client.delete("/api/person")
+        self.assert_response(response, 204)
 
     def test_retrieve(self):
         uri = "/api/person/{}".format(PERSON_ID_1)


### PR DESCRIPTION
Add `DeleteBatch` operation to allow endpoints like:

```
DELETE /collection
```

with optional query params, returning `204` on success with empty body.