### PR TITLE
[Do Not Merge] POC to enable interceptors/before filters in microcosm-flask

### DIFF
--- a/microcosm_flask/conventions/crud_adapter.py
+++ b/microcosm_flask/conventions/crud_adapter.py
@@ -3,7 +3,18 @@ Adapter between conventional crud functions and the `microcosm_postgres.store.St
 
 """
 from microcosm_flask.naming import name_for
+from functools import wraps
 
+def print_cool_stuff(api_method):
+    @wraps(api_method)
+    def print_cool_stuff(*args, **kwargs):
+        print("Hello, I'm executing before the retrieve method!")
+        print(f' Args: {args}')
+        print(f' Kwargs: {kwargs}')
+        return api_method(*args, **kwargs)
+
+
+    return print_cool_stuff
 
 class CRUDStoreAdapter:
     """
@@ -33,6 +44,7 @@ class CRUDStoreAdapter:
         model = self.store.model_class(id=identifier, **kwargs)
         return self.store.replace(identifier, model)
 
+    @print_cool_stuff
     def retrieve(self, **kwargs):
         identifier = kwargs.pop(self.identifier_key)
         return self.store.retrieve(identifier)


### PR DESCRIPTION
This is a crude example of how we could get Microcosm-flask to implement the interceptors pattern.
https://en.wikipedia.org/wiki/Interceptor_pattern

It seems like we could also use:

https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.before_request

But we have far less control over that and when it executes, and it doesn't seem to be easily implementable at a controller level? Potentially we could, as we have access to the graph, and the graph has access to an app, which is where we'd get the before_request from, but still we couldn't implement it on a route-by-route basis easily.

I think the advantage of this is twofold:
1. It's generic enough to be unintrusive in code
2. It's flexible enough to allow us to either import it and decorate routes as we go along, allowing us to change to OPA server calls as and when we please, either here at a top level or in the individual controllers themselves.

I think the disadvantage is:
1. This means that we will have to remember to decorate any and all "extra" controller methods going forward if we want them to have authentication.

I can't help but wonder if something like this could be better accomplished with middleware - but I don't know how middleware work in flask and so can't give a good answer yet. This sprang to mind because previously I built/used [coach](https://github.com/gocardless/coach) to do the same thing, which is fundamentally middleware based.


E.g. logs hitting the `company/:id` route in juvenal:

```
2021-01-07 14:03:27,575 - werkzeug - [INFO] -  * Running on http://127.0.0.1:5403/ (Press CTRL+C to quit)
2021-01-07 14:03:27,576 - werkzeug - [INFO] -  * Restarting with stat
2021-01-07 14:03:29,294 - juvenal - [INFO] - Skipping initialization because memory profiling is not enabled!
2021-01-07 14:03:29,319 - botocore.credentials - [INFO] - Found credentials in environment variables.
2021-01-07 14:03:29,480 - werkzeug - [WARNING] -  * Debugger is active!
2021-01-07 14:03:29,485 - werkzeug - [INFO] -  * Debugger PIN: 242-164-421
Hello, I'm executing before the retrieve method!
 Args: (<juvenal.routes.v2.company.controller.CompanyController object at 0x112052190>,)
 Kwargs: {'company_id': UUID('0cffbd9f-d9bd-4dbb-88fa-327ebaec1a4b')}
2021-01-07 14:03:33,722 - audit - [INFO] - {'operation': 'company.retrieve.v2', 'func': 'retrieve', 'method': 'GET', 'elapsed_time': 181.78987503051758, 'success': True, 'status_code': 200}
2021-01-07 14:03:33,722 - werkzeug - [INFO] - 127.0.0.1 - - [07/Jan/2021 14:03:33] "GET /api/v2/company/0cffbd9f-d9bd-4dbb-88fa-327ebaec1a4b HTTP/1.1" 200 -
```