### PR TITLE
Enable optional health checks

### DIFF
--- a/microcosm_flask/tests/conventions/test_health.py
+++ b/microcosm_flask/tests/conventions/test_health.py
@@ -2,16 +2,45 @@
 Health check convention tests.
 
 """
-from json import loads
-
 from hamcrest import assert_that, equal_to, is_
 from microcosm.api import create_object_graph
 from microcosm.loaders import load_from_dict
+from parameterized import parameterized
 
 
 def test_health_check():
     """
     Default health check returns OK.
+
+    """
+    graph = create_object_graph(name="example", testing=True)
+    graph.use("health_convention")
+
+    client = graph.flask.test_client()
+
+    graph.health_convention.optional_checks["foo"] = _health_check()
+
+    response = client.get("/api/health")
+    assert_that(response.status_code, is_(equal_to(200)))
+    assert_that(response.json, is_(equal_to({
+        "name": "example",
+        "ok": True,
+        "checks": {
+            "build_num": {
+                "message": "undefined",
+                "ok": True
+            },
+            "sha1": {
+                "message": "undefined",
+                "ok": True
+            },
+        },
+    })))
+
+
+def test_health_check_required_check_failed():
+    """
+    Should return 503 on health check failure.
 
     """
     loader = load_from_dict(
@@ -24,10 +53,44 @@ def test_health_check():
 
     client = graph.flask.test_client()
 
+    graph.health_convention.checks["foo"] = _health_check(False)
+
     response = client.get("/api/health")
+
+    assert_that(response.status_code, is_(equal_to(503)))
+    assert_that(response.json, is_(equal_to({
+        "name": "example",
+        "ok": False,
+        "checks": {
+            "foo": {
+                "message": "failure!",
+                "ok": False,
+            },
+        },
+    })))
+
+
+def test_health_check_optional_check_failed():
+    """
+    Optional checks should not be evaluated by default
+
+    """
+    loader = load_from_dict(
+        health_convention=dict(
+            include_build_info="false",
+        ),
+    )
+    graph = create_object_graph(name="example", testing=True, loader=loader)
+    graph.use("health_convention")
+
+    client = graph.flask.test_client()
+
+    graph.health_convention.optional_checks["foo"] = _health_check(False)
+
+    response = client.get("/api/health")
+
     assert_that(response.status_code, is_(equal_to(200)))
-    data = loads(response.get_data().decode("utf-8"))
-    assert_that(data, is_(equal_to({
+    assert_that(response.json, is_(equal_to({
         "name": "example",
         "ok": True,
     })))
@@ -39,10 +102,9 @@ def test_health_check_with_build_info():
 
     client = graph.flask.test_client()
 
-    response = client.get("/api/health")
+    response = client.get("/api/health", query_string=dict(full=True))
     assert_that(response.status_code, is_(equal_to(200)))
-    data = loads(response.get_data().decode("utf-8"))
-    assert_that(data, is_(equal_to(dict(
+    assert_that(response.json, is_(equal_to(dict(
         name="example",
         ok=True,
         checks=dict(
@@ -58,11 +120,15 @@ def test_health_check_with_build_info():
     ))))
 
 
-def test_health_check_custom_check():
-    """
-    Should return Custom health check results.
-
-    """
+@parameterized([
+    # When non-optional, always end up in the response
+    (False, False, True),
+    (False, True, True),
+    # Optional checks conditionally show up
+    (True, False, False),
+    (True, True, True),
+])
+def test_health_check_custom_checks(optional_check, full_check, expect_check_response):
     loader = load_from_dict(
         health_convention=dict(
             include_build_info="false",
@@ -73,28 +139,40 @@ def test_health_check_custom_check():
 
     client = graph.flask.test_client()
 
-    graph.health_convention.checks["foo"] = lambda graph: "hi"
+    if optional_check:
+        graph.health_convention.optional_checks["foo"] = _health_check()
+    else:
+        graph.health_convention.checks["foo"] = _health_check()
 
-    response = client.get("/api/health")
+    response = client.get("/api/health", query_string=dict(full=full_check))
     assert_that(response.status_code, is_(equal_to(200)))
-    data = loads(response.get_data().decode("utf-8"))
-    assert_that(data, is_(equal_to({
+
+    expected_response = {
         "name": "example",
         "ok": True,
-        "checks": {
-            "foo": {
-                "message": "hi",
-                "ok": True,
+    }
+    if expect_check_response:
+        expected_response.update({
+            "checks": {
+                "foo": {
+                    "message": "hi",
+                    "ok": True,
+                },
             },
-        },
-    })))
+        })
+
+    assert_that(response.json, is_(equal_to(expected_response)))
 
 
-def test_health_check_custom_check_failed():
-    """
-    Should return 503 on health check failure.
-
-    """
+@parameterized([
+    # When non-optional, always end up in the response and fail
+    (False, False, True),
+    (False, True, True),
+    # Optional checks conditionally show up, and only fail is specified
+    (True, False, False),
+    (True, True, True),
+])
+def test_health_check_custom_check_failed(optional_check, full_check, expect_failure):
     loader = load_from_dict(
         health_convention=dict(
             include_build_info="false",
@@ -104,22 +182,39 @@ def test_health_check_custom_check_failed():
     graph.use("health_convention")
 
     client = graph.flask.test_client()
+
+    if optional_check:
+        graph.health_convention.optional_checks["foo"] = _health_check(False)
+    else:
+        graph.health_convention.checks["foo"] = _health_check(False)
+
+    response = client.get("/api/health", query_string=dict(full=full_check))
+
+    if expect_failure:
+        assert_that(response.status_code, is_(equal_to(503)))
+        assert_that(response.json, is_(equal_to({
+            "name": "example",
+            "ok": False,
+            "checks": {
+                "foo": {
+                    "message": "failure!",
+                    "ok": False,
+                },
+            },
+        })))
+    else:
+        assert_that(response.status_code, is_(equal_to(200)))
+        assert_that(response.json, is_(equal_to({
+            "name": "example",
+            "ok": True,
+        })))
+
+
+def _health_check(success=True):
+    if success:
+        return lambda graph: "hi"
 
     def fail(graph):
         raise Exception("failure!")
 
-    graph.health_convention.checks["foo"] = fail
-
-    response = client.get("/api/health")
-    assert_that(response.status_code, is_(equal_to(503)))
-    data = loads(response.get_data().decode("utf-8"))
-    assert_that(data, is_(equal_to({
-        "name": "example",
-        "ok": False,
-        "checks": {
-            "foo": {
-                "message": "failure!",
-                "ok": False,
-            },
-        },
-    })))
+    return fail


### PR DESCRIPTION
Adds the ability to cordon off essential health checks from other
"diagnostic" type of checks.

The health endpoint is intended to be quick, non-intrusive, and accurate
with regards to providing a minimal guarantee of functionality for a
service. However, because there was only one avenue for adding any type of
"status" check here, the endpoint has trended to be slower over time.

This will allow those slower checks to be seen on-demand, but not
interfere with the default checks used by monitoring systems.

This also doesn't change any previous checks; services will have to
"opt-in" to this.

The main impetus here was noticing that some services have extensive
migration histories, causing some checks to hit nearly 100ms(!).