### PR TITLE
[Don't Merge] Add some logging around serialization time.

### DIFF
--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -21,6 +21,10 @@ from microcosm_flask.conventions.registry import qs, request, response
 from microcosm_flask.operations import Operation
 from microcosm_flask.paging import OffsetLimitPage, OffsetLimitPageSchema, identity
 
+from microcosm_logging.decorators import logger
+
+from timeit import default_timer as timer
+
 
 class CRUDConvention(Convention):
 
@@ -126,13 +130,17 @@ class CRUDConvention(Convention):
             headers = encode_id_header(response_data)
             definition.header_func(headers, response_data)
             response_format = self.negotiate_response_content(definition.response_formats)
-            return dump_response_data(
+
+            serialization_start = timer()
+            out = dump_response_data(
                 definition.response_schema,
                 response_data,
                 status_code=Operation.Create.value.default_code,
                 headers=headers,
                 response_format=response_format,
             )
+            self.logger.info(f"Checkpoint -- Serialization took: {timer() - serialization_start:.2f}s")
+            return out
 
         create.__doc__ = "Create a new {}".format(ns.subject_name)
 

--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -3,9 +3,11 @@ Conventions for canonical CRUD endpoints.
 
 """
 from functools import wraps
+from timeit import default_timer as timer
 
 from inflection import pluralize
 from marshmallow import Schema
+from microcosm_logging.decorators import logger
 
 from microcosm_flask.conventions.base import Convention
 from microcosm_flask.conventions.encoding import (
@@ -21,11 +23,8 @@ from microcosm_flask.conventions.registry import qs, request, response
 from microcosm_flask.operations import Operation
 from microcosm_flask.paging import OffsetLimitPage, OffsetLimitPageSchema, identity
 
-from microcosm_logging.decorators import logger
 
-from timeit import default_timer as timer
-
-
+@logger
 class CRUDConvention(Convention):
 
     @property


### PR DESCRIPTION
Using for testing on sphinx to get a better idea of time spent during requests, particularly for creating plans where the response is very large and serialization is likely to be expensive.

Not to be merged.