### PR TITLE
Upgrade microcosm-flask to Python 3.10.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.3
+current_version = 4.1.4
 commit = False
 tag = False
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #
 
 # ----------- deps -----------
-FROM python:3.7-slim as deps
+FROM python:3.10-slim-bullseye as deps
 
 #
 # Most services will use the same set of packages here, though a few will install

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install -U -e .
 Run the tests
 
 ```
-python setup.py nosetests
+pytest
 ```
 
 ## Linting

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ if [ "$1" = "test" ]; then
    # Install standard test dependencies; YMMV
    pip --quiet install \
        .[test]
-   nosetests
+   pytest
 elif [ "$1" = "lint" ]; then
    # Install standard linting dependencies; YMMV
    pip --quiet install \

--- a/microcosm_flask/audit.py
+++ b/microcosm_flask/audit.py
@@ -309,7 +309,7 @@ class RequestInfo:
             if parts[-1] != "Id":
                 continue
 
-            dct["{}_id".format(underscore(parts[1]))] = value
+            dct[f"{underscore(parts[1])}_id"] = value
 
 
 def _audit_request(options, func, request_context, *args, **kwargs):  # noqa: C901

--- a/microcosm_flask/basic_auth.py
+++ b/microcosm_flask/basic_auth.py
@@ -44,7 +44,7 @@ class ConfigBasicAuth(BasicAuth):
     """
 
     def __init__(self, app, credentials):
-        super(ConfigBasicAuth, self).__init__(app)
+        super().__init__(app)
         self.credentials = credentials
 
     def check_credentials(self, username, password):
@@ -59,7 +59,7 @@ class ConfigBasicAuth(BasicAuth):
         Override challenge to raise an exception that will trigger regular error handling.
 
         """
-        response = super(ConfigBasicAuth, self).challenge()
+        response = super().challenge()
         raise with_headers(Unauthorized(), response.headers)
 
 

--- a/microcosm_flask/conventions/alias.py
+++ b/microcosm_flask/conventions/alias.py
@@ -42,13 +42,13 @@ class AliasConvention(Convention):
             resource = definition.func(**merge_data(path_data, request_data))
 
             kwargs = dict()
-            identifier = "{}_id".format(name_for(ns.subject))
+            identifier = f"{name_for(ns.subject)}_id"
             kwargs[identifier] = resource.id
             url = ns.url_for(Operation.Retrieve, **kwargs)
 
             return redirect(url)
 
-        retrieve.__doc__ = "Alias a {} by name".format(ns.subject_name)
+        retrieve.__doc__ = f"Alias a {ns.subject_name} by name"
 
 
 def configure_alias(graph, ns, mappings):

--- a/microcosm_flask/conventions/base.py
+++ b/microcosm_flask/conventions/base.py
@@ -138,7 +138,7 @@ class Convention:
         else:
             operation_name = operation.lower()
 
-        return getattr(self, "configure_{}".format(operation_name))
+        return getattr(self, f"configure_{operation_name}")
 
     def negotiate_response_content(self, allowed_response_formats):
         response_format = find_response_format(allowed_response_formats)

--- a/microcosm_flask/conventions/build_info.py
+++ b/microcosm_flask/conventions/build_info.py
@@ -44,7 +44,7 @@ class BuildInfo:
 class BuildInfoConvention(Convention):
 
     def __init__(self, graph):
-        super(BuildInfoConvention, self).__init__(graph)
+        super().__init__(graph)
         self.build_info = BuildInfo.from_config(graph.config)
 
     def configure_retrieve(self, ns, definition):

--- a/microcosm_flask/conventions/config.py
+++ b/microcosm_flask/conventions/config.py
@@ -48,7 +48,7 @@ class Config:
 class ConfigDiscoveryConvention(Convention):
 
     def __init__(self, graph):
-        super(ConfigDiscoveryConvention, self).__init__(graph)
+        super().__init__(graph)
         self.config_discovery = Config(graph)
 
     def configure_retrieve(self, ns, definition):

--- a/microcosm_flask/conventions/crud.py
+++ b/microcosm_flask/conventions/crud.py
@@ -77,7 +77,7 @@ class CRUDConvention(Convention):
         search.__doc__ = (
             definition.description
             or search.__doc__
-            or "Search the collection of all {}".format(pluralize(ns.subject_name))
+            or f"Search the collection of all {pluralize(ns.subject_name)}"
         )
 
     def configure_count(self, ns, definition):
@@ -158,7 +158,7 @@ class CRUDConvention(Convention):
         create.__doc__ = (
             definition.description
             or create.__doc__
-            or "Create a new {}".format(ns.subject_name)
+            or f"Create a new {ns.subject_name}"
         )
 
     def configure_updatebatch(self, ns, definition):
@@ -198,7 +198,7 @@ class CRUDConvention(Convention):
         update_batch.__doc__ = (
             definition.description
             or update_batch.__doc__
-            or "Update a batch of {}".format(ns.subject_name)
+            or f"Update a batch of {ns.subject_name}"
         )
 
     def configure_deletebatch(self, ns, definition):
@@ -240,7 +240,7 @@ class CRUDConvention(Convention):
         delete_batch.__doc__ = (
             definition.description
             or delete_batch.__doc__
-            or "Delete a batch of {}".format(ns.subject_name)
+            or f"Delete a batch of {ns.subject_name}"
         )
 
     def configure_retrieve(self, ns, definition):
@@ -281,7 +281,7 @@ class CRUDConvention(Convention):
         retrieve.__doc__ = (
             definition.description
             or retrieve.__doc__
-            or "Retrieve a {} by id".format(ns.subject_name)
+            or f"Retrieve a {ns.subject_name} by id"
         )
 
     def configure_delete(self, ns, definition):
@@ -322,7 +322,7 @@ class CRUDConvention(Convention):
         delete.__doc__ = (
             definition.description
             or delete.__doc__
-            or "Delete a {} by id".format(ns.subject_name)
+            or f"Delete a {ns.subject_name} by id"
         )
 
     def configure_replace(self, ns, definition):
@@ -365,7 +365,7 @@ class CRUDConvention(Convention):
         replace.__doc__ = (
             definition.description
             or replace.__doc__
-            or "Create or update a {} by id".format(ns.subject_name)
+            or f"Create or update a {ns.subject_name} by id"
         )
 
     def configure_update(self, ns, definition):
@@ -405,7 +405,7 @@ class CRUDConvention(Convention):
         update.__doc__ = (
             definition.description
             or update.__doc__
-            or "Update some or all of a {} by id".format(ns.subject_name)
+            or f"Update some or all of a {ns.subject_name} by id"
         )
 
     def configure_createcollection(self, ns, definition):
@@ -455,7 +455,7 @@ class CRUDConvention(Convention):
         create_collection.__doc__ = (
             definition.description
             or create_collection.__doc__
-            or "Create the collection of {}".format(pluralize(ns.subject_name))
+            or f"Create the collection of {pluralize(ns.subject_name)}"
         )
 
 

--- a/microcosm_flask/conventions/crud_adapter.py
+++ b/microcosm_flask/conventions/crud_adapter.py
@@ -18,7 +18,7 @@ class CRUDStoreAdapter:
 
     @property
     def identifier_key(self):
-        return "{}_id".format(name_for(self.store.model_class))
+        return f"{name_for(self.store.model_class)}_id"
 
     def create(self, **kwargs):
         model = self.store.model_class(**kwargs)

--- a/microcosm_flask/conventions/encoding.py
+++ b/microcosm_flask/conventions/encoding.py
@@ -79,7 +79,7 @@ def load_request_data(request_schema):
             UnprocessableEntity("Validation error"),
             [
                 {
-                    "message": "Could not validate field: {}".format(field),
+                    "message": f"Could not validate field: {field}",
                     "field": field,
                     "reasons": reasons,
                 } for field, reasons in error.messages.items()

--- a/microcosm_flask/conventions/health.py
+++ b/microcosm_flask/conventions/health.py
@@ -9,7 +9,7 @@ from distutils.util import strtobool
 from functools import wraps
 from itertools import chain
 from logging import Logger
-from typing import Any, Dict
+from typing import Any
 
 from marshmallow import Schema, fields
 from microcosm.api import defaults
@@ -94,7 +94,7 @@ class Health:
 
         return wrapper
 
-    def to_dict(self, full=None) -> Dict[str, Any]:
+    def to_dict(self, full=None) -> dict[str, Any]:
         """
         Encode the name, the status of all checks, and the current overall status.
 
@@ -105,7 +105,7 @@ class Health:
             checks = self.checks.items()
 
         # evaluate checks
-        check_results: Dict[str, HealthResult] = {
+        check_results: dict[str, HealthResult] = {
             key: HealthResult.evaluate(self.log_error(func), self.graph)
             for key, func in checks
         }
@@ -130,13 +130,11 @@ class RetrieveHealthSchema(Schema):
 
 
 class HealthConvention(Convention):
-
     def __init__(self, graph, include_build_info=False):
         super().__init__(graph)
         self.health = Health(graph, include_build_info)
 
     def configure_retrieve(self, ns, definition):
-
         @self.add_route(ns.singleton_path, Operation.Retrieve, ns)
         @skip_logging
         def current_health():

--- a/microcosm_flask/conventions/landing.py
+++ b/microcosm_flask/conventions/landing.py
@@ -66,9 +66,9 @@ def configure_landing(graph):   # noqa: C901
             conf_string = []
         for key, value in config.items():
             if isinstance(value, dict):
-                get_env_file_commands(value, "{}__{}".format(conf_key, key), conf_string)
+                get_env_file_commands(value, f"{conf_key}__{key}", conf_string)
             else:
-                conf_string.append("export {}__{}='{}'".format(conf_key.upper(), key.upper(), value))
+                conf_string.append(f"export {conf_key.upper()}__{key.upper()}='{value}'")
         return conf_string
 
     def get_links(swagger_versions, properties):

--- a/microcosm_flask/conventions/logging_level.py
+++ b/microcosm_flask/conventions/logging_level.py
@@ -90,7 +90,7 @@ class LoggingLevelConvention(Convention):
 
     """
     def __init__(self, graph):
-        super(LoggingLevelConvention, self).__init__(graph)
+        super().__init__(graph)
         self.max_duration = float(graph.config.logging_level_convention.max_duration)
 
     def configure_retrieve(self, ns, definition):

--- a/microcosm_flask/conventions/registry.py
+++ b/microcosm_flask/conventions/registry.py
@@ -3,7 +3,7 @@ Support for registering function metadata.
 
 """
 import re
-from typing import Iterator, Optional, Tuple
+from collections.abc import Iterator
 
 from werkzeug.exceptions import InternalServerError
 
@@ -55,7 +55,7 @@ def get_converter(rule):
     return None
 
 
-def parse_rule(rule: str) -> Iterator[Tuple[Optional[str], Optional[str], str]]:
+def parse_rule(rule: str) -> Iterator[tuple[str | None, str | None, str]]:
     """
     (this method disappeared from werkzeug after version 2.1.2. Just copied here
     for simplicity)
@@ -109,9 +109,11 @@ def request(schema):
     Decorate a function with a request schema.
 
     """
+
     def wrapper(func):
         setattr(func, REQUEST, schema)
         return func
+
     return wrapper
 
 
@@ -120,9 +122,11 @@ def response(schema):
     Decorate a function with a response schema.
 
     """
+
     def wrapper(func):
         setattr(func, RESPONSE, schema)
         return func
+
     return wrapper
 
 
@@ -131,9 +135,11 @@ def qs(schema):
     Decorate a function with a query string schema.
 
     """
+
     def wrapper(func):
         setattr(func, QS, schema)
         return func
+
     return wrapper
 
 

--- a/microcosm_flask/conventions/relation.py
+++ b/microcosm_flask/conventions/relation.py
@@ -31,7 +31,7 @@ class RelationConvention(Convention):
         return OffsetLimitPage
 
     def __init__(self, graph):
-        super(RelationConvention, self).__init__(graph)
+        super().__init__(graph)
 
     def configure_createfor(self, ns, definition):
         """
@@ -63,7 +63,7 @@ class RelationConvention(Convention):
                 response_format=response_format,
             )
 
-        create.__doc__ = "Create a new {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
+        create.__doc__ = f"Create a new {pluralize(ns.object_name)} relative to a {ns.subject_name}"
 
     def configure_deletefor(self, ns, definition):
         """
@@ -93,7 +93,7 @@ class RelationConvention(Convention):
                 response_format=response_format,
             )
 
-        delete.__doc__ = "Delete a {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
+        delete.__doc__ = f"Delete a {pluralize(ns.object_name)} relative to a {ns.subject_name}"
 
     def configure_replacefor(self, ns, definition):
         """
@@ -132,7 +132,7 @@ class RelationConvention(Convention):
                 response_format=response_format,
             )
 
-        replace.__doc__ = "Replace a {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
+        replace.__doc__ = f"Replace a {pluralize(ns.object_name)} relative to a {ns.subject_name}"
 
     def configure_updatefor(self, ns, definition):
         """
@@ -171,7 +171,7 @@ class RelationConvention(Convention):
                 response_format=response_format,
             )
 
-        replace.__doc__ = "Replace a {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
+        replace.__doc__ = f"Replace a {pluralize(ns.object_name)} relative to a {ns.subject_name}"
 
     def configure_retrievefor(self, ns, definition):
         """
@@ -206,7 +206,7 @@ class RelationConvention(Convention):
                 response_format=response_format,
             )
 
-        retrieve.__doc__ = "Retrieve {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
+        retrieve.__doc__ = f"Retrieve {pluralize(ns.object_name)} relative to a {ns.subject_name}"
 
     def configure_searchfor(self, ns, definition):
         """
@@ -246,7 +246,7 @@ class RelationConvention(Convention):
                 response_format=response_format,
             )
 
-        search.__doc__ = "Search for {} relative to a {}".format(pluralize(ns.object_name), ns.subject_name)
+        search.__doc__ = f"Search for {pluralize(ns.object_name)} relative to a {ns.subject_name}"
 
 
 def configure_relation(graph, ns, mappings):

--- a/microcosm_flask/conventions/saved_search.py
+++ b/microcosm_flask/conventions/saved_search.py
@@ -58,7 +58,7 @@ class SavedSearchConvention(Convention):
                 response_format=response_format,
             )
 
-        saved_search.__doc__ = "Persist and return the search results of {}".format(pluralize(ns.subject_name))
+        saved_search.__doc__ = f"Persist and return the search results of {pluralize(ns.subject_name)}"
 
 
 def configure_saved_search(graph, ns, mappings):

--- a/microcosm_flask/conventions/upload.py
+++ b/microcosm_flask/conventions/upload.py
@@ -108,7 +108,7 @@ class UploadConvention(Convention):
 
         """
         upload = self.create_upload_func(ns, definition, ns.collection_path, Operation.Upload)
