### PR TITLE
Add support for Constant field to 3.9.*

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.9.0
+current_version = 3.9.1
 commit = False
 tag = False
 

--- a/microcosm_flask/swagger/parameters/constant.py
+++ b/microcosm_flask/swagger/parameters/constant.py
@@ -1,0 +1,32 @@
+from typing import Any, Optional
+
+from marshmallow.fields import Constant, Field
+
+from microcosm_flask.swagger.parameters.base import ParameterBuilder
+from microcosm_flask.swagger.parameters.enum import is_int
+
+
+class ConstantParameterBuilder(ParameterBuilder):
+    """
+    Builder parameters for constant fields.
+
+    """
+    def supports_field(self, field: Field) -> bool:
+        return isinstance(field, Constant)
+
+    def parse_default(self, field: Field) -> Any:
+        """
+        Parse the default value for the field, if any.
+
+        """
+        return getattr(field, "constant", None)
+
+    def parse_type(self, field: Field) -> Optional[str]:
+        constant = getattr(field, "constant", None)
+        if isinstance(constant, list):
+            return "array"
+        elif isinstance(constant, str):
+            return "string"
+        elif is_int(constant):
+            return "integer"
+        return None

--- a/microcosm_flask/swagger/parameters/default.py
+++ b/microcosm_flask/swagger/parameters/default.py
@@ -33,6 +33,7 @@ FIELD_MAPPINGS = {
     fields.Time: FieldInfo("string", None),
     fields.URL: FieldInfo("string", "url"),
     fields.UUID: FieldInfo("string", "uuid"),
+    fields.Constant: FieldInfo("object", None),
 }
 
 

--- a/microcosm_flask/tests/swagger/parameters/test_constant.py
+++ b/microcosm_flask/tests/swagger/parameters/test_constant.py
@@ -1,0 +1,33 @@
+from hamcrest import assert_that, equal_to, is_
+from marshmallow import Schema, fields
+
+from microcosm_flask.swagger.api import build_parameter
+
+
+class TestSchema(Schema):
+    deprecated_constant_list = fields.Constant(constant=[], dump_only=True)
+    deprecated_constant_string = fields.Constant(constant="HELLO", dump_only=True)
+    deprecated_constant_int = fields.Constant(constant=123, dump_only=True)
+
+
+def test_field_constant_list():
+    parameter = build_parameter(TestSchema().fields["deprecated_constant_list"])
+    assert_that(parameter, is_(equal_to({
+        "type": "array",
+    })))
+
+
+def test_field_constant_string():
+    parameter = build_parameter(TestSchema().fields["deprecated_constant_string"])
+    assert_that(parameter, is_(equal_to({
+        "type": "string",
+        "default": "HELLO",
+    })))
+
+
+def test_field_constant_int():
+    parameter = build_parameter(TestSchema().fields["deprecated_constant_int"])
+    assert_that(parameter, is_(equal_to({
+        "type": "integer",
+        "default": 123,
+    })))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-flask"
-version = "3.9.0"
+version = "3.9.1"
 
 
 setup(
@@ -58,6 +58,7 @@ setup(
     dependency_links=[],
     entry_points={
         "microcosm_flask.swagger.parameters": [
+            "constant = microcosm_flask.swagger.parameters.constant:ConstantParameterBuilder",
             "decorated = microcosm_flask.swagger.parameters.decorated:DecoratedParameterBuilder",
             "enum = microcosm_flask.swagger.parameters.enum:EnumParameterBuilder",
             "list = microcosm_flask.swagger.parameters.list:ListParameterBuilder",


### PR DESCRIPTION
## Why?
Using `fields.Constant` in a scehma causes a 500 error in the swagger endpoint.
4.0.0 is broken with the rest of the `microcosm` ecosystem, so porting this change into an older version.

## What?
Add support for constant field