### PR TITLE
GLOB-61031: Add graph component for catch-all route

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,9 +183,24 @@ jobs:
       - attach_workspace:
           at: ~/repo
       - run:
-          name: Deploy
+          name: Override version
           command: |
-            echo "Not publishing package!"
+            sed -i -e "s/^\(version = \".*\)\"$/\1.dev${CIRCLE_BUILD_NUM}\"/" setup.py
+      - run:
+          name: Authenticate
+          command: |
+            echo "[distutils]" > ~/.pypirc
+            echo "index-servers =" >> ~/.pypirc
+            echo "    jfrog" >> ~/.pypirc
+            echo >> ~/.pypirc
+            echo "[jfrog]" >> ~/.pypirc
+            echo "repository:https://globality.jfrog.io/globality/api/pypi/pypi" >> ~/.pypirc
+            echo "username:$JFROG_USERNAME" >> ~/.pypirc
+            echo "password:$JFROG_PASSWORD" >> ~/.pypirc
+            echo >> ~/.pypirc
+      - run:
+          name: Publish
+          command: python setup.py sdist upload -r jfrog
 
   publish_library:
     <<: *defaults
@@ -255,6 +270,9 @@ workflows:
             - test
             - lint
             - typehinting
+          filters:
+            branches:
+              ignore: master
       - typehinting:
           context: 
           - Globality-Common

--- a/microcosm_flask/conventions/catchall.py
+++ b/microcosm_flask/conventions/catchall.py
@@ -1,0 +1,26 @@
+"""
+Flask's default behavior is to return a 404 for a route the app can't match.
+For backend services that are not queried directly by a front-end it can be useful
+to specify a different HTTP code, to differentiate between a nonexistent resource
+on a well-understood path (e.g. GET /user/123) and a nonexistent (e.g. GET /ursr).
+
+In particular, this can allow a reverse-proxy to identify cases where it is routing a request
+based on an outdated DNS entry.
+
+
+"""
+from microcosm.api import binding, defaults, typed
+
+
+@binding("catchall_convention")
+@defaults(
+    fallback_http_code=typed(int, default_value=421),
+)
+def configure_catchall_convention(graph):
+    fallback_http_code = graph.config.catchall_convention.fallback_http_code
+
+    @graph.flask.route("/<path:path>", methods=["GET", "POST", "PATCH", "PUT", "DELETE"])
+    def catch_all(path):
+        return "Unknown path", fallback_http_code
+
+    return catch_all

--- a/microcosm_flask/conventions/catchall.py
+++ b/microcosm_flask/conventions/catchall.py
@@ -20,7 +20,8 @@ def configure_catchall_convention(graph):
     fallback_http_code = graph.config.catchall_convention.fallback_http_code
 
     @graph.flask.route("/<path:path>", methods=["GET", "POST", "PATCH", "PUT", "DELETE"])
-    def catch_all(path):
+    @graph.audit
+    def catchall_route(path):
         return "Unknown path", fallback_http_code
 
-    return catch_all
+    return catchall_route

--- a/microcosm_flask/conventions/catchall.py
+++ b/microcosm_flask/conventions/catchall.py
@@ -10,11 +10,12 @@ based on an outdated DNS entry, and to directly retry the request on a different
 
 """
 from microcosm.api import binding, defaults, typed
+from werkzeug.exceptions import abort
 
 
 @binding("catchall_convention")
 @defaults(
-    fallback_http_code=typed(int, default_value=421),
+    fallback_http_code=typed(int, default_value=501),
 )
 def configure_catchall_convention(graph):
     fallback_http_code = graph.config.catchall_convention.fallback_http_code
@@ -22,6 +23,6 @@ def configure_catchall_convention(graph):
     @graph.flask.route("/<path:path>", methods=["GET", "POST", "PATCH", "PUT", "DELETE"])
     @graph.audit
     def catchall_route(path):
-        return "Unknown path", fallback_http_code
+        abort(fallback_http_code, f"Unknown path {path}")
 
     return catchall_route

--- a/microcosm_flask/conventions/catchall.py
+++ b/microcosm_flask/conventions/catchall.py
@@ -4,8 +4,8 @@ For backend services that are not queried directly by a front-end it can be usef
 to specify a different HTTP code, to differentiate between a nonexistent resource
 on a well-understood path (e.g. GET /user/123) and a nonexistent (e.g. GET /ursr).
 
-In particular, this can allow a reverse-proxy to identify cases where it is routing a request
-based on an outdated DNS entry.
+In particular, this can allow a load-balancer to identify cases where it is routing a request
+based on an outdated DNS entry, and to directly retry the request on a different instance.
 
 
 """

