### PR TITLE
Added support for fields.Constant swagger - 4.0.0 branch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.1
+current_version = 4.1.2
 commit = False
 tag = False
 

--- a/microcosm_flask/swagger/parameters/constant.py
+++ b/microcosm_flask/swagger/parameters/constant.py
@@ -1,0 +1,31 @@
+from typing import Any, Mapping
+
+from marshmallow.fields import Field, Constant
+
+from microcosm_flask.swagger.parameters.base import ParameterBuilder
+from microcosm_flask.swagger.parameters.enum import is_int
+
+
+class ConstantParameterBuilder(ParameterBuilder):
+    """
+    Builder parameters for constant fields.
+
+    """
+    def supports_field(self, field: Field) -> bool:
+        return isinstance(field, Constant)
+
+    def parse_default(self, field: Constant) -> Any:
+        """
+        Parse the default value for the field, if any.
+
+        """
+        return field.constant
+
+    def parse_type(self, field: Constant) -> str:
+        if isinstance(field.constant, list):
+            return "array"
+        elif isinstance(field.constant, str):
+            return "string"
+        elif is_int(field.constant):
+            return "integer"
+

--- a/microcosm_flask/swagger/parameters/constant.py
+++ b/microcosm_flask/swagger/parameters/constant.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional
 
-from marshmallow.fields import Field, Constant
+from marshmallow.fields import Constant, Field
 
 from microcosm_flask.swagger.parameters.base import ParameterBuilder
 from microcosm_flask.swagger.parameters.enum import is_int
@@ -30,4 +30,3 @@ class ConstantParameterBuilder(ParameterBuilder):
         elif is_int(constant):
             return "integer"
         return None
-

--- a/microcosm_flask/swagger/parameters/constant.py
+++ b/microcosm_flask/swagger/parameters/constant.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping
+from typing import Any, Optional
 
 from marshmallow.fields import Field, Constant
 
@@ -14,18 +14,20 @@ class ConstantParameterBuilder(ParameterBuilder):
     def supports_field(self, field: Field) -> bool:
         return isinstance(field, Constant)
 
-    def parse_default(self, field: Constant) -> Any:
+    def parse_default(self, field: Field) -> Any:
         """
         Parse the default value for the field, if any.
 
         """
-        return field.constant
+        return getattr(field, "constant", None)
 
-    def parse_type(self, field: Constant) -> str:
-        if isinstance(field.constant, list):
+    def parse_type(self, field: Field) -> Optional[str]:
+        constant = getattr(field, "constant", None)
+        if isinstance(constant, list):
             return "array"
-        elif isinstance(field.constant, str):
+        elif isinstance(constant, str):
             return "string"
-        elif is_int(field.constant):
+        elif is_int(constant):
             return "integer"
+        return None
 

--- a/microcosm_flask/swagger/parameters/default.py
+++ b/microcosm_flask/swagger/parameters/default.py
@@ -33,6 +33,7 @@ FIELD_MAPPINGS = {
     fields.Time: FieldInfo("string", None),
     fields.URL: FieldInfo("string", "url"),
     fields.UUID: FieldInfo("string", "uuid"),
+    fields.Constant: FieldInfo("object", None),
 }
 
 

--- a/microcosm_flask/tests/swagger/parameters/test_constant.py
+++ b/microcosm_flask/tests/swagger/parameters/test_constant.py
@@ -10,12 +10,12 @@ class TestSchema(Schema):
     deprecated_constant_int = fields.Constant(constant=123, dump_only=True)
 
 
-
 def test_field_constant_list():
     parameter = build_parameter(TestSchema().fields["deprecated_constant_list"])
     assert_that(parameter, is_(equal_to({
         "type": "array",
     })))
+
 
 def test_field_constant_string():
     parameter = build_parameter(TestSchema().fields["deprecated_constant_string"])
@@ -23,6 +23,7 @@ def test_field_constant_string():
         "type": "string",
         "default": "HELLO",
     })))
+
 
 def test_field_constant_int():
     parameter = build_parameter(TestSchema().fields["deprecated_constant_int"])

--- a/microcosm_flask/tests/swagger/parameters/test_constant.py
+++ b/microcosm_flask/tests/swagger/parameters/test_constant.py
@@ -1,0 +1,32 @@
+from hamcrest import assert_that, equal_to, is_
+from marshmallow import Schema, fields
+
+from microcosm_flask.swagger.api import build_parameter
+
+
+class TestSchema(Schema):
+    deprecated_constant_list = fields.Constant(constant=[], dump_only=True)
+    deprecated_constant_string = fields.Constant(constant="HELLO", dump_only=True)
+    deprecated_constant_int = fields.Constant(constant=123, dump_only=True)
+
+
+
+def test_field_constant_list():
+    parameter = build_parameter(TestSchema().fields["deprecated_constant_list"])
+    assert_that(parameter, is_(equal_to({
+        "type": "array",
+    })))
+
+def test_field_constant_string():
+    parameter = build_parameter(TestSchema().fields["deprecated_constant_string"])
+    assert_that(parameter, is_(equal_to({
+        "type": "string",
+        "default": "HELLO",
+    })))
+
+def test_field_constant_int():
+    parameter = build_parameter(TestSchema().fields["deprecated_constant_int"])
+    assert_that(parameter, is_(equal_to({
+        "type": "integer",
+        "default": 123,
+    })))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-flask"
-version = "4.1.1"
+version = "4.1.2"
 
 
 setup(
@@ -60,6 +60,7 @@ setup(
     dependency_links=[],
     entry_points={
         "microcosm_flask.swagger.parameters": [
+            "constant = microcosm_flask.swagger.parameters.constant:ConstantParameterBuilder",
             "decorated = microcosm_flask.swagger.parameters.decorated:DecoratedParameterBuilder",
             "enum = microcosm_flask.swagger.parameters.enum:EnumParameterBuilder",
             "list = microcosm_flask.swagger.parameters.list:ListParameterBuilder",


### PR DESCRIPTION
## Why?
Using `fields.Constant` in a scehma causes a 500 error in the swagger endpoint

## What?
Add support for constant field