### PR TITLE
Optional non-strict OpenAPI definition for enums

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.7.1
+current_version = 3.8.0
 commit = False
 tag = False
 

--- a/microcosm_flask/swagger/parameters/enum.py
+++ b/microcosm_flask/swagger/parameters/enum.py
@@ -44,8 +44,9 @@ class EnumParameterBuilder(ParameterBuilder):
         return bool(getattr(field, "enum", None))
 
     def parse_format(self, field: Field) -> Optional[str]:
-        if isinstance(field, EnumField) and self.strict_enums:
+        if self.is_strict(field):
             return "enum"
+
         return None
 
     def parse_type(self, field: Field) -> str:
@@ -67,6 +68,14 @@ class EnumParameterBuilder(ParameterBuilder):
         ]
 
     def parse_enum_values(self, field: Field) -> Optional[Sequence]:
-        if self.strict_enums:
+        if self.is_strict(field):
             return self._parse_enum_values(field)
+
         return None
+
+    def is_strict(self, field: Field) -> bool:
+        return (
+            isinstance(field, EnumField) and
+            self.strict_enums and
+            getattr(field.enum, "__openapi_strict__", True)
+        )

--- a/microcosm_flask/tests/swagger/parameters/test_enum.py
+++ b/microcosm_flask/tests/swagger/parameters/test_enum.py
@@ -1,4 +1,9 @@
-from enum import Enum, IntEnum, unique
+from enum import (
+    Enum,
+    EnumMeta,
+    IntEnum,
+    unique,
+)
 
 from hamcrest import assert_that, equal_to, is_
 from marshmallow import Schema
@@ -18,9 +23,19 @@ class ValueType(IntEnum):
     Bar = 2
 
 
+class FormatNonStrictMeta(EnumMeta):
+    __openapi_strict__ = False
+
+
+@unique
+class ChoicesNonStrict(Enum, metaclass=FormatNonStrictMeta):
+    Profit = "profit"
+
+
 class TestSchema(Schema):
     choice = EnumField(Choices)
     value = EnumField(ValueType, by_value=True)
+    choice_non_strict = EnumField(ChoicesNonStrict)
 
 
 def test_field_enum():
@@ -50,4 +65,11 @@ def test_field_int_enum():
             1,
             2
         ],
+    })))
+
+
+def test_enum_format_override():
+    parameter = build_parameter(TestSchema().fields["choice_non_strict"])
+    assert_that(parameter, is_(equal_to({
+        "type": "string",
     })))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-flask"
-version = "3.7.1"
+version = "3.8.0"
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
             "parameterized",
         ],
         "lint": [
-            "flake8",
+            "flake8<5",
             "flake8-print",
             "flake8-logging-format",
             "flake8-isort"


### PR DESCRIPTION
For some enums, we'd like to keep OpenAPI protocol open and defer to service level validation.