-        upload.__doc__ = "Upload a {}".format(ns.subject_name)
+        upload.__doc__ = f"Upload a {ns.subject_name}"
 
     def configure_uploadfor(self, ns, definition):
         """
@@ -124,7 +124,7 @@ class UploadConvention(Convention):
 
         """
         upload_for = self.create_upload_func(ns, definition, ns.relation_path, Operation.UploadFor)
-        upload_for.__doc__ = "Upload a {} for a {}".format(ns.subject_name, ns.object_name)
+        upload_for.__doc__ = f"Upload a {ns.subject_name} for a {ns.object_name}"
 
 
 def configure_upload(graph, ns, mappings, exclude_func=None):

--- a/microcosm_flask/decorators/schemas.py
+++ b/microcosm_flask/decorators/schemas.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import List, Optional
 
 from inflection import camelize, underscore
 from marshmallow import Schema
@@ -12,10 +11,10 @@ from microcosm_flask.swagger.naming import type_name
 @dataclass
 class SelectedField:
     name: str
-    required: Optional[bool] = None
+    required: bool | None = None
 
 
-def get_fields_from_schema(schema_cls: Schema, selected_fields: List[SelectedField]):
+def get_fields_from_schema(schema_cls: Schema, selected_fields: list[SelectedField]):
     """
     Select fields definitions from a schema
 
@@ -45,10 +44,14 @@ def associated_schema_name(schema_cls, name_suffix):
 
 
 def get_associated_schema(schema_cls, name_suffix):
-    associated_schemas = getattr(schema_cls, associated_schemas_attr_name(schema_cls), {})
+    associated_schemas = getattr(
+        schema_cls, associated_schemas_attr_name(schema_cls), {}
+    )
     if name_suffix in associated_schemas:
         return associated_schemas[name_suffix]
-    raise KeyError(f"Schema {schema_cls} does not have an associated schema with suffix {name_suffix}")
+    raise KeyError(
+        f"Schema {schema_cls} does not have an associated schema with suffix {name_suffix}"
+    )
 
 
 def set_associated_schema(target_cls, name_suffix, associated_schema):
@@ -62,7 +65,9 @@ def set_associated_schema(target_cls, name_suffix, associated_schema):
     try:
         associated_schemas = getattr(target_cls, attr_name)
         if name_suffix in associated_schemas:
-            raise ValueError(f"Schema {target_cls} already has an associated schema for suffix {name_suffix}")
+            raise ValueError(
+                f"Schema {target_cls} already has an associated schema for suffix {name_suffix}"
+            )
         associated_schemas[name_suffix] = associated_schema
     except AttributeError:
         setattr(
@@ -97,6 +102,7 @@ def add_associated_schema(name_suffix, selected_fields=(), inherits_from=(Schema
                       be passed, which will make all sected field required
 
     """
+
     def decorator(schema_cls):
         associated_fields = get_fields_from_schema(schema_cls, selected_fields)
 

--- a/microcosm_flask/fields/language_field.py
+++ b/microcosm_flask/fields/language_field.py
@@ -23,7 +23,7 @@ class LanguageField(String):
 
     def _serialize(self, value, attr, obj, **kwargs):
         validated = str(self._validated(value)) if value is not None else None
-        return super(LanguageField, self)._serialize(validated, attr, obj)
+        return super()._serialize(validated, attr, obj)
 
     def _deserialize(self, value, attr, data, **kwargs):
         return self._validated(value)

--- a/microcosm_flask/fields/timestamp_field.py
+++ b/microcosm_flask/fields/timestamp_field.py
@@ -19,7 +19,7 @@ class TimestampField(Field):
 
     def __init__(self, use_isoformat=False, *args, **kwargs):
         self.use_isoformat = use_isoformat
