### PR TITLE
GLOB-68575: Add schema, schema fields, and query params descriptions for improved API doc generation

### DIFF
--- a/microcosm_flask/conventions/base.py
+++ b/microcosm_flask/conventions/base.py
@@ -21,7 +21,16 @@ class EndpointDefinition(tuple):
     A definition for an endpoint.
 
     """
-    def __new__(cls, func=None, request_schema=None, response_schema=None, header_func=None, response_formats=None):
+
+    def __new__(
+        cls,
+        func=None,
+        request_schema=None,
+        response_schema=None,
+        header_func=None,
+        response_formats=None,
+        description=None,
+    ):
         """
         Define an API endpoint.
 
@@ -40,11 +49,19 @@ class EndpointDefinition(tuple):
         :param response_schema: a marshmallow schema to encode response data
         :param header_func: a header-modifying function
         :param response_formats: an optional list of support response formats
+        :param description: a description of the endpoint for documentation
 
         """
         return tuple.__new__(
             EndpointDefinition,
-            (func, request_schema, response_schema, header_func, response_formats),
+            (
+                func,
+                request_schema,
+                response_schema,
+                header_func,
+                response_formats,
+                description,
+            ),
         )
 
     @property
@@ -67,12 +84,17 @@ class EndpointDefinition(tuple):
     def response_formats(self):
         return self[4] or []
 
+    @property
+    def description(self):
+        return self[5]
+
 
 class Convention:
     """
     A convention is a recipe for applying Flask-compatible functions to a namespace.
 
     """
+
     def __init__(self, graph):
         self.graph = graph
         self._registered_routes = set()

--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -23,7 +23,6 @@ from microcosm_flask.paging import OffsetLimitPage, OffsetLimitPageSchema, ident
 
 
 class CRUDConvention(Convention):
-
     @property
     def page_cls(self):
         return OffsetLimitPage
@@ -58,10 +57,16 @@ class CRUDConvention(Convention):
         @wraps(definition.func)
         def search(**path_data):
             page = self.page_cls.from_query_string(definition.request_schema)
-            result = definition.func(**merge_data(path_data, page.to_dict(func=identity)))
-            response_data, headers = page.to_paginated_list(result, ns, Operation.Search)
+            result = definition.func(
+                **merge_data(path_data, page.to_dict(func=identity))
+            )
+            response_data, headers = page.to_paginated_list(
+                result, ns, Operation.Search
+            )
             definition.header_func(headers, response_data)
-            response_format = self.negotiate_response_content(definition.response_formats)
+            response_format = self.negotiate_response_content(
+                definition.response_formats
+            )
             return dump_response_data(
                 paginated_list_schema,
                 response_data,
@@ -69,7 +74,11 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        search.__doc__ = search.__doc__ or "Search the collection of all {}".format(pluralize(ns.subject_name))
+        search.__doc__ = (
+            definition.description
+            or search.__doc__
+            or "Search the collection of all {}".format(pluralize(ns.subject_name))
+        )
 
     def configure_count(self, ns, definition):
         """
@@ -85,6 +94,7 @@ class CRUDConvention(Convention):
         :param definition: the endpoint definition
 
         """
+
         @self.add_route(ns.collection_path, Operation.Count, ns)
         @qs(definition.request_schema)
         @wraps(definition.func)
@@ -94,7 +104,9 @@ class CRUDConvention(Convention):
             count = definition.func(**merge_data(path_data, request_data))
             headers = encode_count_header(count)
             definition.header_func(headers, response_data)
-            response_format = self.negotiate_response_content(definition.response_formats)
+            response_format = self.negotiate_response_content(
+                definition.response_formats
+            )
             return dump_response_data(
                 None,
                 None,
@@ -102,7 +114,13 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        count.__doc__ = count.__doc__ or "Count the size of the collection of all {}".format(pluralize(ns.subject_name))
+        count.__doc__ = (
+            definition.description
+            or count.__doc__
+            or "Count the size of the collection of all {}".format(
+                pluralize(ns.subject_name)
+            )
+        )
 
     def configure_create(self, ns, definition):
         """
