### PR TITLE
Add Swagger UI endpoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,9 +6,10 @@ microcosm_flask/tests
 !MANIFEST.in
 !README.md
 !HISTORY.rst
-!requirements.txt
+!requirements*.txt
 !setup.py
 !setup.cfg
+!mypy.ini
 !pyproject.toml
 !conftest.py
 **/*.pyc

--- a/.globality/build.json
+++ b/.globality/build.json
@@ -6,6 +6,10 @@
     "entrypoint": {
       "pre_test_commands": [
         "pip --quiet install microcosm-metrics"
+      ],
+      "pre_typehinting_commands": [
+        "pip install types-python-dateutil",
+        "pip install types-setuptools"
       ]
     },
     "name": "microcosm-flask",

--- a/.globality/build.json
+++ b/.globality/build.json
@@ -1,5 +1,8 @@
 {
   "params": {
+    "docker": {
+      "docker_tag": "python:3.7-stretch"
+    },
     "entrypoint": {
       "pre_test_commands": [
         "pip --quiet install microcosm-metrics"
@@ -11,5 +14,5 @@
     }
   },
   "type": "python-library",
-  "version": "2020.51.0"
+  "version": "2022.23.1"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@
 #
 
 # ----------- deps -----------
-# Install from Debian Stretch with modern Python support
-FROM python:slim-stretch as deps
+FROM python:3.7-stretch as deps
 
 #
 # Most services will use the same set of packages here, though a few will install
@@ -84,7 +83,6 @@ RUN pip install --no-cache-dir --upgrade --extra-index-url ${EXTRA_INDEX_URL} /s
     apt-get remove --purge -y ${BUILD_PACKAGES} && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
-
 
 # ----------- final -----------
 FROM base

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+#  This file is auto generated with globality-build.
+#  You should not make any changes to this file manually
+#
+#  See: http://github.com/globality-corp/globality-build
+
 # Container entrypoint to simplify running the production and dev servers.
 
 # Entrypoint conventions are as follows:
@@ -22,19 +27,17 @@ if [ "$1" = "test" ]; then
    pip --quiet install microcosm-metrics
    # Install standard test dependencies; YMMV
    pip --quiet install \
-       .[test] nose PyHamcrest coverage
-   exec nosetests
+       .[test]
+   nosetests
 elif [ "$1" = "lint" ]; then
    # Install standard linting dependencies; YMMV
    pip --quiet install \
-       .[lint] flake8 flake8-print flake8-logging-format flake8-isort
-   flake8 ${NAME}
+       .[lint]
+   exec flake8 ${NAME}
 elif [ "$1" = "typehinting" ]; then
    # Install standard type-linting dependencies
-   pip install types-python-dateutil
-   pip install types-setuptools
    pip --quiet install mypy
-   mypy ${NAME} --ignore-missing-imports
+   exec mypy ${NAME} --ignore-missing-imports
 else
    echo "Cannot execute $@"
    exit 3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,8 @@ elif [ "$1" = "lint" ]; then
        .[lint]
    exec flake8 ${NAME}
 elif [ "$1" = "typehinting" ]; then
+   pip install types-python-dateutil
+   pip install types-setuptools
    # Install standard type-linting dependencies
    pip --quiet install mypy
    exec mypy ${NAME} --ignore-missing-imports

--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -69,7 +69,7 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        search.__doc__ = "Search the collection of all {}".format(pluralize(ns.subject_name))
+        search.__doc__ = search.__doc__ or "Search the collection of all {}".format(pluralize(ns.subject_name))
 
     def configure_count(self, ns, definition):
         """
@@ -102,7 +102,7 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        count.__doc__ = "Count the size of the collection of all {}".format(pluralize(ns.subject_name))
+        count.__doc__ = count.__doc__ or "Count the size of the collection of all {}".format(pluralize(ns.subject_name))
 
     def configure_create(self, ns, definition):
         """
@@ -134,7 +134,7 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        create.__doc__ = "Create a new {}".format(ns.subject_name)
+        create.__doc__ = create.__doc__ or "Create a new {}".format(ns.subject_name)
 
     def configure_updatebatch(self, ns, definition):
         """
@@ -168,7 +168,7 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        update_batch.__doc__ = "Update a batch of {}".format(ns.subject_name)
+        update_batch.__doc__ = update_batch.__doc__ or "Update a batch of {}".format(ns.subject_name)
 
     def configure_deletebatch(self, ns, definition):
         """
@@ -202,7 +202,7 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        delete_batch.__doc__ = "Delete a batch of {}".format(ns.subject_name)
+        delete_batch.__doc__ = delete_batch.__doc__ or "Delete a batch of {}".format(ns.subject_name)
 
     def configure_retrieve(self, ns, definition):
         """
@@ -235,7 +235,7 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        retrieve.__doc__ = "Retrieve a {} by id".format(ns.subject_name)
+        retrieve.__doc__ = retrieve.__doc__ or "Retrieve a {} by id".format(ns.subject_name)
 
     def configure_delete(self, ns, definition):
         """
@@ -268,7 +268,7 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        delete.__doc__ = "Delete a {} by id".format(ns.subject_name)
+        delete.__doc__ = delete.__doc__ or "Delete a {} by id".format(ns.subject_name)
 
     def configure_replace(self, ns, definition):
         """
@@ -302,7 +302,7 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        replace.__doc__ = "Create or update a {} by id".format(ns.subject_name)
+        replace.__doc__ = replace.__doc__ or "Create or update a {} by id".format(ns.subject_name)
 
     def configure_update(self, ns, definition):
         """
@@ -333,7 +333,7 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        update.__doc__ = "Update some or all of a {} by id".format(ns.subject_name)
+        update.__doc__ = update.__doc__ or "Update some or all of a {} by id".format(ns.subject_name)
 
     def configure_createcollection(self, ns, definition):
         """
@@ -373,7 +373,9 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        create_collection.__doc__ = "Create the collection of {}".format(pluralize(ns.subject_name))
+        create_collection.__doc__ = (
+            create_collection.__doc__ or "Create the collection of {}".format(pluralize(ns.subject_name))
+        )
 
 
 def configure_crud(graph, ns, mappings):

--- a/microcosm_flask/conventions/landing.py
+++ b/microcosm_flask/conventions/landing.py
@@ -68,12 +68,13 @@ def configure_landing(graph):   # noqa: C901
         links = {key: value for (key, value) in graph.config.landing_convention.get("links", {}).items()}
 
         # add links for each swagger version
-        for swagger_version in swagger_versions:
-            links["swagger {}". format(swagger_version)] = "api/{}/swagger".format(swagger_version)
+        for version in swagger_versions:
+            links[f"Swagger {version}"] = f"api/{version}/swagger"
+            links[f"Swagger {version} UI"] = f"api/{version}/swagger/docs"
 
         # add link to home page
         if hasattr(properties, "url"):
-            links["home page"] = properties.url
+            links["Home page"] = properties.url
 
         return links
 

--- a/microcosm_flask/conventions/swagger.py
+++ b/microcosm_flask/conventions/swagger.py
@@ -14,6 +14,7 @@ from microcosm_flask.conventions.registry import iter_endpoints, request
 from microcosm_flask.namespaces import Namespace
 from microcosm_flask.operations import Operation
 from microcosm_flask.swagger.definitions import build_swagger
+from microcosm_flask.templates import swagger_ui
 
 
 class ValidateSwaggerSchema(Schema):
@@ -58,6 +59,10 @@ class SwaggerConvention(Convention):
             swagger = build_swagger(self.graph, ns, self.find_matching_endpoints(ns), **request_data)
             g.hide_body = True
             return make_response(swagger)
+
+        @self.add_route(f"{ns.singleton_path}/docs", Operation.Query, ns)
+        def swagger_docs():
+            return swagger_ui.html
 
 
 @defaults(

--- a/microcosm_flask/swagger/definitions.py
+++ b/microcosm_flask/swagger/definitions.py
@@ -17,6 +17,7 @@ Note that:
 
 """
 from enum import Enum, unique
+from inspect import getdoc
 from logging import getLogger
 from typing import (
     Dict,
@@ -296,12 +297,17 @@ def build_operation(operation, ns, rule, func):
     Build an operation definition.
 
     """
+    description = ""
+    if func.__doc__:
+        description = getdoc(func)
+
     swagger_operation = swagger.Operation(
         operationId=operation_name(operation, ns),
         parameters=swagger.ParametersList([
         ]),
         responses=swagger.Responses(),
         tags=[ns.subject_name],
+        description=description,
     )
 
     # custom header parameter

--- a/microcosm_flask/templates/landing.py
+++ b/microcosm_flask/templates/landing.py
@@ -4,7 +4,7 @@ template = """
         <head>
             <meta charset="utf-8">
             <meta http-equiv="x-ua-compatible" content="ie=edge">
-            <title>{{ service_name | capitalize }}</title>
+            <title>{{ service_name }}</title>
             <meta name="description" content="Landing">
             <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
             <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">

--- a/microcosm_flask/templates/landing.py
+++ b/microcosm_flask/templates/landing.py
@@ -96,7 +96,7 @@ template = """
                 {%- for link in links | sort -%}
                 <ul>
                     <li>
-                        <a href="{{ links[link] }}">{{ link | replace("_", " ") | capitalize }}</a>
+                        <a href="{{ links[link] }}">{{ link | replace("_", " ") }}</a>
                     </li>
                 </ul>
                 {%- endfor -%}

--- a/microcosm_flask/templates/swagger_ui.py
+++ b/microcosm_flask/templates/swagger_ui.py
@@ -1,0 +1,42 @@
+# flake8: noqa
+html = """
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <!-- <link rel="stylesheet" type="text/css" href="./swagger-ui.css" /> -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.12.0/swagger-ui.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.12.0/index.min.css">
+    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.12.0/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.12.0/favicon-16x16.png" sizes="16x16" />
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.12.0/swagger-ui-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.12.0/swagger-ui-standalone-preset.min.js"></script>
+    <script type="text/javascript">
+      window.onload = function() {
+        // Assumes swagger is located under this URL, without the `/docs`
+        var swaggerLocation = window.location.href.replace("/docs", "");
+
+        window.ui = SwaggerUIBundle({
+          url: swaggerLocation,
+          dom_id: '#swagger-ui',
+          deepLinking: true,
+          presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIStandalonePreset
+          ],
+          plugins: [
+            SwaggerUIBundle.plugins.DownloadUrl
+          ],
+          layout: "StandaloneLayout"
+        });
+      };
+    </script>
+  </body>
+</html>
+"""

--- a/microcosm_flask/templates/swagger_ui.py
+++ b/microcosm_flask/templates/swagger_ui.py
@@ -7,16 +7,24 @@ html = """
     <meta charset="UTF-8">
     <title>Swagger UI</title>
     <!-- <link rel="stylesheet" type="text/css" href="./swagger-ui.css" /> -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.12.0/swagger-ui.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.12.0/index.min.css">
-    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.12.0/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.12.0/favicon-16x16.png" sizes="16x16" />
+    <link rel="stylesheet" href="https://static.globality.com/swagger-ui/swagger-ui.min.css">
+    <link rel="stylesheet" href="https://static.globality.com/swagger-ui/index.min.css">
+    <link rel="icon" type="image/png" href="https://static.globality.com/swagger-ui/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="https://static.globality.com/swagger-ui/favicon-16x16.png" sizes="16x16" />
   </head>
 
   <body>
     <div id="swagger-ui"></div>
-    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.12.0/swagger-ui-bundle.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.12.0/swagger-ui-standalone-preset.min.js"></script>
+    <script
+      src="https://static.globality.com/swagger-ui/swagger-ui-bundle.min.js"
+      integrity="sha384-LcgLZWos2uaRMwKJ/GTaZG1YnVGGDfFZEi76GEE36zMizIyUqYnsraObUwMNmuc+"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://static.globality.com/swagger-ui/swagger-ui-standalone-preset.min.js"
+      integrity="sha384-ELu05sHa6F1QPgm+8BhV45gWSiSqaL2yiZqfzvdctJkUyihk0nKxkyZCFepBZhuP"
+      crossorigin="anonymous"
+    ></script>
     <script type="text/javascript">
       window.onload = function() {
         // Assumes swagger is located under this URL, without the `/docs`

--- a/microcosm_flask/tests/conventions/test_command.py
+++ b/microcosm_flask/tests/conventions/test_command.py
@@ -99,6 +99,7 @@ class TestCommand:
         assert_that(swagger["paths"], is_(equal_to({
             "/foo/do": {
                 "post": {
+                    "description": "My doc string",
                     "tags": ["foo"],
                     "responses": {
                         "default": {

--- a/microcosm_flask/tests/conventions/test_query.py
+++ b/microcosm_flask/tests/conventions/test_query.py
@@ -97,7 +97,7 @@ class TestQuery:
         assert_that(response.status_code, is_(equal_to(200)))
         swagger = loads(response.get_data().decode("utf-8"))
         # we have the swagger docs endpoint too, which is implemented as a query.
-        # ingore it here for now.
+        # ignore it here for now.
         del swagger["paths"]["/swagger/docs"]
         assert_that(swagger["paths"], is_(equal_to({
             "/foo/get": {

--- a/microcosm_flask/tests/conventions/test_query.py
+++ b/microcosm_flask/tests/conventions/test_query.py
@@ -96,9 +96,13 @@ class TestQuery:
         response = self.client.get("/api/v1/swagger", query_string=dict(validate_schema=True))
         assert_that(response.status_code, is_(equal_to(200)))
         swagger = loads(response.get_data().decode("utf-8"))
+        # we have the swagger docs endpoint too, which is implemented as a query.
+        # ingore it here for now.
+        del swagger["paths"]["/swagger/docs"]
         assert_that(swagger["paths"], is_(equal_to({
             "/foo/get": {
                 "get": {
+                    "description": "My doc string",
                     "tags": ["foo"],
                     "responses": {
                         "default": {

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -57,6 +57,7 @@ def test_build_swagger():
         paths={
             "/person": {
                 "post": {
+                    "description": "Create a new person",
                     "tags": ["person"],
                     "responses": {
                         "default": {
@@ -91,6 +92,7 @@ def test_build_swagger():
             },
             "/person/{person_id}": {
                 "patch": {
+                    "description": "Update some or all of a person by id",
                     "tags": ["person"],
                     "responses": {
                         "default": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
-exclude = */migrations/*,.eggs/*
 max-line-length = 120
 max-complexity = 15
+exclude = */migrations/*,.eggs/*
 
 [isort]
 combine_as_imports = True
@@ -29,6 +29,7 @@ cover-erase = True
 addopts =
     --cov microcosm_flask
     --cov-report xml:microcosm_flask/tests/coverage/cov.xml
+    --junitxml=microcosm_flask/tests/test-results/pytest/junit.xml
 
 [coverage:report]
 show_missing = True

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ setup(
         "PyYAML>=3.13",
         "rfc3986>=1.2.0",
         "regex>=2021.8.21",
+        # Breaking change here removing `soft_unicode` used by Jinja.
+        "MarkupSafe<2.1.0",
     ],
     extras_require={
         "metrics": "microcosm-metrics>=2.2.0",


### PR DESCRIPTION
**What?**
- Add a `/api/v1/swagger/docs` endpoint to our existing convention along with `/api/v1/swagger`. Renders Swagger UI, pointing to the corresponding swagger endpoint.
- Add a description to the Swagger Operation, based on the function docstring (usually the controller function).
    - Update crud conventions to only overwrite the `func.__doc__` if there's nothing there.
    
**Why?**
- Originating from discussing ways of improving API documentation in ID (for Sphinx specifically).
- Swagger UI is pretty helpful to browse swagger with, might not be obvious as an option so make it easily available.
- Provide an on-ramp for more complicated documentation where needed, that can live on the docstring of the controller function.
- Living close to the code to help with maintainability and alleviate concerns of docs becoming stale too easily.