### PR TITLE
Add option for non-strict enums in OpenAPI definition

### DIFF
--- a/microcosm_flask/swagger/api.py
+++ b/microcosm_flask/swagger/api.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Iterable,
     Mapping,
+    Optional,
     Tuple,
 )
 
@@ -16,30 +17,30 @@ from microcosm_flask.swagger.parameters import Parameters
 from microcosm_flask.swagger.schemas import Schemas
 
 
-def build_schema(schema: Schema) -> Mapping[str, Any]:
+def build_schema(schema: Schema, strict_enums: Optional[bool] = True) -> Mapping[str, Any]:
     """
     Build JSON schema from a marshmallow schema.
 
     """
-    builder = Schemas(build_parameter=build_parameter)
+    builder = Schemas(build_parameter=build_parameter, strict_enums=strict_enums)
     return builder.build(schema)
 
 
-def iter_schemas(schema: Schema) -> Iterable[Tuple[str, Any]]:
+def iter_schemas(schema: Schema, strict_enums: Optional[bool] = True) -> Iterable[Tuple[str, Any]]:
     """
     Build zero or more JSON schemas for a marshmallow schema.
 
     Generates: name, schema pairs.
 
     """
-    builder = Schemas(build_parameter=build_parameter)
+    builder = Schemas(build_parameter=build_parameter, strict_enums=strict_enums)
     return builder.iter_schemas(schema)
 
 
-def build_parameter(field: Field) -> Mapping[str, Any]:
+def build_parameter(field: Field, **kwargs) -> Mapping[str, Any]:
     """
     Build JSON parameter from a marshmallow field.
 
     """
-    builder = Parameters()
+    builder = Parameters(**kwargs)
     return builder.build(field)

--- a/microcosm_flask/swagger/api.py
+++ b/microcosm_flask/swagger/api.py
@@ -6,7 +6,6 @@ from typing import (
     Any,
     Iterable,
     Mapping,
-    Optional,
     Tuple,
 )
 
@@ -17,7 +16,7 @@ from microcosm_flask.swagger.parameters import Parameters
 from microcosm_flask.swagger.schemas import Schemas
 
 
-def build_schema(schema: Schema, strict_enums: Optional[bool] = True) -> Mapping[str, Any]:
+def build_schema(schema: Schema, strict_enums: bool = True) -> Mapping[str, Any]:
     """
     Build JSON schema from a marshmallow schema.
 
@@ -26,7 +25,7 @@ def build_schema(schema: Schema, strict_enums: Optional[bool] = True) -> Mapping
     return builder.build(schema)
 
 
-def iter_schemas(schema: Schema, strict_enums: Optional[bool] = True) -> Iterable[Tuple[str, Any]]:
+def iter_schemas(schema: Schema, strict_enums: bool = True) -> Iterable[Tuple[str, Any]]:
     """
     Build zero or more JSON schemas for a marshmallow schema.
 

--- a/microcosm_flask/swagger/parameters/__init__.py
+++ b/microcosm_flask/swagger/parameters/__init__.py
@@ -4,6 +4,7 @@ from typing import (
     Any,
     List,
     Mapping,
+    Optional,
     Type,
 )
 
@@ -24,6 +25,9 @@ class Parameters:
     and delegates to the first compatible implementation.
 
     """
+    def __init__(self, strict_enums: Optional[bool] = True):
+        self.strict_enums = strict_enums
+
     def build(self, field: Field) -> Mapping[str, Any]:
         """
         Build a swagger parameter from a marshmallow field.
@@ -37,6 +41,7 @@ class Parameters:
         builders: List[ParameterBuilder] = [
             builder_type(
                 build_parameter=self.build,  # type: ignore
+                strict_enums=self.strict_enums,
             )
             for builder_type in builder_types
         ]

--- a/microcosm_flask/swagger/parameters/__init__.py
+++ b/microcosm_flask/swagger/parameters/__init__.py
@@ -4,7 +4,6 @@ from typing import (
     Any,
     List,
     Mapping,
-    Optional,
     Type,
 )
 
@@ -25,7 +24,7 @@ class Parameters:
     and delegates to the first compatible implementation.
 
     """
-    def __init__(self, strict_enums: Optional[bool] = True):
+    def __init__(self, strict_enums: bool = True):
         self.strict_enums = strict_enums
 
     def build(self, field: Field) -> Mapping[str, Any]:

--- a/microcosm_flask/swagger/parameters/base.py
+++ b/microcosm_flask/swagger/parameters/base.py
@@ -24,7 +24,7 @@ class ParameterBuilder(ABC):
     and delegates to the first compatible implementation.
 
     """
