### PR TITLE
Bump all versions to 4.1.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.0
+current_version = 4.1.1
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-flask"
-version = "4.1.0"
+version = "4.1.1"
 
 
 setup(


### PR DESCRIPTION
**Why?**
Tried to release previous version `4.1.0`, but bumpversion didn't match, so publish failed.

**What?**
- Bump version, so we can now tag with `4.1.1` and all will match, and publish okay.