### PR TITLE
Add byte order mark when outputting CSV for Excel

### DIFF
--- a/microcosm_flask/formatting/csv_formatter.py
+++ b/microcosm_flask/formatting/csv_formatter.py
@@ -9,6 +9,7 @@ from werkzeug import Response
 from werkzeug.utils import get_content_type
 
 from microcosm_flask.formatting.base import BaseFormatter
+from microcosm_flask.formatting.encoding import UTF_8, UTF_8_SIG
 
 
 class CSVFormatter(BaseFormatter):
@@ -29,12 +30,12 @@ class CSVFormatter(BaseFormatter):
     def build_response(self, response_data):
         response = Response(
             self.format(response_data),
-            content_type=get_content_type(self.content_type, 'utf-8')
+            content_type=get_content_type(self.content_type, UTF_8)
         )
 
         # start the output with U+FEFF BYTE ORDER MARK
         # to signal to Excel to import the text file as UTF-8 rather than a legacy encoding
-        response.charset = "utf-8-sig"
+        response.charset = UTF_8_SIG
         return response
 
     def get_column_names(self, list_response_data):

--- a/microcosm_flask/formatting/csv_formatter.py
+++ b/microcosm_flask/formatting/csv_formatter.py
@@ -5,6 +5,9 @@ CSV response formatting.
 from csv import QUOTE_MINIMAL, writer
 from io import StringIO
 
+from werkzeug import Response
+from werkzeug.utils import get_content_type
+
 from microcosm_flask.formatting.base import BaseFormatter
 
 
@@ -22,6 +25,17 @@ class CSVFormatter(BaseFormatter):
         headers["Content-Disposition"] = "attachment; filename=\"{}\"".format(filename)
 
         return headers
+
+    def build_response(self, response_data):
+        response = Response(
+            self.format(response_data),
+            content_type=get_content_type(self.content_type, 'utf-8')
+        )
+
+        # start the output with U+FEFF BYTE ORDER MARK
+        # to signal to Excel to import the text file as UTF-8 rather than a legacy encoding
+        response.charset = "utf-8-sig"
+        return response
 
     def get_column_names(self, list_response_data):
         response_fields = list(list_response_data[0].keys())

--- a/microcosm_flask/formatting/encoding.py
+++ b/microcosm_flask/formatting/encoding.py
@@ -1,0 +1,2 @@
+UTF_8 = "utf-8"
+UTF_8_SIG = "utf-8-sig"

--- a/microcosm_flask/tests/conventions/test_csv.py
+++ b/microcosm_flask/tests/conventions/test_csv.py
@@ -21,6 +21,7 @@ from microcosm_flask.conventions.base import EndpointDefinition
 from microcosm_flask.conventions.crud import configure_crud
 from microcosm_flask.enums import ResponseFormats
 from microcosm_flask.fields import EnumField, QueryStringList
+from microcosm_flask.formatting.encoding import UTF_8_SIG
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 from microcosm_flask.paging import OffsetLimitPageSchema
@@ -91,7 +92,7 @@ class TestCSV:
         if status_code == 204:
             response_lines = None
         else:
-            response_lines = [row for row in reader(StringIO(response.data.decode("utf-8-sig")))]
+            response_lines = [row for row in reader(StringIO(response.data.decode(UTF_8_SIG)))]
 
         # validate data if provided
         assert_that(

--- a/microcosm_flask/tests/conventions/test_csv.py
+++ b/microcosm_flask/tests/conventions/test_csv.py
@@ -91,7 +91,7 @@ class TestCSV:
         if status_code == 204:
             response_lines = None
         else:
-            response_lines = [row for row in reader(StringIO(response.data.decode("utf-8")))]
+            response_lines = [row for row in reader(StringIO(response.data.decode("utf-8-sig")))]
 
         # validate data if provided
         assert_that(

--- a/microcosm_flask/tests/formatting/test_csv_formatter.py
+++ b/microcosm_flask/tests/formatting/test_csv_formatter.py
@@ -2,6 +2,8 @@
 Test CSV formatting.
 
 """
+from codecs import BOM_UTF8
+
 from hamcrest import (
     assert_that,
     contains_inanyorder,
@@ -22,14 +24,14 @@ def test_make_response():
         dict(foo="baz"),
     ]))
 
-    assert_that(response.data, is_(equal_to(b"foo\r\nbar\r\nbaz\r\n")))
+    assert_that(response.data, is_(equal_to(BOM_UTF8 + b"foo\r\nbar\r\nbaz\r\n")))
     assert_that(response.content_type, is_(equal_to("text/csv; charset=utf-8")))
     assert_that(response.headers, contains_inanyorder(
         ("Content-Disposition", "attachment; filename=\"response.csv\""),
         ("Content-Type", "text/csv; charset=utf-8"),
         ("ETag", etag_for(
-            md5_hash='"a2ead3516dd1be4a3c7f45716c0a0eb7"',
-            spooky_hash='"02dee263db4f9326a3fbee9135939717"',
+            md5_hash='"d0366f8e71095c1b68e2ddfd551b3285"',
+            spooky_hash='"e264d2b6b13c5298cb2059716018aa4d"',
         )),
     ))
 
@@ -42,14 +44,14 @@ def test_make_response_tuples():
         ("d", "e", "f"),
     ]))
 
-    assert_that(response.data, is_(equal_to(b"a,b,c\r\nd,e,f\r\n")))
+    assert_that(response.data, is_(equal_to(BOM_UTF8 + b"a,b,c\r\nd,e,f\r\n")))
     assert_that(response.content_type, is_(equal_to("text/csv; charset=utf-8")))
     assert_that(response.headers, contains_inanyorder(
         ("Content-Disposition", "attachment; filename=\"response.csv\""),
         ("Content-Type", "text/csv; charset=utf-8"),
         ("ETag", etag_for(
-            md5_hash='"eb8bde290633452402b37aa580ca30e9"',
-            spooky_hash='"63b989eb36315937ef68206fb9fc3104"',
+            md5_hash='"22252aa7c314539c78dfa19dbf9af674"',
+            spooky_hash='"37cd063df88efefe1929f3cf4532b718"',
         )),
     ))
 
@@ -62,14 +64,14 @@ def test_make_response_list():
         ["d", "e", "f"],
     ]))
 
-    assert_that(response.data, is_(equal_to(b"a,b,c\r\nd,e,f\r\n")))
+    assert_that(response.data, is_(equal_to(BOM_UTF8 + b"a,b,c\r\nd,e,f\r\n")))
     assert_that(response.content_type, is_(equal_to("text/csv; charset=utf-8")))
     assert_that(response.headers, contains_inanyorder(
         ("Content-Disposition", "attachment; filename=\"response.csv\""),
         ("Content-Type", "text/csv; charset=utf-8"),
         ("ETag", etag_for(
-            md5_hash='"eb8bde290633452402b37aa580ca30e9"',
-            spooky_hash='"63b989eb36315937ef68206fb9fc3104"',
+            md5_hash='"22252aa7c314539c78dfa19dbf9af674"',
+            spooky_hash='"37cd063df88efefe1929f3cf4532b718"',
         )),
     ))
 
@@ -85,13 +87,13 @@ def test_make_response_ordered():
         )
     ]))
 
-    assert_that(response.data, is_(equal_to(b"id,firstName,lastName\r\nme,First,Last\r\n")))
+    assert_that(response.data, is_(equal_to(BOM_UTF8 + b"id,firstName,lastName\r\nme,First,Last\r\n")))
     assert_that(response.content_type, is_(equal_to("text/csv; charset=utf-8")))
     assert_that(response.headers, contains_inanyorder(
         ("Content-Disposition", "attachment; filename=\"response.csv\""),
         ("Content-Type", "text/csv; charset=utf-8"),
         ("ETag", etag_for(
-            md5_hash='"4480bd6748cf93740490ebeee7eae1fe"',
-            spooky_hash='"0a7f40b47efb0a197b180444c4911b17"',
+            md5_hash='"79e41b38792fdca793f61791ef55e026"',
+            spooky_hash='"994df8aa1632af103265ebeae37a3804"',
         )),
     ))

--- a/microcosm_flask/tests/formatting/test_json_formatter.py
+++ b/microcosm_flask/tests/formatting/test_json_formatter.py
@@ -28,6 +28,6 @@ def test_make_response():
         ("Content-Length", "14"),
         ("ETag", etag_for(
             md5_hash='"2f8acf3fe5e5c2839a04b7677d9399b8"',
-            spooky_hash='"af072b51e1eb2a8d7b2ab84dab972674"',
+            spooky_hash='"053dd24aa81b8b2c3243143a14834d37"',
         )),
     ))


### PR DESCRIPTION
By default, Excel will open text CSV files as a legacy encoding, but it
will detect a BOM as an in-band indiction that the file is encoded as
UTF-8.

When formatting CSVs, use Python's utf-8-sig codec to add the BOM
to the response body.