-        super(TimestampField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _serialize(self, value, attr, obj, **kwargs):
         """

--- a/microcosm_flask/fields/uri_field.py
+++ b/microcosm_flask/fields/uri_field.py
@@ -87,7 +87,7 @@ class URIField(Field):
     def normalize(self, value):
         result = normalize_uri_result(value)
         if not result.scheme:
-            raise ValidationError("URI scheme is required for: {}".format(value))
+            raise ValidationError(f"URI scheme is required for: {value}")
         if not result.authority:
-            raise ValidationError("URI authority is required for: {}".format(value))
+            raise ValidationError(f"URI authority is required for: {value}")
         return result.unsplit()

--- a/microcosm_flask/formatting/base.py
+++ b/microcosm_flask/formatting/base.py
@@ -17,7 +17,6 @@ except ImportError:
 
 
 class BaseFormatter(metaclass=ABCMeta):
-
     def __init__(self, response_schema=None):
         # Formatting could need the response schema
         # e.g. to specify column ordering in CSV response
@@ -41,7 +40,7 @@ class BaseFormatter(metaclass=ABCMeta):
     def build_response(self, response_data):
         return Response(
             self.format(response_data),
-            content_type=get_content_type(self.content_type, Response.charset)
+            content_type=get_content_type(self.content_type, "utf-8"),
         )
 
     def build_headers(self, headers, **kwargs):

--- a/microcosm_flask/formatting/csv_formatter.py
+++ b/microcosm_flask/formatting/csv_formatter.py
@@ -23,7 +23,7 @@ class CSVFormatter(BaseFormatter):
     def build_headers(self, headers, **kwargs):
         # TODO: pass in optional filename
         filename = "response.csv"
-        headers["Content-Disposition"] = "attachment; filename=\"{}\"".format(filename)
+        headers["Content-Disposition"] = f"attachment; filename=\"{filename}\""
 
         return headers
 

--- a/microcosm_flask/linking.py
+++ b/microcosm_flask/linking.py
@@ -95,7 +95,7 @@ class Link:
             if not allow_templates:
                 raise
             uri_templates = {
-                argument: "{{{}}}".format(argument)
+                argument: f"{{{argument}}}"
                 for argument in error.suggested.arguments
             }
             kwargs.update(uri_templates)

--- a/microcosm_flask/matchers.py
+++ b/microcosm_flask/matchers.py
@@ -65,7 +65,7 @@ class JSONMatcher(BaseMatcher):
         raise NotImplementedError
 
     def describe_to(self, description):
-        description.append_text("expected {}".format(prettify(self.expected)))
+        description.append_text(f"expected {prettify(self.expected)}")
 
 
 class URIMatcher(BaseMatcher):
@@ -88,7 +88,7 @@ class URIMatcher(BaseMatcher):
         return normalize_uri(item) == normalize_uri(self.uri)
 
     def describe_to(self, description):
-        description.append_text("expected URI: {}".format(self.uri))
+        description.append_text(f"expected URI: {self.uri}")
 
 
 def matches_uri(uri):

--- a/microcosm_flask/namespaces.py
+++ b/microcosm_flask/namespaces.py
@@ -149,7 +149,7 @@ class Namespace:
         # extract its parts
         matcher = match(operation.endpoint_pattern, endpoint)
         if not matcher:
-            raise InternalServerError("Malformed operation endpoint: {}".format(endpoint))
+            raise InternalServerError(f"Malformed operation endpoint: {endpoint}")
         kwargs = matcher.groupdict()
         del kwargs["operation"]
         if identifier_type is not None:
@@ -180,5 +180,5 @@ class Namespace:
 
         return "{}{}".format(
             url,
-            "{}{}".format(qs_character, urlencode(qs)) if qs else "",
+            f"{qs_character}{urlencode(qs)}" if qs else "",
         )

--- a/microcosm_flask/naming.py
+++ b/microcosm_flask/naming.py
@@ -53,7 +53,7 @@ def instance_path_for(name, identifier_type, identifier_key=None):
     return "/{}/<{}:{}>".format(
         name_for(name),
         identifier_type,
-        identifier_key or "{}_id".format(name_for(name)),
+        identifier_key or f"{name_for(name)}_id",
     )
 
 
@@ -76,6 +76,6 @@ def relation_path_for(from_name, to_name, identifier_type, identifier_key=None):
     return "/{}/<{}:{}>/{}".format(
         name_for(from_name),
         identifier_type,
-        identifier_key or "{}_id".format(name_for(from_name)),
+        identifier_key or f"{name_for(from_name)}_id",
         name_for(to_name),
     )

--- a/microcosm_flask/operations.py
+++ b/microcosm_flask/operations.py
@@ -76,6 +76,6 @@ class Operation(Enum):
         """
         parts = self.value.pattern.split(".")
         return "[.]".join(
-            "(?P<{}>[^.]*)".format(part[1:-1])
+            f"(?P<{part[1:-1]}>[^.]*)"
             for part in parts
         )

--- a/microcosm_flask/paging.py
+++ b/microcosm_flask/paging.py
@@ -106,7 +106,7 @@ class OffsetLimitPaginatedList(PaginatedList):
     """
 
     def __init__(self, items, count, _page, _ns, _operation, _context):
-        super(OffsetLimitPaginatedList, self).__init__(
+        super().__init__(
             items=items,
             _page=_page,
             _ns=_ns,
@@ -129,7 +129,7 @@ class OffsetLimitPaginatedList(PaginatedList):
         Include previous and next links.
 
         """
-        links = super(OffsetLimitPaginatedList, self).links
+        links = super().links
         if self._page.offset + self._page.limit < self.count:
             links["next"] = Link.for_(
                 self._operation,
@@ -234,7 +234,7 @@ class Page:
         """
 
         class PaginatedListSchema(Schema):
-            __alias__ = "{}_list".format(ns.subject_name)
+            __alias__ = f"{ns.subject_name}_list"
             items = fields.List(fields.Nested(item_schema), required=True)
             _links = fields.Raw()
 
@@ -248,7 +248,7 @@ class OffsetLimitPage(Page):
     """
 
     def __init__(self, offset=None, limit=None, **kwargs):
-        super(OffsetLimitPage, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.offset = self.default_offset if offset is None else offset
         self.limit = self.default_limit if limit is None else limit
 
@@ -276,9 +276,7 @@ class OffsetLimitPage(Page):
             return 20
 
     def to_items(self, func=str):
-        return [("offset", self.offset), ("limit", self.limit)] + super(
-            OffsetLimitPage, self
-        ).to_items(func=func)
+        return [("offset", self.offset), ("limit", self.limit)] + super().to_items(func=func)
 
     def to_paginated_list(self, result, _ns, _operation, **kwargs):
         items, count, context = self.parse_result(result)
@@ -312,7 +310,7 @@ class OffsetLimitPage(Page):
     @classmethod
     def make_paginated_list_schema_class(cls, ns, item_schema):
         class PaginatedListSchema(Schema):
-            __alias__ = "{}_list".format(ns.subject_name)
+            __alias__ = f"{ns.subject_name}_list"
 
             offset = fields.Integer(
                 required=True,

--- a/microcosm_flask/profiling.py
+++ b/microcosm_flask/profiling.py
@@ -13,7 +13,7 @@ except ImportError:
 
 
 def default_profile_dir(name):
-    return expanduser("~/.{name}/profile".format(name=name))
+    return expanduser(f"~/.{name}/profile")
 
 
 def enable_profiling(graph):

--- a/microcosm_flask/sentry.py
+++ b/microcosm_flask/sentry.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from os import environ
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import MagicMock
 
 from microcosm.decorators import defaults
@@ -17,9 +17,9 @@ except ImportError:
 
 @dataclass
 class SentryConfig:
-    dsn: Optional[str] = None
+    dsn: str | None = None
     enabled: bool = False
-    client: Optional[Any] = None
+    client: Any | None = None
 
 
 def before_send(event, hint):
@@ -64,8 +64,4 @@ def configure_sentry(graph: ObjectGraph):
             except BadDsn:
                 enabled, dsn, sentry = False, None, None
                 configure_sentry.logger.error("Bad DSN value set")
-    return SentryConfig(
-        dsn=dsn,
-        enabled=enabled,
-        client=sentry
-    )
+    return SentryConfig(dsn=dsn, enabled=enabled, client=sentry)

--- a/microcosm_flask/swagger/api.py
+++ b/microcosm_flask/swagger/api.py
@@ -2,12 +2,8 @@
 API interfaces for swagger operations.
 
 """
-from typing import (
-    Any,
-    Iterable,
-    Mapping,
-    Tuple,
-)
+from collections.abc import Iterable, Mapping
+from typing import Any
 
 from marshmallow import Schema
 from marshmallow.fields import Field
@@ -25,7 +21,9 @@ def build_schema(schema: Schema, strict_enums: bool = True) -> Mapping[str, Any]
     return builder.build(schema)
 
 
-def iter_schemas(schema: Schema, strict_enums: bool = True) -> Iterable[Tuple[str, Any]]:
+def iter_schemas(
+    schema: Schema, strict_enums: bool = True
+) -> Iterable[tuple[str, Any]]:
     """
     Build zero or more JSON schemas for a marshmallow schema.
 

--- a/microcosm_flask/swagger/naming.py
+++ b/microcosm_flask/swagger/naming.py
@@ -21,7 +21,7 @@ def operation_name(operation, ns):
     """
     verb = operation.value.name
     if ns.object_:
-        return "{}_{}".format(verb, pluralize(ns.object_name))
+        return f"{verb}_{pluralize(ns.object_name)}"
     else:
         return verb
 

--- a/microcosm_flask/swagger/parameters/__init__.py
+++ b/microcosm_flask/swagger/parameters/__init__.py
@@ -1,11 +1,7 @@
+from collections.abc import Mapping
 from functools import lru_cache
 from pkg_resources import iter_entry_points
-from typing import (
-    Any,
-    List,
-    Mapping,
-    Type,
-)
+from typing import Any
 
 from marshmallow.fields import Field
 
@@ -24,6 +20,7 @@ class Parameters:
     and delegates to the first compatible implementation.
 
     """
+
     def __init__(self, strict_enums: bool = True):
         self.strict_enums = strict_enums
 
@@ -37,7 +34,7 @@ class Parameters:
             self.default_builder_type()
         ]
 
-        builders: List[ParameterBuilder] = [
+        builders: list[ParameterBuilder] = [
             builder_type(
                 build_parameter=self.build,  # type: ignore
                 strict_enums=self.strict_enums,
@@ -45,29 +42,22 @@ class Parameters:
             for builder_type in builder_types
         ]
 
-        builder = next(
-            builder
-            for builder in builders
-            if builder.supports_field(field)
-        )
+        builder = next(builder for builder in builders if builder.supports_field(field))
 
         return builder.build(field)
 
     @classmethod
     # NB: entry point lookups can be slow; memoize
-    @lru_cache()
-    def builder_types(cls) -> List[Type[ParameterBuilder]]:
+    @lru_cache
+    def builder_types(cls) -> list[type[ParameterBuilder]]:
         """
         Define the available builder types.
 
         """
-        return [
-            entry_point.load()
-            for entry_point in iter_entry_points(ENTRY_POINT)
-        ]
+        return [entry_point.load() for entry_point in iter_entry_points(ENTRY_POINT)]
 
     @classmethod
-    def default_builder_type(cls) -> Type[ParameterBuilder]:
+    def default_builder_type(cls) -> type[ParameterBuilder]:
         """
         Define the default builder type.
 

--- a/microcosm_flask/swagger/parameters/base.py
+++ b/microcosm_flask/swagger/parameters/base.py
@@ -1,13 +1,11 @@
 from abc import ABC
-from typing import (
-    Any,
+from collections.abc import (
     Callable,
     Iterable,
     Mapping,
-    Optional,
     Sequence,
-    Tuple,
 )
+from typing import Any
 
 from marshmallow import Schema
 from marshmallow.fields import Field
@@ -53,7 +51,7 @@ class ParameterBuilder(ABC):
         """
         return False
 
-    def iter_parsed_values(self, field: Field) -> Iterable[Tuple[str, Any]]:
+    def iter_parsed_values(self, field: Field) -> Iterable[tuple[str, Any]]:
         """
         Walk the dictionary of parsers and emit all non-null values.
 
@@ -69,9 +67,9 @@ class ParameterBuilder(ABC):
         Parse the default value for the field, if any.
 
         """
-        return field.default
+        return field.dump_default
 
-    def parse_description(self, field: Field) -> Optional[str]:
+    def parse_description(self, field: Field) -> str | None:
         """
         Parse the description for the field, if any.
 
@@ -81,35 +79,35 @@ class ParameterBuilder(ABC):
             return metadata.get("description")
         return field.metadata.get("description")
 
-    def parse_enum_values(self, field: Field) -> Optional[Sequence]:
+    def parse_enum_values(self, field: Field) -> Sequence | None:
         """
         Parse enumerated value for enum fields, if any.
 
         """
         return None
 
-    def parse_format(self, field: Field) -> Optional[str]:
+    def parse_format(self, field: Field) -> str | None:
         """
         Parse the format for the field, if any.
 
         """
         return None
 
-    def parse_items(self, field: Field) -> Optional[Mapping[str, Any]]:
+    def parse_items(self, field: Field) -> Mapping[str, Any] | None:
         """
         Parse the child item type for list fields, if any.
 
         """
         return None
 
-    def parse_ref(self, field: Field) -> Optional[str]:
+    def parse_ref(self, field: Field) -> str | None:
         """
         Parse the reference type for nested fields, if any.
 
         """
         return None
 
-    def parse_type(self, field: Field) -> Optional[str]:
+    def parse_type(self, field: Field) -> str | None:
         """
         Parse the type for the field, if any.
 

--- a/microcosm_flask/swagger/parameters/constant.py
+++ b/microcosm_flask/swagger/parameters/constant.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from marshmallow.fields import Constant, Field
 
@@ -11,6 +11,7 @@ class ConstantParameterBuilder(ParameterBuilder):
     Builder parameters for constant fields.
 
     """
+
     def supports_field(self, field: Field) -> bool:
         return isinstance(field, Constant)
 
@@ -21,7 +22,7 @@ class ConstantParameterBuilder(ParameterBuilder):
         """
         return getattr(field, "constant", None)
 
-    def parse_type(self, field: Field) -> Optional[str]:
+    def parse_type(self, field: Field) -> str | None:
         constant = getattr(field, "constant", None)
         if isinstance(constant, list):
             return "array"

--- a/microcosm_flask/swagger/parameters/decorated.py
+++ b/microcosm_flask/swagger/parameters/decorated.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from marshmallow.fields import Field
 
 from microcosm_flask.swagger.parameters.base import ParameterBuilder
@@ -14,13 +12,14 @@ class DecoratedParameterBuilder(ParameterBuilder):
     Build parameter from custom attributes (injected by a decorator).
 
     """
+
     def supports_field(self, field: Field) -> bool:
         return hasattr(field, SWAGGER_TYPE)
 
-    def parse_format(self, field: Field) -> Optional[str]:
+    def parse_format(self, field: Field) -> str | None:
         return getattr(field, SWAGGER_FORMAT, None)
 
-    def parse_type(self, field: Field) -> Optional[str]:
+    def parse_type(self, field: Field) -> str | None:
         field_type = getattr(field, SWAGGER_TYPE)
         if isinstance(field_type, list):
             # Ideally we'd use oneOf here, but OpenAPI 2.0 uses the 0.4-draft jsonschema

--- a/microcosm_flask/swagger/parameters/default.py
+++ b/microcosm_flask/swagger/parameters/default.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 from logging import Logger
-from typing import Optional
 
 from marshmallow import fields
 from marshmallow.fields import Field
@@ -43,19 +42,22 @@ class DefaultParameterBuilder(ParameterBuilder):
     Builds parameters using default field mappings.
 
     """
+
     logger: Logger
 
     def supports_field(self, field: Field) -> bool:
         try:
             FIELD_MAPPINGS[type(field)]
         except KeyError:
-            self.logger.exception("No mapped swagger type for marshmallow field: %s", field)
+            self.logger.exception(
+                "No mapped swagger type for marshmallow field: %s", field
+            )
             raise
         else:
             return True
 
-    def parse_format(self, field: Field) -> Optional[str]:
+    def parse_format(self, field: Field) -> str | None:
         return FIELD_MAPPINGS[type(field)].format
 
-    def parse_type(self, field: Field) -> Optional[str]:
+    def parse_type(self, field: Field) -> str | None:
         return FIELD_MAPPINGS[type(field)].type

--- a/microcosm_flask/swagger/parameters/enum.py
+++ b/microcosm_flask/swagger/parameters/enum.py
@@ -1,10 +1,5 @@
-from typing import (
-    Any,
-    Callable,
-    Mapping,
-    Optional,
-    Sequence,
-)
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
 
 from marshmallow import Schema
 from marshmallow.fields import Field
@@ -31,6 +26,7 @@ class EnumParameterBuilder(ParameterBuilder):
     as a string.
 
     """
+
     def __init__(
         self,
         build_parameter: Callable[[Schema], Mapping[str, Any]],
@@ -43,7 +39,7 @@ class EnumParameterBuilder(ParameterBuilder):
     def supports_field(self, field: Field) -> bool:
         return bool(getattr(field, "enum", None))
 
-    def parse_format(self, field: Field) -> Optional[str]:
+    def parse_format(self, field: Field) -> str | None:
         if self.is_strict(field):
             return "enum"
 
@@ -52,22 +48,23 @@ class EnumParameterBuilder(ParameterBuilder):
     def parse_type(self, field: Field) -> str:
         enum_values = self._parse_enum_values(field)
 
-        if all((isinstance(enum_value, str) for enum_value in enum_values)):
+        if all(isinstance(enum_value, str) for enum_value in enum_values):
             return "string"
-        elif all((is_int(enum_value) for enum_value in enum_values)):
+        elif all(is_int(enum_value) for enum_value in enum_values):
             return "integer"
         else:
             raise Exception(f"Cannot infer enum type for field: {field.name}")
 
     def _parse_enum_values(self, field: Field) -> Sequence:
         if not isinstance(field, EnumField):
-            raise Exception(f"Cannot parse enum values for non-enum fields: {field.name}")
+            raise Exception(
+                f"Cannot parse enum values for non-enum fields: {field.name}"
+            )
         return [
-            choice.value if field.by_value else choice.name
-            for choice in field.enum
+            choice.value if field.by_value else choice.name for choice in field.enum
         ]
 
-    def parse_enum_values(self, field: Field) -> Optional[Sequence]:
+    def parse_enum_values(self, field: Field) -> Sequence | None:
         if self.is_strict(field):
             return self._parse_enum_values(field)
 
@@ -75,7 +72,7 @@ class EnumParameterBuilder(ParameterBuilder):
 
     def is_strict(self, field: Field) -> bool:
         return (
-            isinstance(field, EnumField) and
-            self.strict_enums and
-            getattr(field.enum, "__openapi_strict__", True)
+            isinstance(field, EnumField)
+            and self.strict_enums
+            and getattr(field.enum, "__openapi_strict__", True)
         )

--- a/microcosm_flask/swagger/parameters/list.py
+++ b/microcosm_flask/swagger/parameters/list.py
@@ -1,4 +1,5 @@
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 from marshmallow.fields import Field, List
 

--- a/microcosm_flask/swagger/parameters/numeric.py
+++ b/microcosm_flask/swagger/parameters/numeric.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from marshmallow.fields import Decimal, Field
 
 from microcosm_flask.swagger.parameters.base import ParameterBuilder
@@ -10,10 +8,11 @@ class NumericParameterBuilder(ParameterBuilder):
     Build a string-formatted numeric parameter.
 
     """
+
     def supports_field(self, field: Field) -> bool:
         return bool(getattr(field, "as_string", None))
 
-    def parse_format(self, field: Field) -> Optional[str]:
+    def parse_format(self, field: Field) -> str | None:
         if isinstance(field, Decimal):
             return "decimal"
         return None

--- a/microcosm_flask/swagger/schemas.py
+++ b/microcosm_flask/swagger/schemas.py
@@ -3,15 +3,8 @@ Generate JSON Schema for Marshmallow schemas.
 
 """
 import re
-from typing import (
-    Any,
-    Callable,
-    Iterable,
-    Mapping,
-    Set,
-    Tuple,
-    Type,
-)
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any
 
 from marshmallow import Schema
 from marshmallow.fields import Field, List, Nested
@@ -41,7 +34,7 @@ class Schemas:
 
         # NB: This will break if this class is ever instantiated and then has
         # `build` called more than once
-        self.seen_schemas: Set[Type[Schema]] = set()
+        self.seen_schemas: set[type[Schema]] = set()
 
     def build(self, schema: Schema) -> Mapping[str, Any]:
         """
@@ -72,7 +65,7 @@ class Schemas:
 
         return result
 
-    def iter_fields(self, schema: Schema) -> Iterable[Tuple[str, Field]]:
+    def iter_fields(self, schema: Schema) -> Iterable[tuple[str, Field]]:
         """
         Iterate through marshmallow schema fields.
 
@@ -85,7 +78,7 @@ class Schemas:
 
             yield field_name, field
 
-    def iter_schemas(self, schema: Schema) -> Iterable[Tuple[str, Any]]:
+    def iter_schemas(self, schema: Schema) -> Iterable[tuple[str, Any]]:
         """
         Build zero or more JSON schemas for a marshmallow schema.
 
@@ -114,5 +107,5 @@ class Schemas:
             if isinstance(field, List) and isinstance(field.inner, Nested):
                 yield from self.iter_schemas(field.inner.schema)
 
-    def to_tuple(self, schema: Schema) -> Tuple[str, Any]:
+    def to_tuple(self, schema: Schema) -> tuple[str, Any]:
         return definition_name_for_schema(schema), self.build(schema)

--- a/microcosm_flask/tests/conventions/test_alias.py
+++ b/microcosm_flask/tests/conventions/test_alias.py
@@ -39,8 +39,7 @@ PERSON_MAPPINGS = {
 
 
 class TestAlias:
-
-    def setup(self):
+    def setup_method(self):
         self.graph = create_object_graph(name="example", testing=True)
 
         self.ns = Namespace(
@@ -68,7 +67,7 @@ class TestAlias:
         assert_that(response.status_code, is_(equal_to(302)))
         assert_that(
             response.headers["Location"],
-            is_(equal_to(f"http://localhost/api/person/{PERSON_ID_1}"))
+            is_(equal_to(f"http://localhost/api/person/{PERSON_ID_1}")),
         )
 
     def test_swagger(self):

--- a/microcosm_flask/tests/conventions/test_catchall.py
+++ b/microcosm_flask/tests/conventions/test_catchall.py
@@ -13,6 +13,7 @@ def make_routes(graph):
     Create a few routes
 
     """
+
     @graph.flask.route("/")
     def root_route():
         return "root"
@@ -25,7 +26,7 @@ def make_routes(graph):
 
 
 class TestCatchall:
-    def setup(self):
+    def setup_method(self):
         self.graph = create_object_graph(name="example", testing=True)
         self.graph.use("catchall_convention")
 

--- a/microcosm_flask/tests/conventions/test_create_collection.py
+++ b/microcosm_flask/tests/conventions/test_create_collection.py
@@ -41,8 +41,7 @@ FOO_MAPPINGS = {
 
 
 class TestCreateCollection:
-
-    def setup(self):
+    def setup_method(self):
         self.graph = create_object_graph(name="example", testing=True)
 
         self.ns = Namespace(subject="foo")
@@ -111,14 +110,21 @@ class TestCreateCollection:
         )
 
         assert_that(response.status_code, is_(equal_to(200)))
-        assert_that(response.json, is_(equal_to({
-            "count": 1,
-            "offset": 0,
-            "limit": 20,
-            "items": [{"text": text}],
-            "_links": {
-                "self": {
-                    "href": "http://localhost/api/foo?offset=0&limit=20",
-                },
-            },
-        })))
+        assert_that(
+            response.json,
+            is_(
+                equal_to(
+                    {
+                        "count": 1,
+                        "offset": 0,
+                        "limit": 20,
+                        "items": [{"text": text}],
+                        "_links": {
+                            "self": {
+                                "href": "http://localhost/api/foo?offset=0&limit=20",
+                            },
+                        },
+                    }
+                )
+            ),
+        )

--- a/microcosm_flask/tests/conventions/test_create_collection_conflict.py
+++ b/microcosm_flask/tests/conventions/test_create_collection_conflict.py
@@ -9,8 +9,7 @@ from microcosm_flask.operations import Operation
 
 
 class TestCreateCollectionConflict:
-
-    def setup(self):
+    def setup_method(self):
         self.graph = create_object_graph(name="example", testing=True)
 
         self.ns = Namespace(subject="foo")

--- a/microcosm_flask/tests/conventions/test_crud.py
+++ b/microcosm_flask/tests/conventions/test_crud.py
@@ -47,7 +47,7 @@ from microcosm_flask.tests.conventions.fixtures import (
 )
 
 
-class TestEnum(Enum):
+class ForTestEnum(Enum):
     A = "A"
     B = "B"
 
@@ -57,7 +57,7 @@ class TestEnum(Enum):
 
 class SearchAddressPageSchema(OffsetLimitPageSchema):
     list_param = QueryStringList(String())
-    enum_param = EnumField(TestEnum)
+    enum_param = EnumField(ForTestEnum)
 
 
 def add_request_id(headers, response_data):
@@ -65,10 +65,19 @@ def add_request_id(headers, response_data):
 
 
 PERSON_MAPPINGS = {
-    Operation.Create: (person_create, NewPersonSchema(), PersonSchema(), add_request_id),
+    Operation.Create: (
+        person_create,
+        NewPersonSchema(),
+        PersonSchema(),
+        add_request_id,
+    ),
     Operation.Delete: (person_delete,),
     Operation.DeleteBatch: (person_delete_batch,),
-    Operation.UpdateBatch: (person_update_batch, NewPersonBatchSchema(), PersonBatchSchema()),
+    Operation.UpdateBatch: (
+        person_update_batch,
+        NewPersonBatchSchema(),
+        PersonBatchSchema(),
+    ),
     Operation.Replace: (person_replace, NewPersonSchema(), PersonSchema()),
     Operation.Retrieve: (person_retrieve, PersonLookupSchema(), PersonSchema()),
     Operation.Search: (person_search, OffsetLimitPageSchema(), PersonSchema()),
@@ -84,8 +93,7 @@ ADDRESS_MAPPINGS = {
 
 
 class TestCRUD:
-
-    def setup(self):
+    def setup_method(self):
         self.graph = create_object_graph(name="example", testing=True)
         person_ns = Namespace(subject=Person)
         address_ns = Namespace(subject=Address)
@@ -110,26 +118,32 @@ class TestCRUD:
     def test_search(self):
         uri = "/api/person"
         response = self.client.get(uri)
-        self.assert_response(response, 200, {
-            "count": 1,
-            "offset": 0,
-            "limit": 20,
-            "items": [{
-                "id": str(PERSON_ID_1),
-                "firstName": "Alice",
-                "lastName": "Smith",
+        self.assert_response(
+            response,
+            200,
+            {
+                "count": 1,
+                "offset": 0,
+                "limit": 20,
+                "items": [
+                    {
+                        "id": str(PERSON_ID_1),
+                        "firstName": "Alice",
+                        "lastName": "Smith",
+                        "_links": {
+                            "self": {
+                                "href": f"http://localhost/api/person/{PERSON_ID_1}",
+                            }
+                        },
+                    }
+                ],
                 "_links": {
                     "self": {
-                        "href": "http://localhost/api/person/{}".format(PERSON_ID_1),
+                        "href": "http://localhost/api/person?offset=0&limit=20",
                     }
                 },
-            }],
-            "_links": {
-                "self": {
-                    "href": "http://localhost/api/person?offset=0&limit=20",
-                }
-            }
-        })
+            },
+        )
 
     def test_count(self):
         uri = "/api/person"
@@ -140,25 +154,31 @@ class TestCRUD:
     def test_search_with_context(self):
         uri = "/api/address"
         response = self.client.get(uri)
-        self.assert_response(response, 200, {
-            "count": 1,
-            "offset": 0,
-            "limit": 20,
-            "items": [{
-                "id": str(ADDRESS_ID_1),
-                "addressLine": "21 Acme St., San Francisco CA 94110",
+        self.assert_response(
+            response,
+            200,
+            {
+                "count": 1,
+                "offset": 0,
+                "limit": 20,
+                "items": [
+                    {
+                        "id": str(ADDRESS_ID_1),
+                        "addressLine": "21 Acme St., San Francisco CA 94110",
+                        "_links": {
+                            "self": {
+                                "href": f"http://localhost/api/address/{ADDRESS_ID_1}",
+                            }
+                        },
+                    }
+                ],
                 "_links": {
                     "self": {
-                        "href": "http://localhost/api/address/{}".format(ADDRESS_ID_1),
+                        "href": "http://localhost/api/address?offset=0&limit=20",
                     }
                 },
-            }],
-            "_links": {
-                "self": {
-                    "href": "http://localhost/api/address?offset=0&limit=20",
-                }
-            }
-        })
+            },
+        )
 
     def test_reuse_search_self_link(self):
         uri = "/api/address"
@@ -173,25 +193,31 @@ class TestCRUD:
         response = self.client.get(
             response_data["_links"]["self"]["href"],
         )
-        self.assert_response(response, 200, {
-            "count": 1,
-            "offset": 0,
-            "limit": 20,
-            "items": [{
-                "id": str(ADDRESS_ID_1),
-                "addressLine": "a,b,c3A",
+        self.assert_response(
+            response,
+            200,
+            {
+                "count": 1,
+                "offset": 0,
+                "limit": 20,
+                "items": [
+                    {
+                        "id": str(ADDRESS_ID_1),
+                        "addressLine": "a,b,c3A",
+                        "_links": {
+                            "self": {
+                                "href": f"http://localhost/api/address/{ADDRESS_ID_1}",
+                            }
+                        },
+                    }
+                ],
                 "_links": {
                     "self": {
-                        "href": "http://localhost/api/address/{}".format(ADDRESS_ID_1),
+                        "href": "http://localhost/api/address?offset=0&limit=20&enum_param=A&list_param=a%2Cb%2Cc",
                     }
                 },
-            }],
-            "_links": {
-                "self": {
-                    "href": "http://localhost/api/address?offset=0&limit=20&enum_param=A&list_param=a%2Cb%2Cc",
-                }
-            }
-        })
+            },
+        )
 
     def test_delete_with_params(self):
         uri = f"/api/address/{ADDRESS_ID_1}"
@@ -207,164 +233,202 @@ class TestCRUD:
             "lastName": "Jones",
         }
         response = self.client.post("/api/person", json=request_data)
-        self.assert_response(response, 201, {
-            "id": str(PERSON_ID_2),
-            "firstName": "Bob",
-            "lastName": "Jones",
-            "_links": {
-                "self": {
-                    "href": "http://localhost/api/person/{}".format(PERSON_ID_2),
-                }
+        self.assert_response(
+            response,
+            201,
+            {
+                "id": str(PERSON_ID_2),
+                "firstName": "Bob",
+                "lastName": "Jones",
+                "_links": {
+                    "self": {
+                        "href": f"http://localhost/api/person/{PERSON_ID_2}",
+                    }
+                },
             },
-        })
+        )
         assert_that(response.headers["X-Person-Id"], is_(equal_to(str(PERSON_ID_2))))
         assert_that(response.headers["X-Request-Id"], is_(equal_to("request-id")))
 
     def test_create_empty_object(self):
-        response = self.client.post("/api/person", data='{}')
+        response = self.client.post("/api/person", data="{}")
         self.assert_response(response, 422)
         response_data = response.json
-        assert_that(response_data["context"]["errors"], contains_inanyorder(
-            {
-                "message": "Could not validate field: lastName",
-                "field": "lastName",
-                "reasons": [
-                    "Missing data for required field.",
-                ],
-            }, {
-                "message": "Could not validate field: firstName",
-                "field": "firstName",
-                "reasons": [
-                    "Missing data for required field.",
-                ],
-            }
-        ))
+        assert_that(
+            response_data["context"]["errors"],
+            contains_inanyorder(
+                {
+                    "message": "Could not validate field: lastName",
+                    "field": "lastName",
+                    "reasons": [
+                        "Missing data for required field.",
+                    ],
+                },
+                {
+                    "message": "Could not validate field: firstName",
+                    "field": "firstName",
+                    "reasons": [
+                        "Missing data for required field.",
+                    ],
+                },
+            ),
+        )
 
     def test_create_malformed(self):
         request_data = {
             "lastName": "Jones",
         }
         response = self.client.post("/api/person", json=request_data)
-        self.assert_response(response, 422, {
-            "code": 422,
-            "message": "Validation error",
-            "retryable": False,
-            "context": {
-                "errors": [{
-                    "message": "Could not validate field: firstName",
-                    "field": "firstName",
-                    "reasons": [
-                        "Missing data for required field.",
-                    ],
-                }]
-            }
-        })
+        self.assert_response(
+            response,
+            422,
+            {
+                "code": 422,
+                "message": "Validation error",
+                "retryable": False,
+                "context": {
+                    "errors": [
+                        {
+                            "message": "Could not validate field: firstName",
+                            "field": "firstName",
+                            "reasons": [
+                                "Missing data for required field.",
+                            ],
+                        }
+                    ]
+                },
+            },
+        )
 
     def test_update_batch(self):
         request_data = {
-            "items": [{
-                "firstName": "Bob",
-                "lastName": "Jones",
-            }],
+            "items": [
+                {
+                    "firstName": "Bob",
+                    "lastName": "Jones",
+                }
+            ],
         }
         response = self.client.patch("/api/person", json=request_data)
-        self.assert_response(response, 200, {
-            "items": [{
-                "id": str(PERSON_ID_2),
-                "firstName": "Bob",
-                "lastName": "Jones",
-                "_links": {
-                    "self": {
-                        "href": "http://localhost/api/person/{}".format(PERSON_ID_2),
+        self.assert_response(
+            response,
+            200,
+            {
+                "items": [
+                    {
+                        "id": str(PERSON_ID_2),
+                        "firstName": "Bob",
+                        "lastName": "Jones",
+                        "_links": {
+                            "self": {
+                                "href": f"http://localhost/api/person/{PERSON_ID_2}",
+                            }
+                        },
                     }
-                },
-            }],
-        })
+                ],
+            },
+        )
 
     def test_delete_batch(self):
         response = self.client.delete("/api/person")
         self.assert_response(response, 204)
 
     def test_retrieve(self):
-        uri = "/api/person/{}".format(PERSON_ID_1)
+        uri = f"/api/person/{PERSON_ID_1}"
         response = self.client.get(uri)
-        self.assert_response(response, 200, {
-            "id": str(PERSON_ID_1),
-            "firstName": "Alice",
-            "lastName": "Smith",
-            "_links": {
-                "self": {
-                    "href": "http://localhost/api/person/{}".format(PERSON_ID_1),
-                }
+        self.assert_response(
+            response,
+            200,
+            {
+                "id": str(PERSON_ID_1),
+                "firstName": "Alice",
+                "lastName": "Smith",
+                "_links": {
+                    "self": {
+                        "href": f"http://localhost/api/person/{PERSON_ID_1}",
+                    }
+                },
             },
-        })
+        )
 
     def test_retrieve_qs(self):
-        uri = "/api/person/{}?family_member=true".format(PERSON_ID_1)
+        uri = f"/api/person/{PERSON_ID_1}?family_member=true"
         response = self.client.get(uri)
-        self.assert_response(response, 200, {
-            "id": str(PERSON_ID_3),
-            "firstName": "Charlie",
-            "lastName": "Smith",
-            "_links": {
-                "self": {
-                    "href": "http://localhost/api/person/{}".format(PERSON_ID_3),
-                }
+        self.assert_response(
+            response,
+            200,
+            {
+                "id": str(PERSON_ID_3),
+                "firstName": "Charlie",
+                "lastName": "Smith",
+                "_links": {
+                    "self": {
+                        "href": f"http://localhost/api/person/{PERSON_ID_3}",
+                    }
+                },
             },
-        })
+        )
 
     def test_retrieve_not_found(self):
-        uri = "/api/person/{}".format(PERSON_ID_2)
+        uri = f"/api/person/{PERSON_ID_2}"
         response = self.client.get(uri)
         self.assert_response(response, 404)
 
     def test_delete(self):
-        uri = "/api/person/{}".format(PERSON_ID_1)
+        uri = f"/api/person/{PERSON_ID_1}"
         response = self.client.delete(uri)
         self.assert_response(response, 204)
 
     def test_delete_not_found(self):
-        uri = "/api/person/{}".format(PERSON_ID_2)
+        uri = f"/api/person/{PERSON_ID_2}"
         response = self.client.delete(uri)
         self.assert_response(response, 404)
 
     def test_replace(self):
-        uri = "/api/person/{}".format(PERSON_ID_1)
+        uri = f"/api/person/{PERSON_ID_1}"
         request_data = {
             "firstName": "Bob",
             "lastName": "Jones",
         }
         response = self.client.put(uri, json=request_data)
-        self.assert_response(response, 200, {
-            "id": str(PERSON_ID_1),
-            "firstName": "Bob",
-            "lastName": "Jones",
-            "_links": {
-                "self": {
-                    "href": "http://localhost/api/person/{}".format(PERSON_ID_1),
-                }
+        self.assert_response(
+            response,
+            200,
+            {
+                "id": str(PERSON_ID_1),
+                "firstName": "Bob",
+                "lastName": "Jones",
+                "_links": {
+                    "self": {
+                        "href": f"http://localhost/api/person/{PERSON_ID_1}",
+                    }
+                },
             },
-        })
+        )
 
     def test_update(self):
-        uri = "/api/person/{}".format(PERSON_ID_1)
+        uri = f"/api/person/{PERSON_ID_1}"
         request_data = {
             "firstName": "Bob",
         }
         response = self.client.patch(uri, json=request_data)
-        self.assert_response(response, 200, {
-            "id": str(PERSON_ID_1),
-            "firstName": "Bob",
-            "lastName": "Smith",
-            "_links": {
-                "self": {
-                    "href": "http://localhost/api/person/{}".format(PERSON_ID_1),
-                }
+        self.assert_response(
+            response,
+            200,
+            {
+                "id": str(PERSON_ID_1),
+                "firstName": "Bob",
+                "lastName": "Smith",
+                "_links": {
+                    "self": {
+                        "href": f"http://localhost/api/person/{PERSON_ID_1}",
+                    }
+                },
             },
-        })
+        )
 
     def test_update_not_found(self):
-        uri = "/api/person/{}".format(PERSON_ID_2)
+        uri = f"/api/person/{PERSON_ID_2}"
         request_data = {
             "firstName": "Bob",
         }

--- a/microcosm_flask/tests/conventions/test_csv.py
+++ b/microcosm_flask/tests/conventions/test_csv.py
@@ -36,7 +36,7 @@ from microcosm_flask.tests.conventions.fixtures import (
 )
 
 
-class TestEnum(Enum):
+class ForTestEnum(Enum):
     A = "A"
     B = "B"
 
@@ -46,7 +46,7 @@ class TestEnum(Enum):
 
 class SearchAddressPageSchema(OffsetLimitPageSchema):
     list_param = QueryStringList(String())
-    enum_param = EnumField(TestEnum)
+    enum_param = EnumField(ForTestEnum)
 
 
 def add_request_id(headers):
@@ -74,8 +74,7 @@ ADDRESS_MAPPINGS = {
 
 
 class TestCSV:
-
-    def setup(self):
+    def setup_method(self):
         self.graph = create_object_graph(name="example", testing=True)
         person_ns = Namespace(subject=Person)
         address_ns = Namespace(subject=Address)
@@ -92,7 +91,9 @@ class TestCSV:
         if status_code == 204:
             response_lines = None
         else:
-            response_lines = [row for row in reader(StringIO(response.data.decode(UTF_8_SIG)))]
+            response_lines = [
+                row for row in reader(StringIO(response.data.decode(UTF_8_SIG)))
+            ]
 
         # validate data if provided
         assert_that(
@@ -118,5 +119,5 @@ class TestCSV:
             expected_lines=[
                 ["id", "firstName", "lastName"],
                 [str(PERSON_ID_1), "Alice", "Smith"],
-            ]
+            ],
         )

--- a/microcosm_flask/tests/conventions/test_encoding.py
+++ b/microcosm_flask/tests/conventions/test_encoding.py
@@ -6,7 +6,7 @@ from microcosm_flask.enums import ResponseFormats
 
 
 class TestEncoding:
-    def setup(self):
+    def setup_method(self):
         self.graph = create_object_graph(name="example", testing=True)
 
     def test_find_response_format(self):
@@ -19,9 +19,7 @@ class TestEncoding:
                 is_(ResponseFormats.JSON),
             )
 
-        with self.graph.app.test_request_context(
-            headers=dict()
-        ):
+        with self.graph.app.test_request_context(headers=dict()):
             # If no "Accept" header default to endpoint allowed formats
             assert_that(
                 find_response_format([ResponseFormats.CSV]),
@@ -33,9 +31,7 @@ class TestEncoding:
                 equal_to(ResponseFormats.JSON),
             )
 
-        with self.graph.app.test_request_context(
-            headers=dict(Accept=["text/csv"])
-        ):
+        with self.graph.app.test_request_context(headers=dict(Accept=["text/csv"])):
             # If Accept header is present and that format is allowed, return it
             assert_that(
                 find_response_format([ResponseFormats.CSV, ResponseFormats.JSON]),

--- a/microcosm_flask/tests/conventions/test_saved_search.py
+++ b/microcosm_flask/tests/conventions/test_saved_search.py
@@ -27,19 +27,34 @@ class PersonSearch:
 
 
 class TestSavedSearch:
-
-    def setup(self):
+    def setup_method(self):
         self.graph = create_object_graph(name="example", testing=True)
         self.person_ns = Namespace(subject=Person)
         self.ns = Namespace(subject=PersonSearch)
         # ensure that link hrefs work
-        configure_crud(self.graph, self.person_ns, {
-            Operation.Retrieve: (person_retrieve, PersonLookupSchema(), PersonSchema()),
-        })
+        configure_crud(
+            self.graph,
+            self.person_ns,
+            {
+                Operation.Retrieve: (
+                    person_retrieve,
+                    PersonLookupSchema(),
+                    PersonSchema(),
+                ),
+            },
+        )
         # enable saved search
-        configure_saved_search(self.graph, self.ns, {
-            Operation.SavedSearch: (person_search, OffsetLimitPageSchema(), PersonSchema()),
-        })
+        configure_saved_search(
+            self.graph,
+            self.ns,
+            {
+                Operation.SavedSearch: (
+                    person_search,
+                    OffsetLimitPageSchema(),
+                    PersonSchema(),
+                ),
+            },
+        )
         self.client = self.graph.flask.test_client()
 
     def test_saved_search(self):

--- a/microcosm_flask/tests/conventions/test_schema_decorators.py
+++ b/microcosm_flask/tests/conventions/test_schema_decorators.py
@@ -19,8 +19,7 @@ from microcosm_flask.tests.conventions.fixtures import PersonSchema
 
 
 class TestDecorators:
-
-    def setup(self):
+    def setup_method(self):
         pass
 
     def test_get_fields_from_schema(self):
@@ -63,6 +62,7 @@ class TestDecorators:
         Registering an associated schema with an already-used suffix should raise
 
         """
+
         class ParentSchema(Schema):
             someField = fields.String(attribute="some_field")
 

--- a/microcosm_flask/tests/conventions/test_upload.py
+++ b/microcosm_flask/tests/conventions/test_upload.py
@@ -40,7 +40,6 @@ class FileResponseSchema(Schema):
 
 
 class FileController:
-
     def __init__(self):
         self.calls = []
 
@@ -67,8 +66,7 @@ class FileController:
 
 
 class TestUpload:
-
-    def setup(self):
+    def setup_method(self):
         self.graph = create_object_graph(name="example", testing=True)
 
         self.ns = Namespace(subject="file")
@@ -163,7 +161,12 @@ class TestUpload:
             all_of(
                 has_key("200"),
                 is_not(has_key("204")),
-                has_entry("200", has_entry("schema", has_entry("$ref", "#/definitions/FileResponse"))),
+                has_entry(
+                    "200",
+                    has_entry(
+                        "schema", has_entry("$ref", "#/definitions/FileResponse")
+                    ),
+                ),
             ),
         )
 
@@ -175,33 +178,46 @@ class TestUpload:
             ),
         )
         assert_that(response.status_code, is_(equal_to(204)))
-        assert_that(self.controller.calls, contains(
-            has_entries(
-                files=contains(contains("file", anything(), "hello.txt")),
-                extra="something",
+        assert_that(
+            self.controller.calls,
+            contains(
+                has_entries(
+                    files=contains(contains("file", anything(), "hello.txt")),
+                    extra="something",
+                ),
             ),
-        ))
+        )
 
     def test_upload_for(self):
         person_id = uuid4()
         response = self.client.post(
-            "/api/person/{}/file".format(person_id),
+            f"/api/person/{person_id}/file",
             data=dict(
                 file=(BytesIO(b"Hello World\n"), "hello.txt"),
             ),
         )
         assert_that(response.status_code, is_(equal_to(200)))
         response_data = loads(response.get_data().decode("utf-8"))
-        assert_that(response_data, is_(equal_to(dict(
-            id=str(person_id),
-        ))))
-        assert_that(self.controller.calls, contains(
-            has_entries(
-                files=contains(contains("file", anything(), "hello.txt")),
-                extra="something",
-                person_id=person_id,
+        assert_that(
+            response_data,
+            is_(
+                equal_to(
+                    dict(
+                        id=str(person_id),
+                    )
+                )
             ),
-        ))
+        )
+        assert_that(
+            self.controller.calls,
+            contains(
+                has_entries(
+                    files=contains(contains("file", anything(), "hello.txt")),
+                    extra="something",
+                    person_id=person_id,
+                ),
+            ),
+        )
 
     def test_upload_multipart(self):
         response = self.client.post(
@@ -212,9 +228,12 @@ class TestUpload:
             ),
         )
         assert_that(response.status_code, is_(equal_to(204)))
-        assert_that(self.controller.calls, contains(
-            has_entries(
-                files=contains(contains("file", anything(), "hello.txt")),
-                extra="special",
+        assert_that(
+            self.controller.calls,
+            contains(
+                has_entries(
+                    files=contains(contains("file", anything(), "hello.txt")),
+                    extra="special",
+                ),
             ),
-        ))
+        )

--- a/microcosm_flask/tests/encryption/conventions/fixtures/encryptable_models.py
+++ b/microcosm_flask/tests/encryption/conventions/fixtures/encryptable_models.py
@@ -3,15 +3,14 @@ An end-user message in a chatroom.
 
 """
 from dataclasses import dataclass
-from typing import Optional
 from uuid import UUID
 
 
 @dataclass
 class Encryptable:
     id: UUID
-    value: Optional[str] = None
-    other_value: Optional[str] = None
+    value: str | None = None
+    other_value: str | None = None
 
     # # encryption support
     # __encrypted_identifier__ = "encrypted_chatroom_message_id"

--- a/microcosm_flask/tests/encryption/conventions/test_crud.py
+++ b/microcosm_flask/tests/encryption/conventions/test_crud.py
@@ -9,8 +9,7 @@ import microcosm_flask.tests.encryption.conventions.fixtures.encryptable_store  
 
 
 class TestCRUD:
-
-    def setup(self):
+    def setup_method(self):
         self.graph = create_object_graph(name="example", testing=True)
         self.graph.use(
             "encryptable_crud_routes",
@@ -39,11 +38,15 @@ class TestCRUD:
             "otherValue": "Apple",
         }
         response = self.client.patch(uri, json=request_data)
-        self.assert_response(response, 200, {
-            "id": str(encryptable_id1),
-            "value": "Chair",
-            "otherValue": "Apple",
-        })
+        self.assert_response(
+            response,
+            200,
+            {
+                "id": str(encryptable_id1),
+                "value": "Chair",
+                "otherValue": "Apple",
+            },
+        )
 
     def test_update_to_null(self):
         encryptable_id1 = uuid4()
@@ -52,18 +55,26 @@ class TestCRUD:
             "value": None,
         }
         response = self.client.patch(uri, json=request_data)
-        self.assert_response(response, 200, {
-            "id": str(encryptable_id1),
-            "value": None,
-            "otherValue": None,
-        })
+        self.assert_response(
+            response,
+            200,
+            {
+                "id": str(encryptable_id1),
+                "value": None,
+                "otherValue": None,
+            },
+        )
 
     def test_empty_update(self):
         encryptable_id1 = uuid4()
         uri = f"/api/v1/encryptable/{encryptable_id1}"
         response = self.client.patch(uri, json={})
-        self.assert_response(response, 200, {
-            "id": str(encryptable_id1),
-            "value": "current_value",
-            "otherValue": None,
-        })
+        self.assert_response(
+            response,
+            200,
+            {
+                "id": str(encryptable_id1),
+                "value": "current_value",
+                "otherValue": None,
+            },
+        )

--- a/microcosm_flask/tests/fields/test_enum_field.py
+++ b/microcosm_flask/tests/fields/test_enum_field.py
@@ -18,22 +18,22 @@ from microcosm_flask.fields import EnumField
 
 
 @unique
-class TestEnum(Enum):
+class ForTestEnum(Enum):
     Foo = "foo"
     Bar = "bar"
 
 
 @unique
-class TestIntEnum(IntEnum):
+class ForTestIntEnum(IntEnum):
     Foo = 1
     Bar = 2
 
 
 class EnumSchema(Schema):
-    name = EnumField(TestEnum, by_value=False)
-    value = EnumField(TestEnum, by_value=True)
-    int_name = EnumField(TestIntEnum, by_value=False)
-    int_value = EnumField(TestIntEnum, by_value=True)
+    name = EnumField(ForTestEnum, by_value=False)
+    value = EnumField(ForTestEnum, by_value=True)
+    int_name = EnumField(ForTestIntEnum, by_value=False)
+    int_value = EnumField(ForTestIntEnum, by_value=True)
 
 
 def test_load_enums():
@@ -42,17 +42,19 @@ def test_load_enums():
 
     """
     schema = EnumSchema()
-    result = schema.load({
-        "name": TestEnum.Foo.name,
-        "value": TestEnum.Bar.value,
-        "int_name": TestIntEnum.Foo.name,
-        "int_value": TestIntEnum.Bar.value,
-    })
+    result = schema.load(
+        {
+            "name": ForTestEnum.Foo.name,
+            "value": ForTestEnum.Bar.value,
+            "int_name": ForTestIntEnum.Foo.name,
+            "int_value": ForTestIntEnum.Bar.value,
+        }
+    )
 
-    assert_that(result["name"], is_(equal_to(TestEnum.Foo)))
-    assert_that(result["value"], is_(equal_to(TestEnum.Bar)))
-    assert_that(result["int_name"], is_(equal_to(TestIntEnum.Foo)))
-    assert_that(result["int_value"], is_(equal_to(TestIntEnum.Bar)))
+    assert_that(result["name"], is_(equal_to(ForTestEnum.Foo)))
+    assert_that(result["value"], is_(equal_to(ForTestEnum.Bar)))
+    assert_that(result["int_name"], is_(equal_to(ForTestIntEnum.Foo)))
+    assert_that(result["int_value"], is_(equal_to(ForTestIntEnum.Bar)))
 
 
 def test_dump_enums():
@@ -61,17 +63,19 @@ def test_dump_enums():
 
     """
     schema = EnumSchema()
-    result = schema.dump({
-        "name": TestEnum.Foo,
-        "value": TestEnum.Bar,
-        "int_name": TestIntEnum.Foo,
-        "int_value": TestIntEnum.Bar,
-    })
+    result = schema.dump(
+        {
+            "name": ForTestEnum.Foo,
+            "value": ForTestEnum.Bar,
+            "int_name": ForTestIntEnum.Foo,
+            "int_value": ForTestIntEnum.Bar,
+        }
+    )
 
-    assert_that(result["name"], is_(equal_to(TestEnum.Foo.name)))
-    assert_that(result["value"], is_(equal_to(TestEnum.Bar.value)))
-    assert_that(result["int_name"], is_(equal_to(TestIntEnum.Foo.name)))
-    assert_that(result["int_value"], is_(equal_to(TestIntEnum.Bar.value)))
+    assert_that(result["name"], is_(equal_to(ForTestEnum.Foo.name)))
+    assert_that(result["value"], is_(equal_to(ForTestEnum.Bar.value)))
+    assert_that(result["int_name"], is_(equal_to(ForTestIntEnum.Foo.name)))
+    assert_that(result["int_value"], is_(equal_to(ForTestIntEnum.Bar.value)))
 
 
 def test_load_int_enum_as_string():
@@ -80,31 +84,42 @@ def test_load_int_enum_as_string():
 
     """
     schema = EnumSchema()
-    result = schema.load({
-        "int_value": str(TestIntEnum.Bar.value),
-    })
+    result = schema.load(
+        {
+            "int_value": str(ForTestIntEnum.Bar.value),
+        }
+    )
 
-    assert_that(result["int_value"], is_(equal_to(TestIntEnum.Bar)))
+    assert_that(result["int_value"], is_(equal_to(ForTestIntEnum.Bar)))
 
 
 def test_dump_value_from_string():
     schema = EnumSchema()
-    result = schema.dump({
-        "name": "foo",
-        "value": "bar",
-    })
+    result = schema.dump(
+        {
+            "name": "foo",
+            "value": "bar",
+        }
+    )
 
-    assert_that(result, is_(has_entries(
-        name="foo",
-        value="bar",
-    )))
+    assert_that(
+        result,
+        is_(
+            has_entries(
+                name="foo",
+                value="bar",
+            )
+        ),
+    )
 
 
 def test_load_invalid():
     schema = EnumSchema()
     assert_that(
-        calling(schema.load).with_args(dict(
-            name="unknown",
-        )),
+        calling(schema.load).with_args(
+            dict(
+                name="unknown",
+            )
+        ),
         raises(ValidationError),
     )

--- a/microcosm_flask/tests/fields/test_query_string_list.py
+++ b/microcosm_flask/tests/fields/test_query_string_list.py
@@ -20,13 +20,13 @@ class NullableQueryStringListSchema(Schema):
     foo_ids = QueryStringList(String(), allow_none=True)
 
 
-class TestEnum(Enum):
+class ForTestEnum(Enum):
     A = "A"
     B = "B"
 
 
 class EnumQueryStringListSchema(Schema):
-    foo_ids = QueryStringList(EnumField(TestEnum))
+    foo_ids = QueryStringList(EnumField(ForTestEnum))
 
 
 def test_query_list_deserialize_items():
@@ -35,7 +35,7 @@ def test_query_list_deserialize_items():
         ImmutableMultiDict([("foo_ids", "A,B")]),
     )
 
-    assert_that(result["foo_ids"], is_(equal_to([TestEnum.A, TestEnum.B])))
+    assert_that(result["foo_ids"], is_(equal_to([ForTestEnum.A, ForTestEnum.B])))
 
 
 def test_query_list_load_with_comma_separated_single_keys():
@@ -88,8 +88,10 @@ def test_none_query_list_load():
 
 def test_query_list_dump():
     schema = QueryStringListSchema()
-    result = schema.dump({
-        "foo_ids": ["a"],
-    })
+    result = schema.dump(
+        {
+            "foo_ids": ["a"],
+        }
+    )
 
     assert_that(result["foo_ids"], is_(equal_to(["a"])))

--- a/microcosm_flask/tests/fields/test_uri_field.py
+++ b/microcosm_flask/tests/fields/test_uri_field.py
@@ -2,6 +2,7 @@
 Test URI field.
 
 """
+import pytest
 from hamcrest import (
     assert_that,
     calling,
@@ -19,32 +20,35 @@ class URISchema(Schema):
     foo = URIField(include_query=True)
 
 
-def test_normalize_uri():
-    CASES = [
+@pytest.mark.parametrize(
+    "uri, expected",
+    [
         ("http://example.com", "http://example.com"),
         ("http://example.com/", "http://example.com"),
         ("http://example.com//", "http://example.com"),
         ("http://example.com/foo/", "http://example.com/foo"),
-        ("http://username:password@example.com", "http://username:password@example.com"),
+        (
+            "http://username:password@example.com",
+            "http://username:password@example.com",
+        ),
         ("http://ExAmPlE.com", "http://example.com"),
         ("http://example.com:80", "http://example.com"),
         ("http://example.com:8080", "http://example.com:8080"),
         ("http://example.com/Foo#Bar", "http://example.com/Foo#Bar"),
         ("http://example.com/?foo=bar&bar=baz", "http://example.com?bar=baz&foo=bar"),
-    ]
-
-    def _assert_equal(normalized_uri, expected):
-        assert_that(normalized_uri, is_(equal_to(expected)))
-
-    for uri, expected in CASES:
-        yield _assert_equal, normalize_uri(uri), expected
+    ],
+)
+def test_normalize_uri(uri, expected):
+    assert_that(normalize_uri(uri), is_(equal_to(expected)))
 
 
 def test_uri_dump():
     schema = URISchema()
-    result = schema.dump(dict(
-        foo="http://example.com",
-    ))
+    result = schema.dump(
+        dict(
+            foo="http://example.com",
+        )
+    )
     assert_that(result["foo"], is_(equal_to("http://example.com")))
 
 
@@ -62,9 +66,11 @@ def test_uri_dump_malformed():
 
 def test_uri_load():
     schema = URISchema()
-    result = schema.load(dict(
-        foo="http://example.com",
-    ))
+    result = schema.load(
+        dict(
+            foo="http://example.com",
+        )
+    )
     assert_that(result["foo"], is_(equal_to("http://example.com")))
 
 

--- a/microcosm_flask/tests/formatting/test_csv_formatter.py
+++ b/microcosm_flask/tests/formatting/test_csv_formatter.py
@@ -2,8 +2,6 @@
 Test CSV formatting.
 
 """
-from codecs import BOM_UTF8
-
 from hamcrest import (
     assert_that,
     contains_inanyorder,
@@ -19,81 +17,124 @@ from microcosm_flask.tests.formatting.base import etag_for
 def test_make_response():
     formatter = CSVFormatter()
 
-    response = formatter(dict(items=[
-        dict(foo="bar"),
-        dict(foo="baz"),
-    ]))
+    response = formatter(
+        dict(
+            items=[
+                dict(foo="bar"),
+                dict(foo="baz"),
+            ]
+        )
+    )
 
-    assert_that(response.data, is_(equal_to(BOM_UTF8 + b"foo\r\nbar\r\nbaz\r\n")))
+    assert_that(response.data, is_(equal_to(b"foo\r\nbar\r\nbaz\r\n")))
     assert_that(response.content_type, is_(equal_to("text/csv; charset=utf-8")))
-    assert_that(response.headers, contains_inanyorder(
-        ("Content-Disposition", "attachment; filename=\"response.csv\""),
-        ("Content-Type", "text/csv; charset=utf-8"),
-        ("ETag", etag_for(
-            sha1_hash='"a1ce622dcb1bcf03565e4d6925adb1e752d86080"',
-            spooky_hash='"e264d2b6b13c5298cb2059716018aa4d"',
-        )),
-    ))
+    assert_that(
+        response.headers,
+        contains_inanyorder(
+            ("Content-Disposition", 'attachment; filename="response.csv"'),
+            ("Content-Type", "text/csv; charset=utf-8"),
+            (
+                "ETag",
+                etag_for(
+                    sha1_hash='"959fa0271c7e205c28d778030661eb8e608e6c10"',
+                    spooky_hash='"e264d2b6b13c5298cb2059716018aa4d"',
+                ),
+            ),
+        ),
+    )
 
 
 def test_make_response_tuples():
     formatter = CSVFormatter()
 
-    response = formatter(dict(items=[
-        ("a", "b", "c"),
-        ("d", "e", "f"),
-    ]))
+    response = formatter(
+        dict(
+            items=[
+                ("a", "b", "c"),
+                ("d", "e", "f"),
+            ]
+        )
+    )
 
-    assert_that(response.data, is_(equal_to(BOM_UTF8 + b"a,b,c\r\nd,e,f\r\n")))
+    assert_that(response.data, is_(equal_to(b"a,b,c\r\nd,e,f\r\n")))
     assert_that(response.content_type, is_(equal_to("text/csv; charset=utf-8")))
-    assert_that(response.headers, contains_inanyorder(
-        ("Content-Disposition", "attachment; filename=\"response.csv\""),
-        ("Content-Type", "text/csv; charset=utf-8"),
-        ("ETag", etag_for(
-            sha1_hash='"e4020b884f3ea6fe2bdd18dbf50495bcc32bb430"',
-            spooky_hash='"37cd063df88efefe1929f3cf4532b718"',
-        )),
-    ))
+    assert_that(
+        response.headers,
+        contains_inanyorder(
+            ("Content-Disposition", 'attachment; filename="response.csv"'),
+            ("Content-Type", "text/csv; charset=utf-8"),
+            (
+                "ETag",
+                etag_for(
+                    sha1_hash='"968dd638d0cf781bdff97e5c44c8cc34915600c1"',
+                    spooky_hash='"37cd063df88efefe1929f3cf4532b718"',
+                ),
+            ),
+        ),
+    )
 
 
 def test_make_response_list():
     formatter = CSVFormatter()
 
-    response = formatter(dict(items=[
-        ["a", "b", "c"],
-        ["d", "e", "f"],
-    ]))
+    response = formatter(
+        dict(
+            items=[
+                ["a", "b", "c"],
+                ["d", "e", "f"],
+            ]
+        )
+    )
 
-    assert_that(response.data, is_(equal_to(BOM_UTF8 + b"a,b,c\r\nd,e,f\r\n")))
+    assert_that(response.data, is_(equal_to(b"a,b,c\r\nd,e,f\r\n")))
     assert_that(response.content_type, is_(equal_to("text/csv; charset=utf-8")))
-    assert_that(response.headers, contains_inanyorder(
-        ("Content-Disposition", "attachment; filename=\"response.csv\""),
-        ("Content-Type", "text/csv; charset=utf-8"),
-        ("ETag", etag_for(
-            sha1_hash='"e4020b884f3ea6fe2bdd18dbf50495bcc32bb430"',
-            spooky_hash='"37cd063df88efefe1929f3cf4532b718"',
-        )),
-    ))
+    assert_that(
+        response.headers,
+        contains_inanyorder(
+            ("Content-Disposition", 'attachment; filename="response.csv"'),
+            ("Content-Type", "text/csv; charset=utf-8"),
+            (
+                "ETag",
+                etag_for(
+                    sha1_hash='"968dd638d0cf781bdff97e5c44c8cc34915600c1"',
+                    spooky_hash='"37cd063df88efefe1929f3cf4532b718"',
+                ),
+            ),
+        ),
+    )
 
 
 def test_make_response_ordered():
     formatter = CSVFormatter(PersonCSVSchema())
 
-    response = formatter(dict(items=[
+    response = formatter(
         dict(
-            firstName="First",
-            lastName="Last",
-            id="me",
+            items=[
+                dict(
+                    firstName="First",
+                    lastName="Last",
+                    id="me",
+                )
+            ]
         )
-    ]))
+    )
 
-    assert_that(response.data, is_(equal_to(BOM_UTF8 + b"id,firstName,lastName\r\nme,First,Last\r\n")))
+    assert_that(
+        response.data,
+        is_(equal_to(b"id,firstName,lastName\r\nme,First,Last\r\n")),
+    )
     assert_that(response.content_type, is_(equal_to("text/csv; charset=utf-8")))
-    assert_that(response.headers, contains_inanyorder(
-        ("Content-Disposition", "attachment; filename=\"response.csv\""),
-        ("Content-Type", "text/csv; charset=utf-8"),
-        ("ETag", etag_for(
-            sha1_hash='"9f2b4c62a05e78d0417a92741321f03e3382cb56"',
-            spooky_hash='"994df8aa1632af103265ebeae37a3804"',
-        )),
-    ))
+    assert_that(
+        response.headers,
+        contains_inanyorder(
+            ("Content-Disposition", 'attachment; filename="response.csv"'),
+            ("Content-Type", "text/csv; charset=utf-8"),
+            (
+                "ETag",
+                etag_for(
+                    sha1_hash='"2b89c86c79efb72d290983d7b6406da43da65a06"',
+                    spooky_hash='"994df8aa1632af103265ebeae37a3804"',
+                ),
+            ),
+        ),
+    )

--- a/microcosm_flask/tests/swagger/parameters/test_constant.py
+++ b/microcosm_flask/tests/swagger/parameters/test_constant.py
@@ -4,30 +4,51 @@ from marshmallow import Schema, fields
 from microcosm_flask.swagger.api import build_parameter
 
 
-class TestSchema(Schema):
+class ForTestSchema(Schema):
     deprecated_constant_list = fields.Constant(constant=[], dump_only=True)
     deprecated_constant_string = fields.Constant(constant="HELLO", dump_only=True)
     deprecated_constant_int = fields.Constant(constant=123, dump_only=True)
 
 
 def test_field_constant_list():
-    parameter = build_parameter(TestSchema().fields["deprecated_constant_list"])
-    assert_that(parameter, is_(equal_to({
-        "type": "array",
-    })))
+    parameter = build_parameter(ForTestSchema().fields["deprecated_constant_list"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "array",
+                }
+            )
+        ),
+    )
 
 
 def test_field_constant_string():
-    parameter = build_parameter(TestSchema().fields["deprecated_constant_string"])
-    assert_that(parameter, is_(equal_to({
-        "type": "string",
-        "default": "HELLO",
-    })))
+    parameter = build_parameter(ForTestSchema().fields["deprecated_constant_string"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "string",
+                    "default": "HELLO",
+                }
+            )
+        ),
+    )
 
 
 def test_field_constant_int():
-    parameter = build_parameter(TestSchema().fields["deprecated_constant_int"])
-    assert_that(parameter, is_(equal_to({
-        "type": "integer",
-        "default": 123,
-    })))
+    parameter = build_parameter(ForTestSchema().fields["deprecated_constant_int"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "integer",
+                    "default": 123,
+                }
+            )
+        ),
+    )

