### PR TITLE
unpin flask and use sha1 for etag checks

### DIFF
--- a/microcosm_flask/formatting/base.py
+++ b/microcosm_flask/formatting/base.py
@@ -60,7 +60,7 @@ class BaseFormatter(metaclass=ABCMeta):
             return
 
         if not spooky:
-            # use built-in md5
+            # use built-in SHA-1
             response.add_etag()
             return
 

--- a/microcosm_flask/tests/formatting/base.py
+++ b/microcosm_flask/tests/formatting/base.py
@@ -4,9 +4,9 @@ Common formatting test code.
 """
 
 
-def etag_for(md5_hash, spooky_hash):
+def etag_for(sha1_hash, spooky_hash):
     try:
         import spooky  # noqa: F401
         return spooky_hash
     except ImportError:
-        return md5_hash
+        return sha1_hash

--- a/microcosm_flask/tests/formatting/test_csv_formatter.py
+++ b/microcosm_flask/tests/formatting/test_csv_formatter.py
@@ -30,7 +30,7 @@ def test_make_response():
         ("Content-Disposition", "attachment; filename=\"response.csv\""),
         ("Content-Type", "text/csv; charset=utf-8"),
         ("ETag", etag_for(
-            md5_hash='"d0366f8e71095c1b68e2ddfd551b3285"',
+            sha1_hash='"a1ce622dcb1bcf03565e4d6925adb1e752d86080"',
             spooky_hash='"e264d2b6b13c5298cb2059716018aa4d"',
         )),
     ))
@@ -50,7 +50,7 @@ def test_make_response_tuples():
         ("Content-Disposition", "attachment; filename=\"response.csv\""),
         ("Content-Type", "text/csv; charset=utf-8"),
         ("ETag", etag_for(
-            md5_hash='"22252aa7c314539c78dfa19dbf9af674"',
+            sha1_hash='"e4020b884f3ea6fe2bdd18dbf50495bcc32bb430"',
             spooky_hash='"37cd063df88efefe1929f3cf4532b718"',
         )),
     ))
@@ -70,7 +70,7 @@ def test_make_response_list():
         ("Content-Disposition", "attachment; filename=\"response.csv\""),
         ("Content-Type", "text/csv; charset=utf-8"),
         ("ETag", etag_for(
-            md5_hash='"22252aa7c314539c78dfa19dbf9af674"',
+            sha1_hash='"e4020b884f3ea6fe2bdd18dbf50495bcc32bb430"',
             spooky_hash='"37cd063df88efefe1929f3cf4532b718"',
         )),
     ))
@@ -93,7 +93,7 @@ def test_make_response_ordered():
         ("Content-Disposition", "attachment; filename=\"response.csv\""),
         ("Content-Type", "text/csv; charset=utf-8"),
         ("ETag", etag_for(
-            md5_hash='"79e41b38792fdca793f61791ef55e026"',
+            sha1_hash='"9f2b4c62a05e78d0417a92741321f03e3382cb56"',
             spooky_hash='"994df8aa1632af103265ebeae37a3804"',
         )),
     ))

--- a/microcosm_flask/tests/formatting/test_html_formatter.py
+++ b/microcosm_flask/tests/formatting/test_html_formatter.py
@@ -23,7 +23,7 @@ def test_make_response():
         ("Content-Length", "27"),
         ("Content-Type", "text/html; charset=utf-8"),
         ("ETag", etag_for(
-            md5_hash='"016a5a134aceb7391754f03893d30e06"',
+            sha1_hash='"ec3f3fe41fa61bd5d4e63dc0b4b28b4d33624166"',
             spooky_hash='"1a639cef905e11904ac33817c37997dd"',
         )),
     ))

--- a/microcosm_flask/tests/formatting/test_json_formatter.py
+++ b/microcosm_flask/tests/formatting/test_json_formatter.py
@@ -23,11 +23,12 @@ def test_make_response():
 
     assert_that(response.data, is_(equal_to(b'{"foo":"bar"}\n')))
     assert_that(response.content_type, is_(equal_to("application/json")))
+    print("hello", response.headers)
     assert_that(response.headers, contains_inanyorder(
         ("Content-Type", "application/json"),
         ("Content-Length", "14"),
         ("ETag", etag_for(
-            md5_hash='"2f8acf3fe5e5c2839a04b7677d9399b8"',
+            sha1_hash='"15abb9bce7cf6dc65ab2f6bc6aebfd406448434b"',
             spooky_hash='"053dd24aa81b8b2c3243143a14834d37"',
         )),
     ))

--- a/microcosm_flask/tests/formatting/test_json_formatter.py
+++ b/microcosm_flask/tests/formatting/test_json_formatter.py
@@ -23,7 +23,6 @@ def test_make_response():
 
     assert_that(response.data, is_(equal_to(b'{"foo":"bar"}\n')))
     assert_that(response.content_type, is_(equal_to("application/json")))
-    print("hello", response.headers)
     assert_that(response.headers, contains_inanyorder(
         ("Content-Type", "application/json"),
         ("Content-Length", "14"),

--- a/microcosm_flask/tests/formatting/test_text_formatter.py
+++ b/microcosm_flask/tests/formatting/test_text_formatter.py
@@ -23,7 +23,7 @@ def test_make_response():
         ("Content-Length", "12"),
         ("Content-Type", "text/plain; charset=utf-8"),
         ("ETag", etag_for(
-            md5_hash='"ed076287532e86365e841e92bfc50d8c"',
+            sha1_hash='"2ef7bde608ce5404e97d5f042f95f89f1c232871"',
             spooky_hash='"79aa5e0a1f595e330d662c97a7763cdc"',
         )),
     ))

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     keywords="microcosm",
     install_requires=[
         "Flask>=2",
-        "Flask>=1.0.2",
         "Flask-BasicAuth>=0.2.0",
         "Flask-Cors>=3.0.7",
         "Flask-UUID>=0.2",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     python_requires=">=3.6",
     keywords="microcosm",
     install_requires=[
-        "Flask<2",
+        "Flask>=2",
         "Flask>=1.0.2",
         "Flask-BasicAuth>=0.2.0",
         "Flask-Cors>=3.0.7",


### PR DESCRIPTION
Starting with flask 2, flask requires a version of werkzeug where the [generate_etag](https://github.com/pallets/werkzeug/blame/347291802fcf89bc89660cc9dc62eb1303337bc2/src/werkzeug/http.py#L917) function has changed from using MD5 to SHA-1.

### Changes in this MR

- bumped flask to >= 2 
- updated all md5 etag hashes in tests to sha1

### Links

https://globality.atlassian.net/browse/GLOB-61300