### PR TITLE
Fix recursive schemas

### DIFF
--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -104,11 +104,9 @@ class Schemas:
 
         for name, field in self.iter_fields(schema):
             if isinstance(field, Nested):
-                yield self.to_tuple(field.schema)
                 yield from self.iter_schemas(field.schema)
 
             if isinstance(field, List) and isinstance(field.inner, Nested):
-                yield self.to_tuple(field.inner.schema)
                 yield from self.iter_schemas(field.inner.schema)
 
     def to_tuple(self, schema: Schema) -> Tuple[str, Any]:

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -6,7 +6,7 @@ from typing import (
     Any,
     Callable,
     Iterable,
-    List as TypingList,
+    List as ListType,
     Mapping,
     Tuple,
     Type,
@@ -39,7 +39,7 @@ class Schemas:
 
         # XXX This will break if this class is ever instantiated and then has
         # `build` called more than once
-        self.seen_schemas: TypingList[Type[Schema]] = []
+        self.seen_schemas: ListType[Type[Schema]] = []
 
     def build(self, schema: Schema) -> Mapping[str, Any]:
         """

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -2,11 +2,11 @@
 Generate JSON Schema for Marshmallow schemas.
 
 """
-import typing.List
 from typing import (
     Any,
     Callable,
     Iterable,
+    List as TypingList,
     Mapping,
     Tuple,
     Type,
@@ -36,7 +36,10 @@ class Schemas:
     ):
         self.build_parameter = build_parameter
         self.strict_enums = strict_enums
-        self.seen_schemas: typing.List[Type[Schema]] = []
+
+        # XXX This will break if this class is ever instantiated and then has
+        # `build` called more than once
+        self.seen_schemas: TypingList[Type[Schema]] = []
 
     def build(self, schema: Schema) -> Mapping[str, Any]:
         """

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -6,8 +6,8 @@ from typing import (
     Any,
     Callable,
     Iterable,
-    List as ListType,
     Mapping,
+    Set,
     Tuple,
     Type,
 )
@@ -39,7 +39,7 @@ class Schemas:
 
         # NB: This will break if this class is ever instantiated and then has
         # `build` called more than once
-        self.seen_schemas: ListType[Type[Schema]] = []
+        self.seen_schemas: Set[Type[Schema]] = set()
 
     def build(self, schema: Schema) -> Mapping[str, Any]:
         """
@@ -95,7 +95,7 @@ class Schemas:
         if type(schema) in self.seen_schemas:
             return
 
-        self.seen_schemas.append(type(schema))
+        self.seen_schemas.add(type(schema))
 
         yield self.to_tuple(schema)
 

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -37,7 +37,7 @@ class Schemas:
         self.build_parameter = build_parameter
         self.strict_enums = strict_enums
 
-        # XXX This will break if this class is ever instantiated and then has
+        # NB: This will break if this class is ever instantiated and then has
         # `build` called more than once
         self.seen_schemas: ListType[Type[Schema]] = []
 

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -2,12 +2,14 @@
 Generate JSON Schema for Marshmallow schemas.
 
 """
+import typing.List
 from typing import (
     Any,
     Callable,
     Iterable,
     Mapping,
     Tuple,
+    Type,
 )
 
 from marshmallow import Schema
@@ -34,6 +36,7 @@ class Schemas:
     ):
         self.build_parameter = build_parameter
         self.strict_enums = strict_enums
+        self.seen_schemas: typing.List[Type[Schema]] = []
 
     def build(self, schema: Schema) -> Mapping[str, Any]:
         """
@@ -85,6 +88,11 @@ class Schemas:
         """
         if not schema:
             return
+
+        if type(schema) in self.seen_schemas:
+            return
+
+        self.seen_schemas.append(type(schema))
 
         yield self.to_tuple(schema)
 

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -99,7 +99,7 @@ class PersonCSVSchema(NewPersonSchema):
 
 
 class RecursiveSchema(Schema):
-    children = fields.List(fields.Nested(lambda: RecursiveSchema))
+    children = fields.List(fields.Nested(lambda: RecursiveSchema()))
 
 
 def pubsub_schema(fields):

--- a/microcosm_flask/tests/conventions/fixtures.py
+++ b/microcosm_flask/tests/conventions/fixtures.py
@@ -98,6 +98,10 @@ class PersonCSVSchema(NewPersonSchema):
         return column_order
 
 
+class RecursiveSchema(Schema):
+    children = fields.List(fields.Nested(lambda: RecursiveSchema))
+
+
 def pubsub_schema(fields):
     """
     Example usage of `add_associated_schema`, creating an additional decorator

--- a/microcosm_flask/tests/swagger/test_api.py
+++ b/microcosm_flask/tests/swagger/test_api.py
@@ -4,8 +4,8 @@ Test JSON Schema generation.
 """
 from hamcrest import assert_that, equal_to, is_
 
-from microcosm_flask.swagger.api import build_schema
-from microcosm_flask.tests.conventions.fixtures import NewPersonSchema
+from microcosm_flask.swagger.api import build_schema, iter_schemas
+from microcosm_flask.tests.conventions.fixtures import NewPersonSchema, RecursiveSchema
 
 
 def test_schema_generation():
@@ -63,4 +63,16 @@ def test_schema_generation_non_strict_enums():
             "firstName",
             "lastName",
         ],
+    })))
+
+
+def test_schema_generation_recursive():
+    schemas = list(iter_schemas(RecursiveSchema()))
+    name, schema = schemas[0]
+    assert_that(schema, is_(equal_to({
+        "type": "object",
+        "properties": {'children': {
+            'type': 'array',
+            'items': {'$ref': '#/definitions/Recursive'},
+        }},
     })))

--- a/microcosm_flask/tests/swagger/test_api.py
+++ b/microcosm_flask/tests/swagger/test_api.py
@@ -74,8 +74,8 @@ def test_schema_generation_recursive():
     name, schema = schemas[0]
     assert_that(schema, is_(equal_to({
         "type": "object",
-        "properties": {'children': {
-            'type': 'array',
-            'items': {'$ref': '#/definitions/Recursive'},
+        "properties": {"children": {
+            "type": "array",
+            "items": {"$ref": "#/definitions/Recursive"},
         }},
     })))

--- a/microcosm_flask/tests/swagger/test_api.py
+++ b/microcosm_flask/tests/swagger/test_api.py
@@ -67,9 +67,9 @@ def test_schema_generation_non_strict_enums():
 
 
 def test_schema_generation_recursive():
-    # BEWARE: Using `next` instead of `list()[0]` here wouldn't actually test
-    # what we want, because it would just grab the first item and not trigger
-    # the infinite recursion.
+    # BEWARE: Using `next(...)` instead of `list(...)[0]` here wouldn't
+    # actually test what we want, because it would just grab the first item and
+    # not trigger the infinite recursion.
     schemas = list(iter_schemas(RecursiveSchema()))
     name, schema = schemas[0]
     assert_that(schema, is_(equal_to({

--- a/microcosm_flask/tests/swagger/test_api.py
+++ b/microcosm_flask/tests/swagger/test_api.py
@@ -66,7 +66,7 @@ def test_schema_generation_non_strict_enums():
     })))
 
 
-def test_schema_generation_recursive():
+def test_schema_iteration_recursive():
     # BEWARE: Using `next(...)` instead of `list(...)[0]` here wouldn't
     # actually test what we want, because it would just grab the first item and
     # not trigger the infinite recursion.

--- a/microcosm_flask/tests/swagger/test_api.py
+++ b/microcosm_flask/tests/swagger/test_api.py
@@ -67,6 +67,9 @@ def test_schema_generation_non_strict_enums():
 
 
 def test_schema_generation_recursive():
+    # BEWARE: Using `next` instead of `list()[0]` here wouldn't actually test
+    # what we want, because it would just grab the first item and not trigger
+    # the infinite recursion.
     schemas = list(iter_schemas(RecursiveSchema()))
     name, schema = schemas[0]
     assert_that(schema, is_(equal_to({

--- a/microcosm_flask/tests/swagger/test_api.py
+++ b/microcosm_flask/tests/swagger/test_api.py
@@ -2,7 +2,12 @@
 Test JSON Schema generation.
 
 """
-from hamcrest import assert_that, equal_to, is_
+from hamcrest import (
+    assert_that,
+    equal_to,
+    has_length,
+    is_,
+)
 
 from microcosm_flask.swagger.api import build_schema, iter_schemas
 from microcosm_flask.tests.conventions.fixtures import NewPersonSchema, RecursiveSchema
@@ -71,6 +76,8 @@ def test_schema_iteration_recursive():
     # actually test what we want, because it would just grab the first item and
     # not trigger the infinite recursion.
     schemas = list(iter_schemas(RecursiveSchema()))
+    assert_that(schemas, has_length(1))
+
     name, schema = schemas[0]
     assert_that(name, is_("Recursive"))
     assert_that(schema, is_(equal_to({

--- a/microcosm_flask/tests/swagger/test_api.py
+++ b/microcosm_flask/tests/swagger/test_api.py
@@ -72,6 +72,7 @@ def test_schema_iteration_recursive():
     # not trigger the infinite recursion.
     schemas = list(iter_schemas(RecursiveSchema()))
     name, schema = schemas[0]
+    assert_that(name, is_("Recursive"))
     assert_that(schema, is_(equal_to({
         "type": "object",
         "properties": {"children": {


### PR DESCRIPTION
When trying to generate swagger spec for recursive schema definitions, we'd previously get a max recursion depth error because of an infinite descent.