--- a/microcosm_flask/swagger/parameters/enum.py
+++ b/microcosm_flask/swagger/parameters/enum.py
@@ -61,7 +61,7 @@ class EnumParameterBuilder(ParameterBuilder):
     def _parse_enum_values(self, field: Field) -> Sequence:
         return [
             choice.value if field.by_value else choice.name  # type: ignore
-            for choice in field.enum
+            for choice in field.enum  # type: ignore
         ]
 
     def parse_enum_values(self, field: Field) -> Optional[Sequence]:

--- a/microcosm_flask/swagger/parameters/enum.py
+++ b/microcosm_flask/swagger/parameters/enum.py
@@ -59,7 +59,7 @@ class EnumParameterBuilder(ParameterBuilder):
             raise Exception(f"Cannot infer enum type for field: {field.name}")
 
     def _parse_enum_values(self, field: Field) -> Sequence:
-        enum = getattr(field, "enum", None)
+        enum = getattr(field, "enum")
         return [
             choice.value if field.by_value else choice.name  # type: ignore
             for choice in enum

--- a/microcosm_flask/swagger/parameters/enum.py
+++ b/microcosm_flask/swagger/parameters/enum.py
@@ -59,10 +59,9 @@ class EnumParameterBuilder(ParameterBuilder):
             raise Exception(f"Cannot infer enum type for field: {field.name}")
 
     def _parse_enum_values(self, field: Field) -> Sequence:
-        enum = getattr(field, "enum")
         return [
             choice.value if field.by_value else choice.name  # type: ignore
-            for choice in enum
+            for choice in field.enum
         ]
 
     def parse_enum_values(self, field: Field) -> Optional[Sequence]:

--- a/microcosm_flask/swagger/parameters/enum.py
+++ b/microcosm_flask/swagger/parameters/enum.py
@@ -59,9 +59,11 @@ class EnumParameterBuilder(ParameterBuilder):
             raise Exception(f"Cannot infer enum type for field: {field.name}")
 
     def _parse_enum_values(self, field: Field) -> Sequence:
+        if not isinstance(field, EnumField):
+            raise Exception(f"Cannot parse enum values for non-enum fields: {field.name}")
         return [
-            choice.value if field.by_value else choice.name  # type: ignore
-            for choice in field.enum  # type: ignore
+            choice.value if field.by_value else choice.name
+            for choice in field.enum
         ]
 
     def parse_enum_values(self, field: Field) -> Optional[Sequence]:

--- a/microcosm_flask/tests/conventions/test_catchall.py
+++ b/microcosm_flask/tests/conventions/test_catchall.py
@@ -1,0 +1,50 @@
+"""
+Test catch-all route
+
+"""
+from hamcrest import assert_that, equal_to, is_
+from microcosm.api import create_object_graph
+
+
+def make_routes(graph):
+    """
+    Create a few routes
+
+    """
+    @graph.flask.route("/")
+    def root_route():
+        return "root"
+
+    @graph.flask.route("/something/<string:id>")
+    def id_route(id):
+        if id in ["123", "456"]:
+            return id
+        return "Resource not found", 404
+
+
+class TestCatchall:
+    def setup(self):
+        self.graph = create_object_graph(name="example", testing=True)
+        self.graph.use("catchall_convention")
+
+        make_routes(self.graph)
+
+        self.client = self.graph.flask.test_client()
+
+    def test_catchall(self):
+        # Check that the catch-all route works
+        response_get = self.client.get("/api/v1/nonexistent_uri")
+        assert_that(response_get.status_code, is_(equal_to(421)))
+
+        response_post = self.client.get("/api/v1/nonexistent_uri")
+        assert_that(response_post.status_code, is_(equal_to(421)))
+
+        # Check that existing routes still resolve correctly
+        response_root = self.client.get("/")
+        assert_that(response_root.status_code, is_(equal_to(200)))
+
+        response_id = self.client.get("/something/123")
+        assert_that(response_id.status_code, is_(equal_to(200)))
+
+        response_id = self.client.get("/something/789")
+        assert_that(response_id.status_code, is_(equal_to(404)))

--- a/microcosm_flask/tests/conventions/test_catchall.py
+++ b/microcosm_flask/tests/conventions/test_catchall.py
@@ -34,14 +34,14 @@ class TestCatchall:
     def test_catchall(self):
         # Check that the catch-all route works
         response_get = self.client.get("/api/v1/nonexistent_uri")
-        assert_that(response_get.status_code, is_(equal_to(421)))
+        assert_that(response_get.status_code, is_(equal_to(501)))
 
         response_post = self.client.get("/api/v1/nonexistent_uri")
-        assert_that(response_post.status_code, is_(equal_to(421)))
+        assert_that(response_post.status_code, is_(equal_to(501)))
 
         # Note that the catchall convention overrides the usual HTTP 405 cases
         response_id = self.client.post("/something/123")
-        assert_that(response_id.status_code, is_(equal_to(421)))
+        assert_that(response_id.status_code, is_(equal_to(501)))
 
         # Check that existing routes still resolve correctly
         response_root = self.client.get("/")

--- a/microcosm_flask/tests/conventions/test_catchall.py
+++ b/microcosm_flask/tests/conventions/test_catchall.py
@@ -39,6 +39,10 @@ class TestCatchall:
         response_post = self.client.get("/api/v1/nonexistent_uri")
         assert_that(response_post.status_code, is_(equal_to(421)))
 
+        # Note that the catchall convention overrides the usual HTTP 405 cases
+        response_id = self.client.post("/something/123")
+        assert_that(response_id.status_code, is_(equal_to(421)))
+
         # Check that existing routes still resolve correctly
         response_root = self.client.get("/")
         assert_that(response_root.status_code, is_(equal_to(200)))

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
             "basic_auth = microcosm_flask.basic_auth:configure_basic_auth_decorator",
             "build_info_convention = microcosm_flask.conventions.build_info:configure_build_info",
             "build_route_path = microcosm_flask.paths:RoutePathBuilder",
+            "catchall_convention = microcosm_flask.conventions.catchall:configure_catchall_convention",
             "discovery_convention = microcosm_flask.conventions.discovery:configure_discovery",
             "error_handlers = microcosm_flask.errors:configure_error_handlers",
             "flask = microcosm_flask.factories:configure_flask",


### PR DESCRIPTION
https://globality.atlassian.net/browse/GLOB-61031

## Why?
Flask's default behavior when receiving a request for a non-existent route is to return a 404.

While that is the obvious right choice for any server returning a response to a web browser, in a backend environment it can help to have the ability to differentiate the cases of a correct path but missing resource (i.e. a `404` on /api/v1/user/<uuid>) from the case of a wrong path.

This is particularly useful in an envionment where service instances are spun up and down often enough that propagation of DNS records can lag behind – meaning that a load balancer can end up sending a request intended for one service to another. A different HTTP code for a wrong path allows tuning the load balancer behavior to mark the corresponding DNS record as stale when receiving that HTTP code.

**Note:** I'm aware that this is a slight abuse of HTTP codes; the practical benefits make this worth it.

## What?
Add `catchall_convention` component adding a catch-all Flask route.
Flask/Werkzeug's routing priority order is documented [here](https://github.com/pallets/werkzeug/blob/347291802fcf89bc89660cc9dc62eb1303337bc2/src/werkzeug/routing.py#L1133). This catch-all route will always have fewer static parts than any other, and as a result should come last in priority. This means it won't override any existing route.

## Testing
* [x] Deployed on a dev environment and ran automation tests, to verify this has no adverse effects.