--- a/microcosm_flask/tests/swagger/parameters/test_decorated.py
+++ b/microcosm_flask/tests/swagger/parameters/test_decorated.py
@@ -9,7 +9,7 @@ class MixedField(fields.Field):
     __swagger_type__ = ["integer", "string"]
 
 
-class TestSchema(Schema):
+class ForTestSchema(Schema):
     decorated = swagger_field(swagger_format="uuid")(
         fields.Method(),
     )
@@ -17,14 +17,20 @@ class TestSchema(Schema):
 
 
 def test_field_decorated():
-    parameter = build_parameter(TestSchema().fields["decorated"])
-    assert_that(parameter, is_(equal_to({
-        "type": "string",
-        "format": "uuid",
-    })))
+    parameter = build_parameter(ForTestSchema().fields["decorated"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "string",
+                    "format": "uuid",
+                }
+            )
+        ),
+    )
 
 
 def test_field_one_of():
-    parameter = build_parameter(TestSchema().fields["mixed"])
-    assert_that(parameter, is_(equal_to({
-    })))
+    parameter = build_parameter(ForTestSchema().fields["mixed"])
+    assert_that(parameter, is_(equal_to({})))

--- a/microcosm_flask/tests/swagger/parameters/test_default.py
+++ b/microcosm_flask/tests/swagger/parameters/test_default.py
@@ -4,7 +4,7 @@ from marshmallow import Schema, fields
 from microcosm_flask.swagger.api import build_parameter
 
 