-    def __init__(self, build_parameter: Callable[[Schema], Mapping[str, Any]]):
+    def __init__(self, build_parameter: Callable[[Schema], Mapping[str, Any]], **kwargs):
         self.build_parameter = build_parameter
         self.parsers = {
             "default": self.parse_default,

--- a/microcosm_flask/swagger/parameters/enum.py
+++ b/microcosm_flask/swagger/parameters/enum.py
@@ -1,5 +1,12 @@
-from typing import Optional, Sequence
+from typing import (
+    Any,
+    Callable,
+    Mapping,
+    Optional,
+    Sequence,
+)
 
+from marshmallow import Schema
 from marshmallow.fields import Field
 
 from microcosm_flask.fields import EnumField
@@ -19,17 +26,32 @@ class EnumParameterBuilder(ParameterBuilder):
     """
     Build an enum parameter.
 
+    If `strict_enums` is True, the parameter is built using the "enum" format,
+    with the allowed values under the "enum" key. Otherwise the parameter is simply considered
+    as a string.
+
     """
+    def __init__(
+        self,
+        build_parameter: Callable[[Schema], Mapping[str, Any]],
+        strict_enums: Optional[bool] = True,
+        **kwargs,
+    ):
+        super().__init__(build_parameter)
+        self.strict_enums = strict_enums
+
     def supports_field(self, field: Field) -> bool:
         return bool(getattr(field, "enum", None))
 
     def parse_format(self, field: Field) -> Optional[str]:
-        if isinstance(field, EnumField):
+        if isinstance(field, EnumField) and self.strict_enums:
             return "enum"
         return None
 
     def parse_type(self, field: Field) -> str:
         enum_values = self.parse_enum_values(field)
+        if enum_values is None:
+            return "string"
 
         if all((isinstance(enum_value, str) for enum_value in enum_values)):
             return "string"
@@ -38,7 +60,10 @@ class EnumParameterBuilder(ParameterBuilder):
         else:
             raise Exception(f"Cannot infer enum type for field: {field.name}")
 
-    def parse_enum_values(self, field: Field) -> Sequence:
+    def parse_enum_values(self, field: Field) -> Optional[Sequence]:
+        if not self.strict_enums:
+            return None
+
         enum = getattr(field, "enum", None)
         return [
             choice.value if field.by_value else choice.name  # type: ignore

--- a/microcosm_flask/swagger/parameters/enum.py
+++ b/microcosm_flask/swagger/parameters/enum.py
@@ -66,7 +66,6 @@ class EnumParameterBuilder(ParameterBuilder):
         ]
 
     def parse_enum_values(self, field: Field) -> Optional[Sequence]:
-        if not self.strict_enums:
-            return None
-
-        return self._parse_enum_values(field)
+        if self.strict_enums:
+            return self._parse_enum_values(field)
+        return None

--- a/microcosm_flask/swagger/parameters/enum.py
+++ b/microcosm_flask/swagger/parameters/enum.py
@@ -34,7 +34,7 @@ class EnumParameterBuilder(ParameterBuilder):
     def __init__(
         self,
         build_parameter: Callable[[Schema], Mapping[str, Any]],
-        strict_enums: Optional[bool] = True,
+        strict_enums: bool = True,
         **kwargs,
     ):
         super().__init__(build_parameter)

--- a/microcosm_flask/swagger/parameters/enum.py
+++ b/microcosm_flask/swagger/parameters/enum.py
@@ -49,9 +49,7 @@ class EnumParameterBuilder(ParameterBuilder):
         return None
 
     def parse_type(self, field: Field) -> str:
-        enum_values = self.parse_enum_values(field)
-        if enum_values is None:
-            return "string"
+        enum_values = self._parse_enum_values(field)
 
         if all((isinstance(enum_value, str) for enum_value in enum_values)):
             return "string"
@@ -60,12 +58,15 @@ class EnumParameterBuilder(ParameterBuilder):
         else:
             raise Exception(f"Cannot infer enum type for field: {field.name}")
 
-    def parse_enum_values(self, field: Field) -> Optional[Sequence]:
-        if not self.strict_enums:
-            return None
-
+    def _parse_enum_values(self, field: Field) -> Sequence:
         enum = getattr(field, "enum", None)
         return [
             choice.value if field.by_value else choice.name  # type: ignore
             for choice in enum
         ]
+
+    def parse_enum_values(self, field: Field) -> Optional[Sequence]:
+        if not self.strict_enums:
+            return None
+
+        return self._parse_enum_values(field)

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -7,7 +7,6 @@ from typing import (
     Callable,
     Iterable,
     Mapping,
-    Optional,
     Tuple,
 )
 
@@ -31,7 +30,7 @@ class Schemas:
     def __init__(
         self,
         build_parameter: Callable[..., Mapping[str, Any]],
-        strict_enums: Optional[bool] = True,
+        strict_enums: bool = True,
     ):
         self.build_parameter = build_parameter
         self.strict_enums = strict_enums

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     Iterable,
     Mapping,
+    Optional,
     Tuple,
 )
 
@@ -27,8 +28,13 @@ class Schemas:
     Swagger schema builder.
 
     """
-    def __init__(self, build_parameter: Callable[[Field], Mapping[str, Any]]):
+    def __init__(
+        self,
+        build_parameter: Callable[..., Mapping[str, Any]],
+        strict_enums: Optional[bool] = True,
+    ):
         self.build_parameter = build_parameter
+        self.strict_enums = strict_enums
 
     def build(self, schema: Schema) -> Mapping[str, Any]:
         """
