### PR TITLE
Fix default values and add marshmallow min version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.4
+current_version = 4.1.5
 commit = False
 tag = False
 

--- a/microcosm_flask/errors.py
+++ b/microcosm_flask/errors.py
@@ -22,9 +22,9 @@ class ErrorContextSchema(Schema):
 
 
 class ErrorSchema(Schema):
-    message = fields.String(required=True, dump_default="Unknown Error")
-    code = fields.Integer(required=True, dump_default=500)
-    retryable = fields.Boolean(required=True, dump_default=False)
+    message = fields.String(required=True, default="Unknown Error")
+    code = fields.Integer(required=True, default=500)
+    retryable = fields.Boolean(required=True, default=False)
     context = fields.Nested(ErrorContextSchema, required=False)  # type: ignore
 
 

--- a/microcosm_flask/tests/swagger/parameters/test_default.py
+++ b/microcosm_flask/tests/swagger/parameters/test_default.py
@@ -6,7 +6,7 @@ from microcosm_flask.swagger.api import build_parameter
 
 class ForTestSchema(Schema):
     id = fields.UUID()
-    foo = fields.String(metadata={"description": "Foo"}, dump_default="bar")
+    foo = fields.String(metadata={"description": "Foo"}, default="bar")
     payload = fields.Dict()
     datetime = fields.DateTime()
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-flask"
-version = "4.1.4"
+version = "4.1.5"
 
 
 setup(
@@ -34,6 +34,7 @@ setup(
         "PyYAML>=3.13",
         "rfc3986>=1.2.0",
         "regex>=2021.8.21",
+        "marshmallow>=3.20.0",
     ],
     extras_require={
         "metrics": "microcosm-metrics>=2.2.0",


### PR DESCRIPTION
* Fixed the default values (refactoring during upgrade messed up some defaults).
* Also marshmallow is a required version of 3.20.0 to include `dump_default`