-class TestSchema(Schema):
+class ForTestSchema(Schema):
     id = fields.UUID()
     foo = fields.String(metadata={"description": "Foo"}, dump_default="bar")
     payload = fields.Dict()
@@ -12,24 +12,45 @@ class TestSchema(Schema):
 
 
 def test_field_description_and_default():
-    parameter = build_parameter(TestSchema().fields["foo"])
-    assert_that(parameter, is_(equal_to({
-        "type": "string",
-        "description": "Foo",
-        "default": "bar",
-    })))
+    parameter = build_parameter(ForTestSchema().fields["foo"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "string",
+                    "description": "Foo",
+                    "default": "bar",
+                }
+            )
+        ),
+    )
 
 
 def test_field_uuid():
-    parameter = build_parameter(TestSchema().fields["id"])
-    assert_that(parameter, is_(equal_to({
-        "type": "string",
-        "format": "uuid",
-    })))
+    parameter = build_parameter(ForTestSchema().fields["id"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "string",
+                    "format": "uuid",
+                }
+            )
+        ),
+    )
 
 
 def test_field_dict():
-    parameter = build_parameter(TestSchema().fields["payload"])
-    assert_that(parameter, is_(equal_to({
-        "type": "object",
-    })))
+    parameter = build_parameter(ForTestSchema().fields["payload"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "object",
+                }
+            )
+        ),
+    )

