### PR TITLE
update add responses to use getdoc

### DIFF
--- a/microcosm_flask/errors.py
+++ b/microcosm_flask/errors.py
@@ -131,11 +131,8 @@ def make_json_error(error):
     # Flask will not log user exception (fortunately), but will log an error
     # for exceptions that escape out of the application entirely (e.g. if the
     # error handler raises an error)
-    error_logger.debug("Handling {} error: {}".format(
-        status_code,
-        message,
-    ))
-
+    log_msg = f"Handling {status_code} error: {message}"
+    error_logger.debug(log_msg)
     # Serialize into JSON response
     response_data = {
         "code": status_code,

--- a/microcosm_flask/memory.py
+++ b/microcosm_flask/memory.py
@@ -51,7 +51,8 @@ class MemoryProfiler:
         difference = latest_snapshot.compare_to(self.origin_snapshot, "lineno")
         top_ten = difference[:self.report_size_lines]
         worst_offenders = "\n".join([str(memory_item) for memory_item in top_ten])
-        self.logger.info(f"Memory snapshot: \n {worst_offenders}")
+        log_msg = f"Memory snapshot: \n {worst_offenders}"
+        self.logger.info(log_msg)
         self.last_sampling_time = current_time
 
     def get_now(self):

--- a/microcosm_flask/swagger/definitions.py
+++ b/microcosm_flask/swagger/definitions.py
@@ -355,7 +355,7 @@ def add_responses(swagger_operation, operation, ns, func):
     )
 
     if getattr(func, "__doc__", None):
-        description = func.__doc__.strip().splitlines()[0]
+        description = getdoc(func)
     else:
         description = "{} {}".format(operation.value.name, ns.subject_name)
 

--- a/microcosm_flask/swagger/parameters/default.py
+++ b/microcosm_flask/swagger/parameters/default.py
@@ -48,9 +48,8 @@ class DefaultParameterBuilder(ParameterBuilder):
         try:
             FIELD_MAPPINGS[type(field)]
         except KeyError:
-            self.logger.exception(
-                f"No mapped swagger type for marshmallow field: {field}",
-            )
+            log_msg = f"No mapped swagger type for marshmallow field: {field}"
+            self.logger.exception(log_msg)
             raise
         else:
             return True


### PR DESCRIPTION
Descriptions of paths and responses that are pulled from the docstring are behaving inconsistently.

In the path "/deferral_feedback/{deferral_feedback_id}" for picasso, patch has the following description
```
"patch": {
        "description": "Support re-encryption by enforcing that every update triggers a\nnew encryption call, even if the the original call does not update\nthe encrypted field.",
```
whereas the response description below is cut off at the new line:
```
responses": {
          "200": {
            "description": "Support re-encryption by enforcing that every update triggers a",
```

The two sections in `microcosm-flask/swagger/definitions.py` use different methods to get the docstring. Converting to use `getdoc` ensures the same behavior between the two sections.