@@ -38,7 +44,7 @@ class Schemas:
         fields = list(self.iter_fields(schema))
 
         properties = {
-            name: self.build_parameter(field)
+            name: self.build_parameter(field, strict_enums=self.strict_enums)
             for name, field in fields
         }
 

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -3,14 +3,27 @@ Testing fixtures (e.g. for CRUD).
 
 """
 from copy import copy
+from enum import Enum, unique
 from uuid import uuid4
 
 from marshmallow import Schema, fields
 
 from microcosm_flask.decorators.schemas import SelectedField, add_associated_schema
+from microcosm_flask.fields import EnumField
 from microcosm_flask.linking import Link, Links
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
+
+
+@unique
+class EyeColor(Enum):
+    """
+    Natural eye colors
+
+    """
+    PURPLE = "PURPLE"
+    TEAL = "TEAL"
+    RUBY = "RUBY"
 
 
 class Address:
@@ -35,6 +48,7 @@ class NewPersonSchema(Schema):
     # both attribute and data_key fields should result in the same swagger definition
     firstName = fields.String(attribute="first_name", required=True)
     last_name = fields.String(data_key="lastName", required=True)
+    eye_color = EnumField(EyeColor, data_key="eyeColor")
     email = fields.Email()
 
     @property

--- a/microcosm_flask/tests/swagger/parameters/test_enum.py
+++ b/microcosm_flask/tests/swagger/parameters/test_enum.py
@@ -34,6 +34,13 @@ def test_field_enum():
     })))
 
 
+def test_field_enum_non_strict():
+    parameter = build_parameter(TestSchema().fields["choice"], strict_enums=False)
+    assert_that(parameter, is_(equal_to({
+        "type": "string",
+    })))
+
+
 def test_field_int_enum():
     parameter = build_parameter(TestSchema().fields["value"])
     assert_that(parameter, is_(equal_to({

--- a/microcosm_flask/tests/swagger/test_api.py
+++ b/microcosm_flask/tests/swagger/test_api.py
@@ -38,3 +38,29 @@ def test_schema_generation():
             "lastName",
         ],
     })))
+
+
+def test_schema_generation_non_strict_enums():
+    schema = build_schema(NewPersonSchema(), strict_enums=False)
+    assert_that(schema, is_(equal_to({
+        "type": "object",
+        "properties": {
+            "eyeColor": {
+                "type": "string",
+            },
+            "firstName": {
+                "type": "string",
+            },
+            "lastName": {
+                "type": "string",
+            },
+            "email": {
+                "format": "email",
+                "type": "string",
+            },
+        },
+        "required": [
+            "firstName",
+            "lastName",
+        ],
+    })))

--- a/microcosm_flask/tests/swagger/test_api.py
+++ b/microcosm_flask/tests/swagger/test_api.py
@@ -13,6 +13,15 @@ def test_schema_generation():
     assert_that(schema, is_(equal_to({
         "type": "object",
         "properties": {
+            "eyeColor": {
+                "enum": [
+                    "PURPLE",
+                    "TEAL",
+                    "RUBY",
+                ],
+                "format": "enum",
+                "type": "string",
+            },
             "firstName": {
                 "type": "string",
             },

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -147,6 +147,15 @@ def test_build_swagger():
                         "type": "string",
                         "format": "email",
                     },
+                    "eyeColor": {
+                        "enum": [
+                            "PURPLE",
+                            "TEAL",
+                            "RUBY",
+                        ],
+                        "format": "enum",
+                        "type": "string",
+                    },
                     "lastName": {
                         "type": "string",
                     },
@@ -166,6 +175,10 @@ def test_build_swagger():
                     "email": {
                         "type": "string",
                         "format": "email",
+                    },
+                    # Response-side enums are declared as strings
+                    "eyeColor": {
+                        "type": "string",
                     },
                     "lastName": {
                         "type": "string",

--- a/microcosm_flask/tests/test_errors.py
+++ b/microcosm_flask/tests/test_errors.py
@@ -189,7 +189,7 @@ def test_sentry_integration():
             sentry_logging=dict(
                 dsn="topic",
                 enabled=True,
-            )
+            ),
         )
     graph = create_object_graph(name="example", testing=True, loader=loader)
 


### PR DESCRIPTION
**Why?**
Having closed enums on the response validation side breaks backward-compatibility.

Let's say we have two services `consumer` and `producer`. `producer` gets a new version of a shared enum, with a new enum value.
If `producer` returns that value it in the body of a response, `consumer` will always error on deserializing that response even if that new enum value is backward-compatible: for example, `consumer` may not be using that enum at all.

**What?**
Allow enums to be output as simple strings/ints to the OpenAPI definition, making then effectively open-ended from the client validation perspective.