@@ -116,6 +134,7 @@ class CRUDConvention(Convention):
         :param definition: the endpoint definition
 
         """
+
         @self.add_route(ns.collection_path, Operation.Create, ns)
         @request(definition.request_schema)
         @response(definition.response_schema)
@@ -125,7 +144,9 @@ class CRUDConvention(Convention):
             response_data = definition.func(**merge_data(path_data, request_data))
             headers = encode_id_header(response_data)
             definition.header_func(headers, response_data)
-            response_format = self.negotiate_response_content(definition.response_formats)
+            response_format = self.negotiate_response_content(
+                definition.response_formats
+            )
             return dump_response_data(
                 definition.response_schema,
                 response_data,
@@ -134,7 +155,11 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        create.__doc__ = create.__doc__ or "Create a new {}".format(ns.subject_name)
+        create.__doc__ = (
+            definition.description
+            or create.__doc__
+            or "Create a new {}".format(ns.subject_name)
+        )
 
     def configure_updatebatch(self, ns, definition):
         """
@@ -159,7 +184,9 @@ class CRUDConvention(Convention):
             request_data = load_request_data(definition.request_schema)
             response_data = definition.func(**merge_data(path_data, request_data))
             definition.header_func(headers, response_data)
-            response_format = self.negotiate_response_content(definition.response_formats)
+            response_format = self.negotiate_response_content(
+                definition.response_formats
+            )
             return dump_response_data(
                 definition.response_schema,
                 response_data,
@@ -168,7 +195,11 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        update_batch.__doc__ = update_batch.__doc__ or "Update a batch of {}".format(ns.subject_name)
+        update_batch.__doc__ = (
+            definition.description
+            or update_batch.__doc__
+            or "Update a batch of {}".format(ns.subject_name)
+        )
 
     def configure_deletebatch(self, ns, definition):
         """
@@ -191,9 +222,13 @@ class CRUDConvention(Convention):
         def delete_batch(**path_data):
             headers = dict()
             request_data = load_query_string_data(request_schema)
-            response_data = require_response_data(definition.func(**merge_data(path_data, request_data)))
+            response_data = require_response_data(
+                definition.func(**merge_data(path_data, request_data))
+            )
             definition.header_func(headers, response_data)
-            response_format = self.negotiate_response_content(definition.response_formats)
+            response_format = self.negotiate_response_content(
+                definition.response_formats
+            )
             return dump_response_data(
                 response_schema="",
                 response_data=None,
@@ -202,7 +237,11 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        delete_batch.__doc__ = delete_batch.__doc__ or "Delete a batch of {}".format(ns.subject_name)
+        delete_batch.__doc__ = (
+            definition.description
+            or delete_batch.__doc__
+            or "Delete a batch of {}".format(ns.subject_name)
+        )
 
     def configure_retrieve(self, ns, definition):
         """
@@ -225,9 +264,13 @@ class CRUDConvention(Convention):
         def retrieve(**path_data):
             headers = dict()
             request_data = load_query_string_data(request_schema)
-            response_data = require_response_data(definition.func(**merge_data(path_data, request_data)))
+            response_data = require_response_data(
+                definition.func(**merge_data(path_data, request_data))
+            )
             definition.header_func(headers, response_data)
-            response_format = self.negotiate_response_content(definition.response_formats)
+            response_format = self.negotiate_response_content(
+                definition.response_formats
+            )
             return dump_response_data(
                 definition.response_schema,
                 response_data,
@@ -235,7 +278,11 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        retrieve.__doc__ = retrieve.__doc__ or "Retrieve a {} by id".format(ns.subject_name)
+        retrieve.__doc__ = (
+            definition.description
+            or retrieve.__doc__
+            or "Retrieve a {} by id".format(ns.subject_name)
+        )
 
     def configure_delete(self, ns, definition):
         """
@@ -257,9 +304,13 @@ class CRUDConvention(Convention):
         def delete(**path_data):
             headers = dict()
             request_data = load_query_string_data(request_schema)
-            response_data = require_response_data(definition.func(**merge_data(path_data, request_data)))
+            response_data = require_response_data(
+                definition.func(**merge_data(path_data, request_data))
+            )
             definition.header_func(headers, response_data)
-            response_format = self.negotiate_response_content(definition.response_formats)
+            response_format = self.negotiate_response_content(
+                definition.response_formats
+            )
             return dump_response_data(
                 "",
                 None,
@@ -268,7 +319,11 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        delete.__doc__ = delete.__doc__ or "Delete a {} by id".format(ns.subject_name)
+        delete.__doc__ = (
+            definition.description
+            or delete.__doc__
+            or "Delete a {} by id".format(ns.subject_name)
+        )
 
     def configure_replace(self, ns, definition):
         """
@@ -282,6 +337,7 @@ class CRUDConvention(Convention):
         :param definition: the endpoint definition
 
         """
+
         @self.add_route(ns.instance_path, Operation.Replace, ns)
         @request(definition.request_schema)
         @response(definition.response_schema)
@@ -292,9 +348,13 @@ class CRUDConvention(Convention):
             # Replace/put should create a resource if not already present, but we do not
             # enforce these semantics at the HTTP layer. If `func` returns falsey, we
             # will raise a 404.
-            response_data = require_response_data(definition.func(**merge_data(path_data, request_data)))
+            response_data = require_response_data(
+                definition.func(**merge_data(path_data, request_data))
+            )
             definition.header_func(headers, response_data)
-            response_format = self.negotiate_response_content(definition.response_formats)
+            response_format = self.negotiate_response_content(
+                definition.response_formats
+            )
             return dump_response_data(
                 definition.response_schema,
                 response_data,
@@ -302,7 +362,11 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        replace.__doc__ = replace.__doc__ or "Create or update a {} by id".format(ns.subject_name)
+        replace.__doc__ = (
+            definition.description
+            or replace.__doc__
+            or "Create or update a {} by id".format(ns.subject_name)
+        )
 
     def configure_update(self, ns, definition):
         """
@@ -316,6 +380,7 @@ class CRUDConvention(Convention):
         :param definition: the endpoint definition
 
         """
+
         @self.add_route(ns.instance_path, Operation.Update, ns)
         @request(definition.request_schema)
         @response(definition.response_schema)
@@ -323,9 +388,13 @@ class CRUDConvention(Convention):
         def update(**path_data):
             headers = dict()
             request_data = load_request_data(definition.request_schema)
-            response_data = require_response_data(definition.func(**merge_data(path_data, request_data)))
+            response_data = require_response_data(
+                definition.func(**merge_data(path_data, request_data))
+            )
             definition.header_func(headers, response_data)
-            response_format = self.negotiate_response_content(definition.response_formats)
+            response_format = self.negotiate_response_content(
+                definition.response_formats
+            )
             return dump_response_data(
                 definition.response_schema,
                 response_data,
@@ -333,7 +402,11 @@ class CRUDConvention(Convention):
                 response_format=response_format,
             )
 
-        update.__doc__ = update.__doc__ or "Update some or all of a {} by id".format(ns.subject_name)
+        update.__doc__ = (
+            definition.description
+            or update.__doc__
+            or "Update some or all of a {} by id".format(ns.subject_name)
+        )
 
     def configure_createcollection(self, ns, definition):
         """
@@ -355,17 +428,23 @@ class CRUDConvention(Convention):
             request_data = load_request_data(definition.request_schema)
             page = self.page_cls.from_query_string(self.page_schema(), {})
 
-            result = definition.func(**merge_data(
-                path_data,
-                merge_data(
-                    request_data,
-                    page.to_dict(func=identity),
-                ),
-            ))
+            result = definition.func(
+                **merge_data(
+                    path_data,
+                    merge_data(
+                        request_data,
+                        page.to_dict(func=identity),
+                    ),
+                )
+            )
 
-            response_data, headers = page.to_paginated_list(result, ns, Operation.CreateCollection)
+            response_data, headers = page.to_paginated_list(
+                result, ns, Operation.CreateCollection
+            )
             definition.header_func(headers, response_data)
-            response_format = self.negotiate_response_content(definition.response_formats)
+            response_format = self.negotiate_response_content(
+                definition.response_formats
+            )
             return dump_response_data(
                 paginated_list_schema,
                 response_data,
@@ -374,7 +453,9 @@ class CRUDConvention(Convention):
             )
 
         create_collection.__doc__ = (
-            create_collection.__doc__ or "Create the collection of {}".format(pluralize(ns.subject_name))
+            definition.description
+            or create_collection.__doc__
+            or "Create the collection of {}".format(pluralize(ns.subject_name))
         )
 
 

--- a/microcosm_flask/conventions/landing.py
+++ b/microcosm_flask/conventions/landing.py
@@ -41,7 +41,7 @@ def configure_landing(graph):   # noqa: C901
             Defines a condition to determine which endpoints are swagger type
 
             """
-            if(ns.subject == graph.config.swagger_convention.name):
+            if (ns.subject == graph.config.swagger_convention.name):
                 return True
             return False
 

--- a/microcosm_flask/conventions/landing.py
+++ b/microcosm_flask/conventions/landing.py
@@ -41,7 +41,7 @@ def configure_landing(graph):   # noqa: C901
             Defines a condition to determine which endpoints are swagger type
 
             """
-            if (ns.subject == graph.config.swagger_convention.name):
+            if ns.subject == graph.config.swagger_convention.name:
                 return True
             return False
 

--- a/microcosm_flask/paging.py
+++ b/microcosm_flask/paging.py
@@ -319,7 +319,8 @@ class OffsetLimitPage(Page):
                 metadata={"description": "The pagination starting offset."},
             )
             limit = fields.Integer(
-                required=True, metadata={"description": "The pagination limit."}
+                required=True,
+                metadata={"description": "The pagination limit."},
             )
             count = fields.Integer(
                 required=True,

--- a/microcosm_flask/swagger/parameters/base.py
+++ b/microcosm_flask/swagger/parameters/base.py
@@ -78,7 +78,8 @@ class ParameterBuilder(ABC):
         """
         if "metadata" in field.metadata:
             metadata = field.metadata.get("metadata")
-            return metadata.get("description")
+            if metadata:
+                return metadata.get("description")
         return field.metadata.get("description")
 
     def parse_enum_values(self, field: Field) -> Optional[Sequence]:

--- a/microcosm_flask/swagger/parameters/base.py
+++ b/microcosm_flask/swagger/parameters/base.py
@@ -24,7 +24,10 @@ class ParameterBuilder(ABC):
     and delegates to the first compatible implementation.
 
     """
-    def __init__(self, build_parameter: Callable[[Schema], Mapping[str, Any]], **kwargs):
+
+    def __init__(
+        self, build_parameter: Callable[[Schema], Mapping[str, Any]], **kwargs
+    ):
         self.build_parameter = build_parameter
         self.parsers = {
             "default": self.parse_default,
@@ -73,6 +76,9 @@ class ParameterBuilder(ABC):
         Parse the description for the field, if any.
 
         """
+        if "metadata" in field.metadata:
+            metadata = field.metadata.get("metadata")
+            return metadata.get("description")
         return field.metadata.get("description")
 
     def parse_enum_values(self, field: Field) -> Optional[Sequence]:

--- a/microcosm_flask/swagger/parameters/base.py
+++ b/microcosm_flask/swagger/parameters/base.py
@@ -76,10 +76,9 @@ class ParameterBuilder(ABC):
         Parse the description for the field, if any.
 
         """
-        if "metadata" in field.metadata:
-            metadata = field.metadata.get("metadata")
-            if metadata:
-                return metadata.get("description")
+        metadata = field.metadata.get("metadata", {})
+        if metadata:
+            return metadata.get("description")
         return field.metadata.get("description")
 
     def parse_enum_values(self, field: Field) -> Optional[Sequence]:

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -2,6 +2,7 @@
 Generate JSON Schema for Marshmallow schemas.
 
 """
+import re
 from typing import (
     Any,
     Callable,
@@ -29,6 +30,7 @@ class Schemas:
     Swagger schema builder.
 
     """
+
     def __init__(
         self,
         build_parameter: Callable[..., Mapping[str, Any]],
@@ -59,13 +61,14 @@ class Schemas:
         )
 
         required_fields = [
-            name
-            for name, field in fields
-            if field.required and not field.allow_none
+            name for name, field in fields if field.required and not field.allow_none
         ]
 
         if required_fields:
             result["required"] = required_fields
+
+        if schema.__doc__:
+            result["description"] = re.sub(r"\s+", " ", schema.__doc__.strip())
 
         return result
 
@@ -99,7 +102,9 @@ class Schemas:
 
         yield self.to_tuple(schema)
 
-        for associated_schema in getattr(schema, associated_schemas_attr_name(schema.__class__), {}).values():
+        for associated_schema in getattr(
+            schema, associated_schemas_attr_name(schema.__class__), {}
+        ).values():
             yield self.to_tuple(associated_schema())
 
         for name, field in self.iter_fields(schema):

--- a/microcosm_flask/tests/conventions/test_command.py
+++ b/microcosm_flask/tests/conventions/test_command.py
@@ -120,6 +120,7 @@ class TestCommand:
                             "name": "X-Response-Skip-Null",
                             "required": False,
                             "type": "string",
+                            "description": "Remove fields with null values from the response."
                         },
                         {
                             "schema": {

--- a/microcosm_flask/tests/conventions/test_query.py
+++ b/microcosm_flask/tests/conventions/test_query.py
@@ -123,6 +123,7 @@ class TestQuery:
                             "name": "X-Response-Skip-Null",
                             "required": False,
                             "type": "string",
+                            "description": "Remove fields with null values from the response."
                         },
                         {
                             "required": False,

--- a/microcosm_flask/tests/swagger/parameters/test_default.py
+++ b/microcosm_flask/tests/swagger/parameters/test_default.py
@@ -6,7 +6,7 @@ from microcosm_flask.swagger.api import build_parameter
 
 class TestSchema(Schema):
     id = fields.UUID()
-    foo = fields.String(description="Foo", default="bar")
+    foo = fields.String(metadata={"description": "Foo"}, default="bar")
     payload = fields.Dict()
     datetime = fields.DateTime()
 

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -38,7 +38,7 @@ def match_function(operation, obj, rule):
 
 
 def test_build_swagger():
-    graph = create_object_graph(name="example", testing=True)
+    graph = create_object_graph(name="example", testing=True, description="The API description.")
     ns = Namespace(
         subject=Person,
         version="v1",
@@ -53,6 +53,7 @@ def test_build_swagger():
         info={
             "version": "v1",
             "title": "example",
+            "description": "The API description."
         },
         paths={
             "/person": {
@@ -78,6 +79,7 @@ def test_build_swagger():
                             "name": "X-Response-Skip-Null",
                             "required": False,
                             "type": "string",
+                            "description": "Remove fields with null values from the response."
                         },
                         {
                             "in": "body",
@@ -114,6 +116,7 @@ def test_build_swagger():
                             "type": "string",
                             "name": "X-Response-Skip-Null",
                             "in": "header",
+                            "description": "Remove fields with null values from the response."
                         },
                         {
                             "in": "body",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "Flask-UUID>=0.2",
         "jsonschema==3.2.0",
         "marshmallow>=3.0.0",
-        "microcosm>=3.0.0",
+        "microcosm>=3.1.0",
         "microcosm-logging>=1.5.0",
         "openapi>=1.1.0",
         "python-dateutil>=2.7.3",
@@ -50,18 +50,12 @@ setup(
             "coverage",
             "parameterized",
         ],
-        "lint": [
-            "flake8<5",
-            "flake8-print",
-            "flake8-logging-format",
-            "flake8-isort"
-        ]
+        "lint": ["flake8<5", "flake8-print", "flake8-logging-format", "flake8-isort"],
     },
     setup_requires=[
         "nose>=1.3.7",
     ],
-    dependency_links=[
-    ],
+    dependency_links=[],
     entry_points={
         "microcosm_flask.swagger.parameters": [
             "decorated = microcosm_flask.swagger.parameters.decorated:DecoratedParameterBuilder",


### PR DESCRIPTION
This change enhances the automatic swagger API documentation mechanism by:

- Adding an optional `description` property to the `EndpointDefinition` class such that we can include end-point descriptions in the documentation if provided.
- Including marshmallow Field `metadata.description` in the documentation if provided for query parameters, request and response schema fields.
- Adding such descriptions to the pagination fields like `offset`, `limit`, and `count`. Also documenting the default header `X-Response-Skip-Null`
- Including marshmallow Schema `__doc__` strings in the documentation if provided.

The `black` formatter was also automatically applied.