### PR TITLE
GLOB-44246 Improve swagger endpoint performance

### DIFF
--- a/microcosm_flask/conventions/swagger.py
+++ b/microcosm_flask/conventions/swagger.py
@@ -5,14 +5,19 @@ Exposes swagger definitions for matching operations.
 
 """
 from flask import g
+from marshmallow import Schema, fields
 from microcosm.api import defaults
 
 from microcosm_flask.conventions.base import Convention
-from microcosm_flask.conventions.encoding import make_response
-from microcosm_flask.conventions.registry import iter_endpoints
+from microcosm_flask.conventions.encoding import load_query_string_data, make_response
+from microcosm_flask.conventions.registry import iter_endpoints, request
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 from microcosm_flask.swagger.definitions import build_swagger
+
+
+class ValidateSwaggerSchema(Schema):
+    validate_schema = fields.Boolean()
 
 
 class SwaggerConvention(Convention):
@@ -46,8 +51,11 @@ class SwaggerConvention(Convention):
 
         """
         @self.add_route(ns.singleton_path, Operation.Discover, ns)
+        @request(ValidateSwaggerSchema)
         def discover():
-            swagger = build_swagger(self.graph, ns, self.find_matching_endpoints(ns))
+            request_data = load_query_string_data(ValidateSwaggerSchema())
+
+            swagger = build_swagger(self.graph, ns, self.find_matching_endpoints(ns), **request_data)
             g.hide_body = True
             return make_response(swagger)
 

--- a/microcosm_flask/tests/conventions/test_query.py
+++ b/microcosm_flask/tests/conventions/test_query.py
@@ -93,7 +93,7 @@ class TestQuery:
         Swagger definitions including this operation.
 
         """
-        response = self.client.get("/api/v1/swagger")
+        response = self.client.get("/api/v1/swagger", query_string=dict(validate_schema=True))
         assert_that(response.status_code, is_(equal_to(200)))
         swagger = loads(response.get_data().decode("utf-8"))
         assert_that(swagger["paths"], is_(equal_to({


### PR DESCRIPTION
As the number of endpoints grows, the time taken for this endpoint grows 
non-linearly. This is due to the fact that during `add_paths`, `url_for` 
performs what is essentially a full scan across every possible endpoint 
that the app is already aware of, performing a relatively expensive diff on
each turn.

While this only occurs on BuildError, it is frequently raised when the
endpoint in question requires any path argument, which ends up being many
of them
(retrieve/delete/update/etc.).

We can sidestep that error by performing a preflight operation (which
`url_for` is already end up doing under the hood) that pre-fetches the 
expected arguments used in any given path, and passes that in when 
constructing the path.

Also add an extra flag to enable schema validation, as this can frequently
eat up a non-trivial amount of time. This will, however, push the burden of
validating schemas onto the project itself (e.g. via an additional unit
test).

From local testing (with a schema using 200+ endpoints) this reduced the total time from ~6 seconds to ~1.