### PR TITLE
Update landing page to use optional full health check param

### DIFF
--- a/microcosm_flask/conventions/landing.py
+++ b/microcosm_flask/conventions/landing.py
@@ -85,7 +85,7 @@ def configure_landing(graph):   # noqa: C901
         """
         config = graph.config_convention.to_dict()
         env = get_env_file_commands(config, graph.metadata.name)
-        health = graph.health_convention.to_dict()
+        health = graph.health_convention.to_dict(full=True)
         properties = get_properties_and_version()
         swagger_versions = get_swagger_versions()
 

--- a/microcosm_flask/templates/landing.py
+++ b/microcosm_flask/templates/landing.py
@@ -75,7 +75,7 @@ template = """
             <h3 class="text-center">{{ description }}</h2>
             {%- endif -%}
             <div class="section section-health">
-                <h2 class="no-margin"><a href="api/health">Health</a></h2>
+                <h2 class="no-margin"><a href="api/health?full=true">Health</a></h2>
                 <div>
                     <h2 class="no-margin float-left"><a href="api/config">Config</a></h2>
                 </div>


### PR DESCRIPTION
- update landing page to show optional full health check data

Why?

The default health endpoint returns a minimum set of health data. This
is generally used to make sure a service is "up".

The landing page is meant to be a human consumable resource showing
all health and config data. Since this view is meant for humans to see
a complete view of a service it makes sense to show full health check
data.