--- a/microcosm_flask/tests/swagger/parameters/test_enum.py
+++ b/microcosm_flask/tests/swagger/parameters/test_enum.py
@@ -32,44 +32,69 @@ class ChoicesNonStrict(Enum, metaclass=FormatNonStrictMeta):
     Profit = "profit"
 
 
-class TestSchema(Schema):
+class ForTestSchema(Schema):
     choice = EnumField(Choices)
     value = EnumField(ValueType, by_value=True)
     choice_non_strict = EnumField(ChoicesNonStrict)
 
 
 def test_field_enum():
-    parameter = build_parameter(TestSchema().fields["choice"])
-    assert_that(parameter, is_(equal_to({
-        "format": "enum",
-        "type": "string",
-        "enum": [
-            "Profit",
-        ],
-    })))
+    parameter = build_parameter(ForTestSchema().fields["choice"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "format": "enum",
+                    "type": "string",
+                    "enum": [
+                        "Profit",
+                    ],
+                }
+            )
+        ),
+    )
 
 
 def test_field_enum_non_strict():
-    parameter = build_parameter(TestSchema().fields["choice"], strict_enums=False)
-    assert_that(parameter, is_(equal_to({
-        "type": "string",
-    })))
+    parameter = build_parameter(ForTestSchema().fields["choice"], strict_enums=False)
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "string",
+                }
+            )
+        ),
+    )
 
 
 def test_field_int_enum():
