### PR TITLE
Fix outputted spec so constant array has items.type

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.9.1
+current_version = 3.9.2
 commit = False
 tag = False
 

--- a/microcosm_flask/swagger/parameters/constant.py
+++ b/microcosm_flask/swagger/parameters/constant.py
@@ -1,6 +1,6 @@
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
-from marshmallow.fields import Constant, Field
+from marshmallow.fields import Constant, Field, Raw
 
 from microcosm_flask.swagger.parameters.base import ParameterBuilder
 from microcosm_flask.swagger.parameters.enum import is_int
@@ -29,4 +29,10 @@ class ConstantParameterBuilder(ParameterBuilder):
             return "string"
         elif is_int(constant):
             return "integer"
+        return None
+
+    def parse_items(self, field: Field) -> Optional[Mapping[str, Any]]:
+        constant = getattr(field, "constant", None)
+        if isinstance(constant, list):
+            return self.build_parameter(Raw())  # type: ignore
         return None

--- a/microcosm_flask/tests/swagger/parameters/test_constant.py
+++ b/microcosm_flask/tests/swagger/parameters/test_constant.py
@@ -14,6 +14,9 @@ def test_field_constant_list():
     parameter = build_parameter(TestSchema().fields["deprecated_constant_list"])
     assert_that(parameter, is_(equal_to({
         "type": "array",
+        "items": {
+            "type": "object",
+        }
     })))
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-flask"
-version = "3.9.1"
+version = "3.9.2"
 
 
 setup(


### PR DESCRIPTION
## Why?
Swagger spec expects `type:array` to have `items.type`

## What?
Add a basic items.type of `object` when constant is a list