-    parameter = build_parameter(TestSchema().fields["value"])
-    assert_that(parameter, is_(equal_to({
-        "format": "enum",
-        "type": "integer",
-        "enum": [
-            1,
-            2
-        ],
-    })))
+    parameter = build_parameter(ForTestSchema().fields["value"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "format": "enum",
+                    "type": "integer",
+                    "enum": [1, 2],
+                }
+            )
+        ),
+    )
 
 
 def test_enum_format_override():
-    parameter = build_parameter(TestSchema().fields["choice_non_strict"])
-    assert_that(parameter, is_(equal_to({
-        "type": "string",
-    })))
+    parameter = build_parameter(ForTestSchema().fields["choice_non_strict"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "string",
+                }
+            )
+        ),
+    )

--- a/microcosm_flask/tests/swagger/parameters/test_list.py
+++ b/microcosm_flask/tests/swagger/parameters/test_list.py
@@ -5,27 +5,41 @@ from microcosm_flask.fields import QueryStringList
 from microcosm_flask.swagger.api import build_parameter
 
 
-class TestSchema(Schema):
+class ForTestSchema(Schema):
     names = fields.List(fields.String)
     qs = QueryStringList(fields.URL)
 
 
 def test_field_list():
-    parameter = build_parameter(TestSchema().fields["names"])
-    assert_that(parameter, is_(equal_to({
-        "type": "array",
-        "items": {
-            "type": "string",
-        }
-    })))
+    parameter = build_parameter(ForTestSchema().fields["names"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                    },
+                }
+            )
+        ),
+    )
 
 
 def test_field_query_string_list():
-    parameter = build_parameter(TestSchema().fields["qs"])
-    assert_that(parameter, is_(equal_to({
-        "type": "array",
-        "items": {
-            "format": "url",
-            "type": "string",
-        }
-    })))
+    parameter = build_parameter(ForTestSchema().fields["qs"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "array",
+                    "items": {
+                        "format": "url",
+                        "type": "string",
+                    },
+                }
+            )
+        ),
+    )

--- a/microcosm_flask/tests/swagger/parameters/test_nested.py
+++ b/microcosm_flask/tests/swagger/parameters/test_nested.py
@@ -5,12 +5,19 @@ from microcosm_flask.swagger.api import build_parameter
 from microcosm_flask.tests.conventions.fixtures import NewPersonSchema
 
 
-class TestSchema(Schema):
+class ForTestSchema(Schema):
     ref = fields.Nested(NewPersonSchema)
 
 
 def test_field_nested():
-    parameter = build_parameter(TestSchema().fields["ref"])
-    assert_that(parameter, is_(equal_to({
-        "$ref": "#/definitions/NewPerson",
-    })))
+    parameter = build_parameter(ForTestSchema().fields["ref"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "$ref": "#/definitions/NewPerson",
+                }
+            )
+        ),
+    )

--- a/microcosm_flask/tests/swagger/parameters/test_numeric.py
+++ b/microcosm_flask/tests/swagger/parameters/test_numeric.py
@@ -4,21 +4,35 @@ from marshmallow import Schema, fields
 from microcosm_flask.swagger.api import build_parameter
 
 
-class TestSchema(Schema):
+class ForTestSchema(Schema):
     decimal = fields.Decimal()
     decimalString = fields.Decimal(as_string=True)
 
 
 def test_field_decimal():
-    parameter = build_parameter(TestSchema().fields["decimal"])
-    assert_that(parameter, is_(equal_to({
-        "type": "number",
-    })))
+    parameter = build_parameter(ForTestSchema().fields["decimal"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "number",
+                }
+            )
+        ),
+    )
 
 
 def test_field_decimal_as_string():
-    parameter = build_parameter(TestSchema().fields["decimalString"])
-    assert_that(parameter, is_(equal_to({
-        "type": "string",
-        "format": "decimal",
-    })))
+    parameter = build_parameter(ForTestSchema().fields["decimalString"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "string",
+                    "format": "decimal",
+                }
+            )
+        ),
+    )

--- a/microcosm_flask/tests/swagger/parameters/test_timestamp.py
+++ b/microcosm_flask/tests/swagger/parameters/test_timestamp.py
@@ -5,22 +5,36 @@ from microcosm_flask.fields import TimestampField
 from microcosm_flask.swagger.api import build_parameter
 
 
-class TestSchema(Schema):
+class ForTestSchema(Schema):
     unix_timestamp = TimestampField()
     iso_timestamp = TimestampField(use_isoformat=True)
 
 
 def test_field_unix_timestamp():
-    parameter = build_parameter(TestSchema().fields["unix_timestamp"])
-    assert_that(parameter, is_(equal_to({
-        "type": "float",
-        "format": "timestamp",
-    })))
+    parameter = build_parameter(ForTestSchema().fields["unix_timestamp"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "float",
+                    "format": "timestamp",
+                }
+            )
+        ),
+    )
 
 
 def test_field_iso_timestamp():
-    parameter = build_parameter(TestSchema().fields["iso_timestamp"])
-    assert_that(parameter, is_(equal_to({
-        "type": "string",
-        "format": "date-time",
-    })))
+    parameter = build_parameter(ForTestSchema().fields["iso_timestamp"])
+    assert_that(
+        parameter,
+        is_(
+            equal_to(
+                {
+                    "type": "string",
+                    "format": "date-time",
+                }
+            )
+        ),
+    )

--- a/microcosm_flask/tests/swagger/test_definitions.py
+++ b/microcosm_flask/tests/swagger/test_definitions.py
@@ -310,7 +310,7 @@ def test_build_integer_valued_param():
         swagger_schema = build_swagger(graph, ns, operations)
 
         assert_that(
-            build_path_for_integer_param(ns, Operation.Update, set(["person_id"])),
+            build_path_for_integer_param(ns, Operation.Update, {"person_id"}),
             equal_to("/api/v1/person/{person_id}"),
         )
 

--- a/microcosm_flask/tests/test_audit.py
+++ b/microcosm_flask/tests/test_audit.py
@@ -2,7 +2,7 @@
 Audit structure tests.
 
 """
-from logging import DEBUG, NOTSET, getLogger
+from logging import DEBUG, WARNING, getLogger
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -34,7 +34,8 @@ class TestRequestInfo:
     Test capturing of request data.
 
     """
-    def setup(self):
+
+    def setup_method(self):
         self.graph = create_object_graph("example", testing=True, debug=True)
         self.graph.use(
             "flask",
@@ -62,11 +63,15 @@ class TestRequestInfo:
             dct = request_info.to_dict()
             assert_that(
                 dct,
-                is_(equal_to(dict(
-                    operation="test_func",
-                    method="GET",
-                    func="test_func",
-                ))),
+                is_(
+                    equal_to(
+                        dict(
+                            operation="test_func",
+                            method="GET",
+                            func="test_func",
+                        )
+                    )
+                ),
             )
 
     def test_request_context(self):
@@ -74,18 +79,26 @@ class TestRequestInfo:
         Log entries can include context from headers.
 
         """
-        with self.graph.flask.test_request_context("/", headers={"X-Request-Id": "request-id"}):
-            request_info = RequestInfo(self.options, test_func, self.graph.request_context)
+        with self.graph.flask.test_request_context(
+            "/", headers={"X-Request-Id": "request-id"}
+        ):
+            request_info = RequestInfo(
+                self.options, test_func, self.graph.request_context
+            )
             dct = request_info.to_dict()
             request_id = dct.pop("X-Request-Id")
             assert_that(request_id, is_(equal_to("request-id")))
             assert_that(
                 dct,
-                is_(equal_to(dict(
-                    operation="test_func",
-                    method="GET",
-                    func="test_func",
-                ))),
+                is_(
+                    equal_to(
+                        dict(
+                            operation="test_func",
+                            method="GET",
+                            func="test_func",
+                        )
+                    )
+                ),
             )
 
     def test_success(self):
@@ -95,21 +108,26 @@ class TestRequestInfo:
         """
         with self.graph.flask.test_request_context("/"):
             request_info = RequestInfo(self.options, test_func, None)
-            request_info.capture_response(MagicMock(
-                data="{}",
-                status_code=201,
-            ))
+            request_info.capture_response(
+                MagicMock(
+                    data="{}",
+                    status_code=201,
+                )
+            )
             dct = request_info.to_dict()
             assert_that(
                 dct,
-                is_(equal_to(dict(
-                    operation="test_func",
-                    method="GET",
-                    func="test_func",
-
-                    success=True,
-                    status_code=201,
-                ))),
+                is_(
+                    equal_to(
+                        dict(
+                            operation="test_func",
+                            method="GET",
+                            func="test_func",
+                            success=True,
+                            status_code=201,
+                        )
+                    )
+                ),
             )
 
     def test_error(self):
@@ -130,16 +148,19 @@ class TestRequestInfo:
             assert_that(stack_trace, is_not(none()))
             assert_that(
                 dct,
-                is_(equal_to(dict(
-                    operation="test_func",
-                    method="GET",
-                    func="test_func",
-
-                    success=False,
-                    status_code=404,
-                    message="Not Found",
-                    context=dict(errors=[]),
-                ))),
+                is_(
+                    equal_to(
+                        dict(
+                            operation="test_func",
+                            method="GET",
+                            func="test_func",
+                            success=False,
+                            status_code=404,
+                            message="Not Found",
+                            context=dict(errors=[]),
+                        )
+                    )
+                ),
             )
 
     def test_request_body(self):
@@ -153,13 +174,16 @@ class TestRequestInfo:
             dct = request_info.to_dict()
             assert_that(
                 dct,
-                is_(equal_to(dict(
-                    operation="test_func",
-                    method="GET",
-                    func="test_func",
-
-                    request_body=dict(foo="bar"),
-                ))),
+                is_(
+                    equal_to(
+                        dict(
+                            operation="test_func",
+                            method="GET",
+                            func="test_func",
+                            request_body=dict(foo="bar"),
+                        )
+                    )
+                ),
             )
 
     def test_request_body_with_field_renaming(self):
@@ -175,13 +199,16 @@ class TestRequestInfo:
             dct = request_info.to_dict()
             assert_that(
                 dct,
-                is_(equal_to(dict(
-                    operation="test_func",
-                    method="GET",
-                    func="test_func",
-
-                    request_body=dict(baz="bar"),
-                ))),
+                is_(
+                    equal_to(
+                        dict(
+                            operation="test_func",
+                            method="GET",
+                            func="test_func",
+                            request_body=dict(baz="bar"),
+                        )
+                    )
+                ),
             )
 
     def test_request_body_with_field_deletion(self):
@@ -189,7 +216,9 @@ class TestRequestInfo:
         Can capture the request body with fields removed
 
         """
-        with self.graph.flask.test_request_context("/", data='{"foo": "bar", "this": "that"}'):
+        with self.graph.flask.test_request_context(
+            "/", data='{"foo": "bar", "this": "that"}'
+        ):
             g.hide_request_fields = ["foo"]
 
             request_info = RequestInfo(self.options, test_func, None)
@@ -197,13 +226,16 @@ class TestRequestInfo:
             dct = request_info.to_dict()
             assert_that(
                 dct,
-                is_(equal_to(dict(
-                    operation="test_func",
-                    method="GET",
-                    func="test_func",
-
-                    request_body=dict(this="that"),
-                ))),
+                is_(
+                    equal_to(
+                        dict(
+                            operation="test_func",
+                            method="GET",
+                            func="test_func",
+                            request_body=dict(this="that"),
+                        )
+                    )
+                ),
             )
 
     def test_response_id(self):
@@ -216,22 +248,27 @@ class TestRequestInfo:
         """
         with self.graph.flask.test_request_context("/"):
             request_info = RequestInfo(self.options, test_func, None)
-            request_info.capture_response(MagicMock(
-                data='{"foo": "bar"}',
-                status_code=200,
-            ))
+            request_info.capture_response(
+                MagicMock(
+                    data='{"foo": "bar"}',
+                    status_code=200,
+                )
+            )
             dct = request_info.to_dict()
             assert_that(
                 dct,
-                is_(equal_to(dict(
-                    operation="test_func",
-                    method="GET",
-                    func="test_func",
-
-                    success=True,
-                    status_code=200,
-                    response_body=dict(foo="bar"),
-                ))),
+                is_(
+                    equal_to(
+                        dict(
+                            operation="test_func",
+                            method="GET",
+                            func="test_func",
+                            success=True,
+                            status_code=200,
+                            response_body=dict(foo="bar"),
+                        )
+                    )
+                ),
             )
 
     def test_response_body_with_field_renaming(self):
@@ -243,22 +280,27 @@ class TestRequestInfo:
             g.show_response_fields = dict(foo="baz")
 
             request_info = RequestInfo(self.options, test_func, None)
-            request_info.capture_response(MagicMock(
-                data='{"foo": "bar"}',
-                status_code=200,
-            ))
+            request_info.capture_response(
+                MagicMock(
+                    data='{"foo": "bar"}',
+                    status_code=200,
+                )
+            )
             dct = request_info.to_dict()
             assert_that(
                 dct,
-                is_(equal_to(dict(
-                    operation="test_func",
-                    method="GET",
-                    func="test_func",
-
-                    success=True,
-                    status_code=200,
-                    response_body=dict(baz="bar"),
-                ))),
+                is_(
+                    equal_to(
+                        dict(
+                            operation="test_func",
+                            method="GET",
+                            func="test_func",
+                            success=True,
+                            status_code=200,
+                            response_body=dict(baz="bar"),
+                        )
+                    )
+                ),
             )
 
     def test_response_body_with_field_deletion(self):
@@ -270,22 +312,27 @@ class TestRequestInfo:
             g.hide_response_fields = ["foo"]
 
             request_info = RequestInfo(self.options, test_func, None)
-            request_info.capture_response(MagicMock(
-                data='{"foo": "bar", "this": "that"}',
-                status_code=200,
-            ))
+            request_info.capture_response(
+                MagicMock(
+                    data='{"foo": "bar", "this": "that"}',
+                    status_code=200,
+                )
+            )
             dct = request_info.to_dict()
             assert_that(
                 dct,
-                is_(equal_to(dict(
-                    operation="test_func",
-                    method="GET",
-                    func="test_func",
-
-                    success=True,
-                    status_code=200,
-                    response_body=dict(this="that"),
-                ))),
+                is_(
+                    equal_to(
+                        dict(
+                            operation="test_func",
+                            method="GET",
+                            func="test_func",
+                            success=True,
+                            status_code=200,
+                            response_body=dict(this="that"),
+                        )
+                    )
+                ),
             )
 
     def test_log_default(self):
@@ -298,11 +345,13 @@ class TestRequestInfo:
 
             logger = MagicMock()
             request_info.log(logger)
-            logger.info.assert_called_with(dict(
-                operation="test_func",
-                method="GET",
-                func="test_func",
-            ))
+            logger.info.assert_called_with(
+                dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+                )
+            )
             logger.warning.assert_not_called()
 
     def test_log_debug(self):
@@ -323,11 +372,13 @@ class TestRequestInfo:
 
             logger = MagicMock()
             request_info.log(logger)
-            logger.debug.assert_called_with(dict(
-                operation="test_func",
-                method="GET",
-                func="test_func",
-            ))
+            logger.debug.assert_called_with(
+                dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+                )
+            )
             logger.info.assert_not_called()
             logger.warning.assert_not_called()
 
@@ -337,12 +388,14 @@ class TestRequestInfo:
 
             logger = MagicMock()
             request_info.log(logger)
-            logger.info.assert_called_with(dict(
-                operation="test_func",
-                method="GET",
-                func="test_func",
-                foo="bar",
-            ))
+            logger.info.assert_called_with(
+                dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+                    foo="bar",
+                )
+            )
 
     def test_log_query_string(self):
         ref_id = str(uuid4())
@@ -352,12 +405,9 @@ class TestRequestInfo:
 
             logger = MagicMock()
             request_info.log(logger)
-            logger.info.assert_called_with(dict(
-                operation="test_func",
-                method="GET",
-                func="test_func",
-                foo=ref_id
-            ))
+            logger.info.assert_called_with(
+                dict(operation="test_func", method="GET", func="test_func", foo=ref_id)
+            )
 
     def test_log_response_id_header(self):
         new_id = str(uuid4())
@@ -367,31 +417,39 @@ class TestRequestInfo:
 
             logger = MagicMock()
             request_info.log(logger)
-            logger.info.assert_called_with(dict(
-                operation="test_func",
-                method="GET",
-                func="test_func",
-                foo_bar_id=new_id,
-            ))
+            logger.info.assert_called_with(
+                dict(
+                    operation="test_func",
+                    method="GET",
+                    func="test_func",
+                    foo_bar_id=new_id,
+                )
+            )
 
     def test_root_logging_level(self):
         """
         Enable DEBUG logging temporarily.
 
         """
-        assert_that(getLogger().getEffectiveLevel(), is_(equal_to(NOTSET)))
-        with self.graph.flask.test_request_context("/", headers={"X-Request-Debug": "true"}):
+        assert_that(getLogger().getEffectiveLevel(), is_(equal_to(WARNING)))
+        with self.graph.flask.test_request_context(
+            "/", headers={"X-Request-Debug": "true"}
+        ):
             with logging_levels():
                 assert_that(getLogger().getEffectiveLevel(), is_(equal_to(DEBUG)))
-        assert_that(getLogger().getEffectiveLevel(), is_(equal_to(NOTSET)))
+        assert_that(getLogger().getEffectiveLevel(), is_(equal_to(WARNING)))
 
     def test_disable_logging(self):
         """
         Disable logging per request.
 
         """
-        assert_that(getLogger().getEffectiveLevel(), is_(equal_to(NOTSET)))
-        with self.graph.flask.test_request_context("/", headers={"X-Request-NoLog": "true"}):
+        assert_that(getLogger().getEffectiveLevel(), is_(equal_to(WARNING)))
+        with self.graph.flask.test_request_context(
+            "/", headers={"X-Request-NoLog": "true"}
+        ):
+
             def func():
                 pass
+
             assert_that(should_skip_logging(func), is_(equal_to(True)))

--- a/microcosm_flask/tests/test_custom_identifier.py
+++ b/microcosm_flask/tests/test_custom_identifier.py
@@ -36,10 +36,9 @@ class ContentBasedAddressConverter(BaseConverter):
     @staticmethod
     def make_hash(obj):
         # naive content normalization function
-        content = dumps({
-            key: str(value)
-            for key, value in obj.__dict__.items()
-        }, sort_keys=True)
+        content = dumps(
+            {key: str(value) for key, value in obj.__dict__.items()}, sort_keys=True
+        )
         return sha256(content.encode("utf-8")).hexdigest()
 
 
@@ -71,17 +70,16 @@ PERSON_MAPPINGS = {
 
 
 class TestIdentifierType:
-
-    def setup(self):
+    def setup_method(self):
         loader = load_from_dict(
             route=dict(
-                converters=[
-                    "cba"
-                ],
+                converters=["cba"],
             ),
         )
         self.graph = create_object_graph(name="example", testing=True, loader=loader)
-        assert_that(self.graph.config.route.converters, contains_inanyorder("uuid", "cba"))
+        assert_that(
+            self.graph.config.route.converters, contains_inanyorder("uuid", "cba")
+        )
         self.person_ns = Namespace(
             subject=Person,
             # use custom identifier type
@@ -92,7 +90,7 @@ class TestIdentifierType:
 
     def test_content_based_address(self):
         hash_id = ContentBasedAddressConverter.make_hash(PERSON_1)
-        response = self.client.get("/api/person/{}".format(hash_id))
+        response = self.client.get(f"/api/person/{hash_id}")
 
         assert_that(response.status_code, is_(equal_to(200)))
         response_data = loads(response.get_data().decode("utf-8"))

--- a/microcosm_flask/tests/test_memory.py
+++ b/microcosm_flask/tests/test_memory.py
@@ -14,13 +14,16 @@ class TestMemorySampling:
     Test capturing of memory info on API requests.
 
     """
-    def setup(self):
+
+    def setup_method(self):
         self.loader = load_from_dict(
             memory_profiler=dict(
                 enabled="true",
             ),
         )
-        self.graph = create_object_graph("example", testing=True, debug=True, loader=self.loader)
+        self.graph = create_object_graph(
+            "example", testing=True, debug=True, loader=self.loader
+        )
         self.graph.use(
             "flask",
             "memory_profiler",
@@ -35,21 +38,32 @@ class TestMemorySampling:
             new_now = self.now + timedelta(minutes=15)
             get_now.return_value = new_now
 
-            assert_that(self.graph.memory_profiler.last_sampling_time, is_(equal_to(self.last_sampling_time)))
+            assert_that(
+                self.graph.memory_profiler.last_sampling_time,
+                is_(equal_to(self.last_sampling_time)),
+            )
 
             decorated = self.graph.memory_profiler.snapshot_at_intervals(noop)
             decorated()
 
-            assert_that(self.graph.memory_profiler.last_sampling_time, is_(equal_to(new_now)))
+            assert_that(
+                self.graph.memory_profiler.last_sampling_time, is_(equal_to(new_now))
+            )
 
     def test_should_not_take_snapshot(self):
         with patch.object(self.graph.memory_profiler, "get_now") as get_now:
             new_now = self.now + timedelta(minutes=1)
             get_now.return_value = new_now
 
-            assert_that(self.graph.memory_profiler.last_sampling_time, is_(equal_to(self.last_sampling_time)))
+            assert_that(
+                self.graph.memory_profiler.last_sampling_time,
+                is_(equal_to(self.last_sampling_time)),
+            )
 
             decorated = self.graph.memory_profiler.snapshot_at_intervals(noop)
             decorated()
 
-            assert_that(self.graph.memory_profiler.last_sampling_time, is_(equal_to(self.last_sampling_time)))
+            assert_that(
+                self.graph.memory_profiler.last_sampling_time,
+                is_(equal_to(self.last_sampling_time)),
+            )

--- a/microcosm_flask/tests/test_metrics.py
+++ b/microcosm_flask/tests/test_metrics.py
@@ -14,8 +14,7 @@ from microcosm_flask.operations import Operation
 
 
 class TestRouteMetrics:
-
-    def setup(self):
+    def setup_method(self):
         try:
             import microcosm_metrics  # noqa: F401
         except ImportError:
@@ -45,6 +44,7 @@ class TestRouteMetrics:
         Classifier tag comes from StatusCodeClassifier
 
         """
+
         @self.graph.route(self.ns.collection_path, Operation.Search, self.ns)
         def foo():
             return ""
@@ -75,6 +75,7 @@ class TestRouteMetrics:
         Classifier tag comes from StatusCodeClassifier
 
         """
+
         @self.graph.route(self.ns.collection_path, Operation.Search, self.ns)
         def foo():
             return "", 204
@@ -105,6 +106,7 @@ class TestRouteMetrics:
         Classifier tag comes from StatusCodeClassifier
 
         """
+
         @self.graph.route(self.ns.collection_path, Operation.Search, self.ns)
         def foo():
             raise NotFound
@@ -118,7 +120,7 @@ class TestRouteMetrics:
             tags=[
                 "endpoint:foo.search.v1",
                 "backend_type:microcosm_flask",
-            ]
+            ],
         )
         self.graph.metrics.increment.assert_called_with(
             "route.call.count",

--- a/microcosm_flask/tests/test_paths.py
+++ b/microcosm_flask/tests/test_paths.py
@@ -7,8 +7,7 @@ from microcosm.api import create_object_graph
 
 
 class TestRoutePathBuilder:
-
-    def setup(self):
+    def setup_method(self):
         self.graph = create_object_graph("microcosm-path", testing=True)
         self.build_route_path = self.graph.build_route_path
         self.graph.lock()

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,13 +18,6 @@ skip = __init__.py
 [mypy]
 ignore_missing_imports = True
 
-[nosetests]
-with-coverage = True
-cover-package = microcosm_flask
-cover-html = True
-cover-html-dir = coverage
-cover-erase = True
-
 [tool:pytest]
 addopts =
     --cov microcosm_flask

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-flask"
-version = "4.1.3"
+version = "4.1.4"
 
 
 setup(
@@ -18,14 +18,14 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.6",
+    python_requires=">=3.10",
     keywords="microcosm",
     install_requires=[
         "Flask>=2",
         "Flask-BasicAuth>=0.2.0",
         "Flask-Cors>=3.0.7",
         "Flask-UUID>=0.2",
-        "jsonschema==3.2.0",
+        "jsonschema>=3.2.0",
         "marshmallow>=3.0.0",
         "microcosm>=3.1.0",
         "microcosm-logging>=1.5.0",
@@ -41,18 +41,18 @@ setup(
         "sentry": "sentry-sdk>=0.14.4",
         "spooky": "spooky>=2.0.0",
         "test": [
-            "nose>=1.3.7",
             "sentry-sdk>=0.14.4",
             "PyHamcrest",
             "coverage",
             "parameterized",
+            "pytest-cov",
         ],
         "lint": [
-            "flake8<5",
+            "flake8",
             "flake8-print",
             "flake8-logging-format",
             "flake8-isort",
-        ]
+        ],
     },
     setup_requires=[
         "nose>=1.3.7",
@@ -94,5 +94,6 @@ setup(
     tests_require=[
         "coverage>=3.7.1",
         "PyHamcrest>=1.9.0",
+        "pytest-cov",
     ],
 )


### PR DESCRIPTION
* Upgrade micrcocosm-flask to python 3.10.
* moved to pytest for testing
* fixed most of deprecation (3 to be tackled soon, most were there before).
* allow higher json schema versions and microcosm flask versions.
* most changes are automated ran by python upgrade.